### PR TITLE
DonorCheck v1.2.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>org.pankratzlab</groupId>
 	<artifactId>donorcheck</artifactId>
 	<!-- if version number changes, be sure to update in project.properties file also -->
-	<version>1.1.15</version>
+	<version>1.2.15</version>
 	<packaging>jar</packaging>
 
 	<description>A stand-alone tool for validating DonorNet typing entries.</description>

--- a/src/main/java/org/pankratzlab/unet/deprecated/hla/AntigenDictionary.java
+++ b/src/main/java/org/pankratzlab/unet/deprecated/hla/AntigenDictionary.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.stream.Collectors;
 import org.pankratzlab.unet.deprecated.util.SerializeUtils;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
@@ -267,13 +266,14 @@ public final class AntigenDictionary implements Serializable {
       SerializeUtils.write(typeMap, SERIALIZED_MAP);
       map = typeMap;
 
-      List<HLAType> multi = map.hlaDict.keySet().stream()
-          .filter(ht -> map.hlaDict.get(ht).size() > 1).collect(Collectors.toList());
-      System.out.println("Found " + multi.size() + " HLAType(s) with multiple SeroType mappings:");
-      for (HLAType t : multi) {
-        System.out.println("\t" + t.toString() + " --> "
-            + map.hlaDict.get(t).stream().map(s -> s.toString()).collect(Collectors.joining(", ")));
-      }
+      // List<HLAType> multi = map.hlaDict.keySet().stream()
+      // .filter(ht -> map.hlaDict.get(ht).size() > 1).collect(Collectors.toList());
+      // System.out.println("Found " + multi.size() + " HLAType(s) with multiple SeroType
+      // mappings:");
+      // for (HLAType t : multi) {
+      // System.out.println("\t" + t.toString() + " --> "
+      // + map.hlaDict.get(t).stream().map(s -> s.toString()).collect(Collectors.joining(", ")));
+      // }
 
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/main/java/org/pankratzlab/unet/deprecated/hla/AntigenDictionary.java
+++ b/src/main/java/org/pankratzlab/unet/deprecated/hla/AntigenDictionary.java
@@ -49,7 +49,7 @@ public final class AntigenDictionary implements Serializable {
   public static final String REL_DNA_SER_PROP = "rel.dna.ser.file";
 
   public static final String SERIALIZED_MAP = Info.HLA_HOME + ".hla/map.ser";
-  private static final String MASTER_MAP_RECORDS = "rel_dna_ser.txt";
+  public static final String MASTER_MAP_RECORDS = "rel_dna_ser.txt";
   private static final String COMMENT = "#";
   private static final String COL_DELIM = ";";
   private static final String SPEC_DELIM = ":";
@@ -298,7 +298,7 @@ public final class AntigenDictionary implements Serializable {
     return getVersion(filePath);
   }
 
-  private static String getVersion(String file) {
+  public static String getVersion(String file) {
     try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
       return findVersion(reader);
     } catch (Throwable e) {
@@ -307,7 +307,7 @@ public final class AntigenDictionary implements Serializable {
     return null;
   }
 
-  private static String getBundledVersion() {
+  public static String getBundledVersion() {
     try (BufferedReader reader = new BufferedReader(new InputStreamReader(
         AntigenDictionary.class.getClassLoader().getResourceAsStream(MASTER_MAP_RECORDS)))) {
       return findVersion(reader);
@@ -329,7 +329,9 @@ public final class AntigenDictionary implements Serializable {
 
   public static void clearCache() {
     try {
-      Files.delete(Paths.get(SERIALIZED_MAP));
+      if (new File(SERIALIZED_MAP).exists()) {
+        Files.delete(Paths.get(SERIALIZED_MAP));
+      }
       map = null;
     } catch (IOException e) {
       throw new RuntimeException(

--- a/src/main/java/org/pankratzlab/unet/deprecated/hla/HLAProperties.java
+++ b/src/main/java/org/pankratzlab/unet/deprecated/hla/HLAProperties.java
@@ -1,4 +1,5 @@
 /*-
+
  * #%L
  * DonorCheck
  * %%

--- a/src/main/java/org/pankratzlab/unet/deprecated/hla/SourceType.java
+++ b/src/main/java/org/pankratzlab/unet/deprecated/hla/SourceType.java
@@ -1,5 +1,34 @@
 package org.pankratzlab.unet.deprecated.hla;
 
+import java.io.File;
+import org.pankratzlab.unet.model.ValidationModelBuilder;
+import org.pankratzlab.unet.parser.HtmlDonorParser;
+import org.pankratzlab.unet.parser.PdfDonorParser;
+import org.pankratzlab.unet.parser.XmlDonorParser;
+
 public enum SourceType {
   Score6, SureTyper, DonorNet;
+
+  public static SourceType parseType(File file) {
+    if (file.getName().toLowerCase().endsWith(".html")) {
+      return SourceType.DonorNet;
+    } else if (file.getName().toLowerCase().endsWith(".xml")) {
+      return XmlDonorParser.getSourceType(file);
+    } else if (file.getName().endsWith(".pdf")) {
+      return SourceType.SureTyper;
+    }
+    throw new IllegalArgumentException("Unknown File Type: " + file.getName());
+  }
+
+  public static void parseFile(ValidationModelBuilder builder, File file) {
+    if (file.getName().toLowerCase().endsWith(".html")) {
+      new HtmlDonorParser().parseModel(builder, file);
+    } else if (file.getName().toLowerCase().endsWith(".xml")) {
+      new XmlDonorParser().parseModel(builder, file);
+    } else if (file.getName().endsWith(".pdf")) {
+      new PdfDonorParser().parseModel(builder, file);
+    }
+  }
+
+
 }

--- a/src/main/java/org/pankratzlab/unet/deprecated/jfx/JFXUtilHelper.java
+++ b/src/main/java/org/pankratzlab/unet/deprecated/jfx/JFXUtilHelper.java
@@ -21,6 +21,7 @@
  */
 package org.pankratzlab.unet.deprecated.jfx;
 
+import java.util.concurrent.Callable;
 import javafx.application.Platform;
 import javafx.concurrent.Task;
 import javafx.concurrent.WorkerStateEvent;
@@ -77,7 +78,7 @@ public final class JFXUtilHelper {
    * Helper method to add hooks to close the given {@link Stage} when the given {@link Task}
    * completes.
    */
-  public static void addCloseHooks(Stage stage, Task<Void> task) {
+  public static <T> void addCloseHooks(Stage stage, Task<T> task) {
     EventHandler<WorkerStateEvent> closeStage = (w) -> {
       Platform.runLater(() -> {
         stage.close();
@@ -103,6 +104,27 @@ public final class JFXUtilHelper {
         Platform.runLater(() -> progressStage.show());
         runnable.run();
         return null;
+      }
+    };
+    addCloseHooks(progressStage, progressTask);
+
+    return progressTask;
+  }
+
+  /**
+   * Helper method to combine {@link #createProgressStage()} and
+   * {@link #addCloseHooks(Stage, Task)}, generating a {@link Task} that creates and shows a
+   * progress dialog while running a {@link Runnable} and then closes the progress graphic when
+   * finished.
+   */
+  public static <T> Task<T> createProgressTask(Callable<T> runnable) {
+    Stage progressStage = createProgressStage();
+    Task<T> progressTask = new Task<T>() {
+
+      @Override
+      protected T call() throws Exception {
+        Platform.runLater(() -> progressStage.show());
+        return runnable.call();
       }
     };
     addCloseHooks(progressStage, progressTask);

--- a/src/main/java/org/pankratzlab/unet/deprecated/jfx/JFXUtilHelper.java
+++ b/src/main/java/org/pankratzlab/unet/deprecated/jfx/JFXUtilHelper.java
@@ -63,18 +63,18 @@ public final class JFXUtilHelper {
     return alert;
   }
 
-  public static class ProgressStage {
+  private static class ProgressStage {
     public final Stage stage;
     public final ProgressIndicator pi;
 
-    public ProgressStage(Stage stage, ProgressIndicator pi) {
+    private ProgressStage(Stage stage, ProgressIndicator pi) {
       this.stage = stage;
       this.pi = pi;
     }
   }
 
   /** @return A modal stage pre-built with a progress indicator */
-  public static ProgressStage createDeterminiteProgressStage() {
+  private static ProgressStage createDeterminiteProgressStage() {
     ProgressIndicator pi = new ProgressIndicator(0);
     VBox vbox = new VBox(pi);
     VBox.setVgrow(pi, Priority.ALWAYS);
@@ -94,7 +94,7 @@ public final class JFXUtilHelper {
 
 
   /** @return A modal stage pre-built with a progress indicator */
-  public static Stage createProgressStage() {
+  private static Stage createProgressStage() {
     ProgressIndicator pi = new ProgressIndicator();
     VBox root = new VBox(pi);
     VBox.setVgrow(pi, Priority.ALWAYS);
@@ -113,7 +113,7 @@ public final class JFXUtilHelper {
    * Helper method to add hooks to close the given {@link Stage} when the given {@link Task}
    * completes.
    */
-  public static <T> void addCloseHooks(Stage stage, Task<T> task) {
+  private static <T> void addCloseHooks(Stage stage, Task<T> task) {
     EventHandler<WorkerStateEvent> closeStage = (w) -> {
       Platform.runLater(() -> {
         stage.close();

--- a/src/main/java/org/pankratzlab/unet/hapstats/CommonWellDocumented.java
+++ b/src/main/java/org/pankratzlab/unet/hapstats/CommonWellDocumented.java
@@ -82,7 +82,7 @@ public final class CommonWellDocumented {
     }
   }
 
-  private static enum SOURCE {
+  public static enum SOURCE {
     CWD_200("CWD 2.0.0") {
       @Override
       public void load() {
@@ -140,16 +140,7 @@ public final class CommonWellDocumented {
   public static void init() {
     doGetStatusCache.invalidateAll();
 
-    SOURCE def = SOURCE.CIWD_300;
-
-    if (HLAProperties.get().containsKey(CWD_PROP)) {
-      String propVal = HLAProperties.get().getProperty(CWD_PROP);
-      try {
-        def = SOURCE.valueOf(propVal);
-      } catch (IllegalArgumentException e) {
-        // can't interpret saved value, use hardcoded default
-      }
-    }
+    SOURCE def = loadPropertyCWDSource();
 
     ChoiceDialog<SOURCE> cd = new ChoiceDialog<>(def, SOURCE.values());
     cd.setTitle("Select CWD/CIWD Database");
@@ -167,7 +158,25 @@ public final class CommonWellDocumented {
 
   }
 
-  private static void loadCIWDVersion(SOURCE r) {
+  public static boolean isLoaded() {
+    return ALLELE_FREQS != null && !ALLELE_FREQS.isEmpty();
+  }
+
+  public static SOURCE loadPropertyCWDSource() {
+    SOURCE def = SOURCE.CIWD_300;
+
+    if (HLAProperties.get().containsKey(CWD_PROP)) {
+      String propVal = HLAProperties.get().getProperty(CWD_PROP);
+      try {
+        def = SOURCE.valueOf(propVal);
+      } catch (IllegalArgumentException e) {
+        // can't interpret saved value, use hardcoded default
+      }
+    }
+    return def;
+  }
+
+  public static void loadCIWDVersion(SOURCE r) {
     try {
 
       r.load();

--- a/src/main/java/org/pankratzlab/unet/hapstats/CommonWellDocumented.java
+++ b/src/main/java/org/pankratzlab/unet/hapstats/CommonWellDocumented.java
@@ -83,7 +83,18 @@ public final class CommonWellDocumented {
   }
 
   private static enum SOURCE {
-    CWD_200("CWD 2.0.0"), CIWD_300("CIWD 3.0.0");
+    CWD_200("CWD 2.0.0") {
+      @Override
+      public void load() {
+        loadCWD200();
+      }
+    },
+    CIWD_300("CIWD 3.0.0") {
+      @Override
+      public void load() {
+        loadCIWD300();
+      }
+    };
 
     SOURCE(String d) {
       displayName = d;
@@ -95,6 +106,10 @@ public final class CommonWellDocumented {
     public String toString() {
       return displayName;
     }
+
+    public abstract void load();
+
+
   }
 
   public static void initFromProperty() {
@@ -154,16 +169,8 @@ public final class CommonWellDocumented {
 
   private static void loadCIWDVersion(SOURCE r) {
     try {
-      switch (r) {
-        case CWD_200:
-          loadCWD200();
-          break;
-        case CIWD_300:
-          loadCIWD300();
-          break;
-        default:
-          break;
-      }
+
+      r.load();
 
       // save the selected value
       HLAProperties.get().setProperty(CWD_PROP, r.name());

--- a/src/main/java/org/pankratzlab/unet/jfx/LandingController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/LandingController.java
@@ -33,7 +33,6 @@ import javax.annotation.Nullable;
 import org.controlsfx.dialog.Wizard;
 import org.controlsfx.dialog.Wizard.LinearFlow;
 import org.controlsfx.dialog.WizardPane;
-import org.pankratzlab.unet.deprecated.hla.AntigenDictionary;
 import org.pankratzlab.unet.deprecated.hla.CurrentDirectoryProvider;
 import org.pankratzlab.unet.deprecated.jfx.JFXUtilHelper;
 import org.pankratzlab.unet.hapstats.CommonWellDocumented;
@@ -65,10 +64,6 @@ public class LandingController {
 
   private static final String UNET_BASE_DIR_PROP = "unet.base.dir";
   private static final String MACUI_ENTRY = "/MACUIConversionPanel.fxml";
-  private static final String XML_TUTORIAL = "/XMLDownloadTutorial.fxml";
-  private static final String HTML_TUTORIAL = "/HTMLDownloadTutorial.fxml";
-  private static final String NMDP_DOWNLOAD = "/NMDPDownloadPrompt.fxml";
-  private static final String REL_SER_DOWNLOAD = "/RelDnaSerDownloadPrompt.fxml";
 
   private static final String INPUT_STEP = "/FileInput.fxml";
   private static final String RESULTS_STEP = "/ValidationResults.fxml";
@@ -94,24 +89,12 @@ public class LandingController {
 
   @FXML
   void chooseFreqTables(ActionEvent event) {
-    DownloadNMDPController dc = new DownloadNMDPController();
-    showTutorial(NMDP_DOWNLOAD, dc, "Set Frequency Directory");
-    if (dc.isDirty()) {
-      new Thread(JFXUtilHelper.createProgressTask(() -> {
-        HaplotypeFrequencies.doInitialization();
-      })).start();
-    }
+    TutorialHelper.chooseFreqTables(event);
   }
 
   @FXML
   void chooseRelSerLookupFile(ActionEvent event) {
-    SerotypeLookupFileController controller = new SerotypeLookupFileController();
-    showTutorial(REL_SER_DOWNLOAD, controller, "Set HLA Serotype Lookup File");
-    if (controller.isDirty()) {
-      new Thread(JFXUtilHelper.createProgressTask(() -> {
-        AntigenDictionary.clearCache();
-      })).start();
-    }
+    TutorialHelper.chooseRelSerLookupFile(event);
   }
 
   @FXML
@@ -122,12 +105,12 @@ public class LandingController {
 
   @FXML
   void tutorialHTMLDownload(ActionEvent event) {
-    showTutorial(HTML_TUTORIAL, new DownloadTutorialController(), "Donor Download Instructions");
+    TutorialHelper.tutorialHTMLDownload(event);
   }
 
   @FXML
   void tutorialXMLDownload(ActionEvent event) {
-    showTutorial(XML_TUTORIAL, new DownloadTutorialController(), "Donor Download Instructions");
+    TutorialHelper.tutorialXMLDownload(event);
   }
 
   @FXML
@@ -167,7 +150,7 @@ public class LandingController {
       Platform.runLater(() -> {
         if (!HaplotypeFrequencies.successfullyInitialized()) {
           Alert alert = new Alert(AlertType.INFORMATION,
-              "Haplotype Frequency Tables are not found or valid - frequency data will not be used.\n"
+              "Haplotype Frequency Tables are not found or are invalid, and thus frequency data will not be displayed.\n\n"
                   + "Would you like to set these tables now?\n\n"
                   + "Note: you can adjust these tables any time from the 'Haplotype' menu",
               ButtonType.YES, ButtonType.NO);
@@ -215,26 +198,6 @@ public class LandingController {
     runValidationTask.addEventHandler(WorkerStateEvent.WORKER_STATE_SUCCEEDED, doValidation);
 
     new Thread(runValidationTask).start();
-  }
-
-  /** TODO */
-  private void showTutorial(String tutorialFxml, Object controller, String title) {
-    try (InputStream is = TypeValidationApp.class.getResourceAsStream(tutorialFxml)) {
-      FXMLLoader loader = new FXMLLoader();
-      loader.setController(controller);
-      // NB: reading the controller from FMXL can cause problems
-
-      Alert alert = new Alert(AlertType.NONE, "", ButtonType.OK);
-      alert.getDialogPane().setContent(loader.load(is));
-      alert.setTitle(title);
-      alert.setHeaderText("");
-      alert.showAndWait();
-    } catch (IOException e) {
-      e.printStackTrace();
-      Alert alert = new Alert(AlertType.ERROR, "");
-      alert.setHeaderText("Failed to read tutorial page definition: " + tutorialFxml);
-      alert.showAndWait();
-    }
   }
 
   /**

--- a/src/main/java/org/pankratzlab/unet/jfx/TutorialHelper.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/TutorialHelper.java
@@ -1,0 +1,69 @@
+package org.pankratzlab.unet.jfx;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.pankratzlab.unet.deprecated.hla.AntigenDictionary;
+import org.pankratzlab.unet.deprecated.jfx.JFXUtilHelper;
+import org.pankratzlab.unet.hapstats.HaplotypeFrequencies;
+import javafx.event.ActionEvent;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.ButtonType;
+
+public final class TutorialHelper {
+
+  static final String XML_TUTORIAL = "/XMLDownloadTutorial.fxml";
+  static final String HTML_TUTORIAL = "/HTMLDownloadTutorial.fxml";
+  static final String NMDP_DOWNLOAD = "/NMDPDownloadPrompt.fxml";
+  static final String REL_SER_DOWNLOAD = "/RelDnaSerDownloadPrompt.fxml";
+
+  public static void chooseFreqTables(ActionEvent event) {
+    DownloadNMDPController dc = new DownloadNMDPController();
+    showTutorial(NMDP_DOWNLOAD, dc, "Set Frequency Directory");
+    if (dc.isDirty()) {
+      new Thread(JFXUtilHelper.createProgressTask(() -> {
+        HaplotypeFrequencies.doInitialization();
+      })).start();
+    }
+  }
+
+  public static void chooseRelSerLookupFile(ActionEvent event) {
+    SerotypeLookupFileController controller = new SerotypeLookupFileController();
+    showTutorial(REL_SER_DOWNLOAD, controller, "Set HLA Serotype Lookup File");
+    if (controller.isDirty()) {
+      new Thread(JFXUtilHelper.createProgressTask(() -> {
+        AntigenDictionary.clearCache();
+      })).start();
+    }
+  }
+
+  public static void tutorialHTMLDownload(ActionEvent event) {
+    showTutorial(HTML_TUTORIAL, new DownloadTutorialController(), "Donor Download Instructions");
+  }
+
+  public static void tutorialXMLDownload(ActionEvent event) {
+    showTutorial(XML_TUTORIAL, new DownloadTutorialController(), "Donor Download Instructions");
+  }
+
+  /** TODO */
+  private static void showTutorial(String tutorialFxml, Object controller, String title) {
+    try (InputStream is = TypeValidationApp.class.getResourceAsStream(tutorialFxml)) {
+      FXMLLoader loader = new FXMLLoader();
+      loader.setController(controller);
+      // NB: reading the controller from FMXL can cause problems
+
+      Alert alert = new Alert(AlertType.NONE, "", ButtonType.OK);
+      alert.getDialogPane().setContent(loader.load(is));
+      alert.setTitle(title);
+      alert.setHeaderText("");
+      alert.showAndWait();
+    } catch (IOException e) {
+      e.printStackTrace();
+      Alert alert = new Alert(AlertType.ERROR, "");
+      alert.setHeaderText("Failed to read tutorial page definition: " + tutorialFxml);
+      alert.showAndWait();
+    }
+  }
+
+}

--- a/src/main/java/org/pankratzlab/unet/jfx/ValidationTestMgmtController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/ValidationTestMgmtController.java
@@ -1,5 +1,6 @@
 package org.pankratzlab.unet.jfx;
 
+import java.awt.Desktop;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -101,6 +102,9 @@ public class ValidationTestMgmtController {
 
   @FXML
   Button runAllButton;
+
+  @FXML
+  Button openDirectoryButton;
 
   @FXML
   Button openTestButton;
@@ -277,6 +281,7 @@ public class ValidationTestMgmtController {
           }
         });
 
+    // Any selection enable/disable
     removeSelectedButton.disableProperty().bind(Bindings.createBooleanBinding(() -> {
       return testTable.getSelectionModel().getSelectedIndices().isEmpty();
     }, testTable.getSelectionModel().selectedIndexProperty()));
@@ -285,9 +290,15 @@ public class ValidationTestMgmtController {
       return testTable.getSelectionModel().getSelectedIndices().isEmpty();
     }, testTable.getSelectionModel().selectedIndexProperty()));
 
+    // Table not empty enable/disable
     runAllButton.disableProperty().bind(Bindings.createBooleanBinding(() -> {
       return testTable.getItems().isEmpty();
     }, testTable.itemsProperty()));
+
+    // Single selection enable/disable
+    openDirectoryButton.disableProperty().bind(Bindings.createBooleanBinding(() -> {
+      return testTable.getSelectionModel().getSelectedIndices().size() != 1;
+    }, testTable.getSelectionModel().selectedIndexProperty()));
 
     openTestButton.disableProperty().bind(Bindings.createBooleanBinding(() -> {
       return testTable.getSelectionModel().getSelectedIndices().size() != 1;
@@ -468,6 +479,20 @@ public class ValidationTestMgmtController {
     runValidationTask.addEventHandler(WorkerStateEvent.WORKER_STATE_SUCCEEDED, doValidation);
 
     new Thread(runValidationTask).start();
+  }
+
+  @FXML
+  void openTestDirectory() {
+    ValidationTestFileSet selectedItem = testTable.getSelectionModel().getSelectedItem();
+    String dir = ValidationTesting.getTestDirectory(selectedItem);
+    try {
+      Desktop.getDesktop().open(new File(dir));
+    } catch (IOException e) {
+      e.printStackTrace();
+      Alert alert = new Alert(AlertType.ERROR,
+          "Error opening directory for test " + selectedItem.id.get() + ":\n" + e.getMessage(),
+          ButtonType.CLOSE);
+    }
   }
 
   private void runTasks(List<ValidationTestFileSet> tests) {

--- a/src/main/java/org/pankratzlab/unet/jfx/ValidationTestMgmtController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/ValidationTestMgmtController.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.stream.Collectors;
+import org.pankratzlab.unet.deprecated.hla.AntigenDictionary;
 import org.pankratzlab.unet.deprecated.jfx.JFXUtilHelper;
 import org.pankratzlab.unet.hapstats.CommonWellDocumented;
 import org.pankratzlab.unet.hapstats.CommonWellDocumented.SOURCE;
@@ -125,8 +126,7 @@ public class ValidationTestMgmtController {
     relDnaSerVersion.setCellValueFactory(
         new Callback<CellDataFeatures<ValidationTestFileSet, String>, ObservableValue<String>>() {
           public ObservableValue<String> call(CellDataFeatures<ValidationTestFileSet, String> p) {
-            // TODO either track rel_dna_ser version or load / cache it from the provided file
-            return p.getValue().relDnaSerFile;
+            return p.getValue().relDnaSerFile.map(AntigenDictionary::getVersion).orElse("");
           }
         });
 

--- a/src/main/java/org/pankratzlab/unet/jfx/ValidationTestMgmtController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/ValidationTestMgmtController.java
@@ -1,0 +1,209 @@
+package org.pankratzlab.unet.jfx;
+
+import java.net.URL;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.ResourceBundle;
+import java.util.stream.Collectors;
+import org.pankratzlab.unet.deprecated.jfx.JFXUtilHelper;
+import org.pankratzlab.unet.hapstats.CommonWellDocumented;
+import org.pankratzlab.unet.hapstats.CommonWellDocumented.SOURCE;
+import org.pankratzlab.unet.validation.ValidationTestFileSet;
+import org.pankratzlab.unet.validation.ValidationTesting;
+import com.google.common.collect.Table;
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.value.ObservableValue;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.concurrent.Task;
+import javafx.concurrent.WorkerStateEvent;
+import javafx.event.EventHandler;
+import javafx.fxml.FXML;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableColumn.CellDataFeatures;
+import javafx.scene.control.TableView;
+import javafx.util.Callback;
+
+public class ValidationTestMgmtController {
+
+  @FXML
+  private ResourceBundle resources;
+
+  @FXML
+  private URL location;
+
+  @FXML
+  TableView<ValidationTestFileSet> testTable;
+
+  @FXML
+  TableColumn<ValidationTestFileSet, String> testIDColumn;
+
+  @FXML
+  TableColumn<ValidationTestFileSet, Date> lastRunColumn;
+
+  @FXML
+  TableColumn<ValidationTestFileSet, Boolean> passingStatusColumn;
+
+  @FXML
+  TableColumn<ValidationTestFileSet, String> testFileTypesColumn;
+
+  @FXML
+  TableColumn<ValidationTestFileSet, CommonWellDocumented.SOURCE> ciwdVersionColumn;
+
+  @FXML
+  TableColumn<ValidationTestFileSet, String> relDnaSerVersion;
+
+  @FXML
+  Button closeButton;
+
+  @FXML
+  Button removeSelectedButton;
+
+  @FXML
+  Button runSelectedButton;
+
+  @FXML
+  Button runAllButton;
+
+  @FXML
+  void initialize() {
+    assert testTable != null : "fx:id=\"testTable\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert testIDColumn != null : "fx:id=\"testIDColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert lastRunColumn != null : "fx:id=\"lastRunColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert passingStatusColumn != null : "fx:id=\"passingStatusColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert testFileTypesColumn != null : "fx:id=\"testFileTypesColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert ciwdVersionColumn != null : "fx:id=\"ciwdVersionColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert relDnaSerVersion != null : "fx:id=\"relDnaSerVersion\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert closeButton != null : "fx:id=\"closeButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert removeSelectedButton != null : "fx:id=\"removeSelectedButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert runSelectedButton != null : "fx:id=\"runSelectedButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert runAllButton != null : "fx:id=\"runAllButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+
+    testIDColumn.setCellValueFactory(
+        new Callback<CellDataFeatures<ValidationTestFileSet, String>, ObservableValue<String>>() {
+          public ObservableValue<String> call(CellDataFeatures<ValidationTestFileSet, String> p) {
+            return p.getValue().id;
+          }
+        });
+
+    lastRunColumn.setCellValueFactory(
+        new Callback<CellDataFeatures<ValidationTestFileSet, Date>, ObservableValue<Date>>() {
+          public ObservableValue<Date> call(CellDataFeatures<ValidationTestFileSet, Date> p) {
+            return p.getValue().lastRunDate;
+          }
+        });
+
+    passingStatusColumn.setCellValueFactory(
+        new Callback<CellDataFeatures<ValidationTestFileSet, Boolean>, ObservableValue<Boolean>>() {
+          public ObservableValue<Boolean> call(CellDataFeatures<ValidationTestFileSet, Boolean> p) {
+            return p.getValue().lastPassingState;
+          }
+        });
+
+    testFileTypesColumn.setCellValueFactory(
+        new Callback<CellDataFeatures<ValidationTestFileSet, String>, ObservableValue<String>>() {
+          public ObservableValue<String> call(CellDataFeatures<ValidationTestFileSet, String> p) {
+            // TODO convert file paths to file types
+            return new SimpleStringProperty();
+          }
+        });
+
+    ciwdVersionColumn.setCellValueFactory(
+        new Callback<CellDataFeatures<ValidationTestFileSet, CommonWellDocumented.SOURCE>, ObservableValue<CommonWellDocumented.SOURCE>>() {
+          public ObservableValue<CommonWellDocumented.SOURCE> call(
+              CellDataFeatures<ValidationTestFileSet, CommonWellDocumented.SOURCE> p) {
+            return p.getValue().cwdSource;
+          }
+        });
+
+    relDnaSerVersion.setCellValueFactory(
+        new Callback<CellDataFeatures<ValidationTestFileSet, String>, ObservableValue<String>>() {
+          public ObservableValue<String> call(CellDataFeatures<ValidationTestFileSet, String> p) {
+            // TODO either track rel_dna_ser version or load / cache it from the provided file
+            return p.getValue().relDnaSerFile;
+          }
+        });
+
+    removeSelectedButton.disableProperty().bind(Bindings.createBooleanBinding(() -> {
+      return testTable.getSelectionModel().getSelectedIndices().isEmpty();
+    }, testTable.getSelectionModel().selectedIndexProperty()));
+
+    runSelectedButton.disableProperty().bind(Bindings.createBooleanBinding(() -> {
+      return testTable.getSelectionModel().getSelectedIndices().isEmpty();
+    }, testTable.getSelectionModel().selectedIndexProperty()));
+
+    runAllButton.disableProperty().bind(Bindings.createBooleanBinding(() -> {
+      return testTable.getItems().isEmpty();
+    }, testTable.itemsProperty()));
+
+  }
+
+  public void setTable(Table<SOURCE, String, List<ValidationTestFileSet>> testData) {
+    ObservableList<ValidationTestFileSet> testList = FXCollections.observableArrayList(
+        testData.values().stream().flatMap(List::stream).collect(Collectors.toList()));
+    testTable.setItems(testList);
+  }
+
+  @FXML
+  void close() {
+    // TODO
+  }
+
+  @FXML
+  void removeSelected() {
+    List<ValidationTestFileSet> toRemove =
+        testTable.selectionModelProperty().get().getSelectedItems();
+
+    Alert alert =
+        new Alert(AlertType.CONFIRMATION, "Are you sure you'd like to remove " + toRemove.size()
+            + " test" + (toRemove.size() > 1 ? "s" : "") + "?", ButtonType.OK, ButtonType.CANCEL);
+    alert.setTitle("Remove Tests");
+    alert.setHeaderText("");
+    Optional<ButtonType> selVal = alert.showAndWait();
+
+    if (selVal.isPresent() && selVal.get() == ButtonType.OK) {
+      ValidationTesting.deleteTests(toRemove);
+      testTable.getItems().removeAll(toRemove);
+    }
+
+  }
+
+  @FXML
+  void runSelected() {
+    // run on background thread
+    Task<Void> runValidationTask = JFXUtilHelper.createProgressTask(() -> {
+      ValidationTesting.runTests(testTable.selectionModelProperty().get().getSelectedItems());
+    });
+
+    EventHandler<WorkerStateEvent> showResults = e -> {
+      // TODO do something with results
+    };
+
+    runValidationTask.addEventHandler(WorkerStateEvent.ANY, showResults);
+
+    new Thread(runValidationTask).start();
+  }
+
+  @FXML
+  void runAll() {
+    // run on background thread
+    Task<Void> runValidationTask = JFXUtilHelper.createProgressTask(() -> {
+      ValidationTesting.runTests(testTable.getItems());
+    });
+
+    EventHandler<WorkerStateEvent> showResults = e -> {
+      // TODO do something with results
+    };
+
+    runValidationTask.addEventHandler(WorkerStateEvent.ANY, showResults);
+
+    new Thread(runValidationTask).start();
+  }
+
+}

--- a/src/main/java/org/pankratzlab/unet/jfx/ValidationTestMgmtController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/ValidationTestMgmtController.java
@@ -24,6 +24,7 @@ import org.pankratzlab.unet.hapstats.HaplotypeFrequencies;
 import org.pankratzlab.unet.jfx.wizard.ValidationResultsController;
 import org.pankratzlab.unet.model.ValidationModelBuilder;
 import org.pankratzlab.unet.model.ValidationTable;
+import org.pankratzlab.unet.validation.TEST_RESULT;
 import org.pankratzlab.unet.validation.ValidationTestFileSet;
 import org.pankratzlab.unet.validation.ValidationTesting;
 import org.pankratzlab.unet.validation.XMLRemapProcessor;
@@ -71,6 +72,9 @@ public class ValidationTestMgmtController {
 
   @FXML
   TableColumn<ValidationTestFileSet, Boolean> passingStatusColumn;
+
+  @FXML
+  TableColumn<ValidationTestFileSet, TEST_RESULT> lastRunResultColumn;
 
   @FXML
   TableColumn<ValidationTestFileSet, ObservableSet<SourceType>> testFileTypesColumn;
@@ -149,6 +153,36 @@ public class ValidationTestMgmtController {
                 } else {
                   setText(value ? "Passing" : "Failing");
                   setStyle("-fx-background-color: " + (value ? "LimeGreen" : "OrangeRed"));
+                }
+              }
+            };
+          }
+        });
+
+    lastRunResultColumn.setCellValueFactory(
+        new Callback<CellDataFeatures<ValidationTestFileSet, TEST_RESULT>, ObservableValue<TEST_RESULT>>() {
+          public ObservableValue<TEST_RESULT> call(
+              CellDataFeatures<ValidationTestFileSet, TEST_RESULT> p) {
+            return p.getValue().lastTestResult;
+          }
+        });
+
+    lastRunResultColumn.setCellFactory(
+        new Callback<TableColumn<ValidationTestFileSet, TEST_RESULT>, TableCell<ValidationTestFileSet, TEST_RESULT>>() {
+
+          @Override
+          public TableCell<ValidationTestFileSet, TEST_RESULT> call(
+              TableColumn<ValidationTestFileSet, TEST_RESULT> param) {
+            return new TableCell<ValidationTestFileSet, TEST_RESULT>() {
+              @Override
+              protected void updateItem(TEST_RESULT value, boolean empty) {
+                super.updateItem(value, empty);
+                if (value == null) {
+                  setText(null);
+                } else {
+                  String v = value.name().replace('_', ' ').toLowerCase();
+                  v = v.substring(0, 1).toUpperCase() + v.substring(1);
+                  setText(v);
                 }
               }
             };

--- a/src/main/java/org/pankratzlab/unet/jfx/wizard/FileInputController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/wizard/FileInputController.java
@@ -259,7 +259,6 @@ public class FileInputController extends AbstractValidatingWizardController {
       // valid model, build and set
       try {
         setter.accept(getTable(), builder.build());
-        System.out.println(selectedFile.getAbsolutePath());
         Platform.runLater(() -> {
           linkedFile.set(selectedFile);
         });

--- a/src/main/java/org/pankratzlab/unet/jfx/wizard/FileInputController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/wizard/FileInputController.java
@@ -259,7 +259,9 @@ public class FileInputController extends AbstractValidatingWizardController {
       // valid model, build and set
       try {
         setter.accept(getTable(), builder.build());
-        linkedFile.set(selectedFile);
+        Platform.runLater(() -> {
+          linkedFile.set(selectedFile);
+        });
       } catch (Throwable e) {
         Platform.runLater(() -> {
           Alert alert = new Alert(AlertType.ERROR);

--- a/src/main/java/org/pankratzlab/unet/jfx/wizard/FileInputController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/wizard/FileInputController.java
@@ -259,6 +259,7 @@ public class FileInputController extends AbstractValidatingWizardController {
       // valid model, build and set
       try {
         setter.accept(getTable(), builder.build());
+        System.out.println(selectedFile.getAbsolutePath());
         Platform.runLater(() -> {
           linkedFile.set(selectedFile);
         });

--- a/src/main/java/org/pankratzlab/unet/jfx/wizard/FileInputController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/wizard/FileInputController.java
@@ -31,6 +31,7 @@ import org.pankratzlab.unet.deprecated.hla.HLALocus;
 import org.pankratzlab.unet.deprecated.jfx.JFXPropertyHelper;
 import org.pankratzlab.unet.deprecated.jfx.JFXUtilHelper;
 import org.pankratzlab.unet.jfx.DonorNetUtils;
+import org.pankratzlab.unet.jfx.TutorialHelper;
 import org.pankratzlab.unet.model.ValidationModel;
 import org.pankratzlab.unet.model.ValidationModelBuilder;
 import org.pankratzlab.unet.model.ValidationModelBuilder.ValidationResult;
@@ -93,6 +94,16 @@ public class FileInputController extends AbstractValidatingWizardController {
         .add(createFileBox(XmlDonorParser.class, ValidationTable::setSecondModel));
 
     rootPane().setInvalidBinding(invalidBinding);
+  }
+
+  @FXML
+  void tutorialHTMLDownload(ActionEvent event) {
+    TutorialHelper.tutorialHTMLDownload(event);
+  }
+
+  @FXML
+  void tutorialXMLDownload(ActionEvent event) {
+    TutorialHelper.tutorialXMLDownload(event);
   }
 
   private HBox createFileBox(Class<? extends DonorFileParser> defaultSelected,

--- a/src/main/java/org/pankratzlab/unet/jfx/wizard/FileInputController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/wizard/FileInputController.java
@@ -175,7 +175,7 @@ public class FileInputController extends AbstractValidatingWizardController {
           donorParser.parseModel(builder, selectedFile);
 
           // check that the model is valid
-          ValidationResult validationResult = builder.validate();
+          ValidationResult validationResult = builder.validate(true);
 
           if (!validationResult.valid) {
             // if a value is present, show error message

--- a/src/main/java/org/pankratzlab/unet/jfx/wizard/ValidatingWizardPane.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/wizard/ValidatingWizardPane.java
@@ -22,10 +22,8 @@
 package org.pankratzlab.unet.jfx.wizard;
 
 import java.util.Objects;
-
 import org.controlsfx.dialog.Wizard;
 import org.controlsfx.dialog.WizardPane;
-
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ReadOnlyBooleanWrapper;
 import javafx.beans.value.ObservableBooleanValue;

--- a/src/main/java/org/pankratzlab/unet/jfx/wizard/ValidationResultsController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/wizard/ValidationResultsController.java
@@ -72,6 +72,12 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
   private static final String UNKNOWN_HAPLOTYPE_CLASS = "unknown-haplotype";
   private static final Set<String> HAPLOTYPE_CLASSES =
       ImmutableSet.of(WD_ALLELE_CLASS, UK_ALLELE_CLASS, UNKNOWN_HAPLOTYPE_CLASS);
+  private final Label noHapPatientLabel1 = new Label("No haplotype data found for patient.");
+  private final Label noHapDataLabel1 = new Label(
+      " In order to review haplotype frequencies and flag rare haplotypes,\n download data from NMDP or another source.");
+  private final Label noHapPatientLabel2 = new Label("No haplotype data found for patient.");
+  private final Label noHapDataLabel2 = new Label(
+      " In order to review haplotype frequencies and flag rare haplotypes,\n download data from NMDP or another source.");
 
   @FXML
   private ResourceBundle resources;
@@ -293,8 +299,18 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
     firstSourceCol.textProperty().bind(table.firstColSource());
     secondSourceCol.textProperty().bind(table.secondColSource());
 
-    bcHaplotypeTable.setItems(table.getBCHaplotypeRows());
-    drdqHaplotypeTable.setItems(table.getDRDQHaplotypeRows());
+    bcHaplotypeTable.getItems().clear();
+    drdqHaplotypeTable.getItems().clear();
+
+    if (HaplotypeFrequencies.successfullyInitialized()) {
+      bcHaplotypeTable.setPlaceholder(noHapPatientLabel1);
+      drdqHaplotypeTable.setPlaceholder(noHapPatientLabel2);
+      bcHaplotypeTable.setItems(table.getBCHaplotypeRows());
+      drdqHaplotypeTable.setItems(table.getDRDQHaplotypeRows());
+    } else {
+      bcHaplotypeTable.setPlaceholder(noHapDataLabel1);
+      drdqHaplotypeTable.setPlaceholder(noHapDataLabel2);
+    }
   }
 
   /** Perform required actions when the page is being displayed */

--- a/src/main/java/org/pankratzlab/unet/jfx/wizard/ValidationResultsController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/wizard/ValidationResultsController.java
@@ -40,6 +40,8 @@ import org.pankratzlab.unet.model.DRDQHaplotypeRow;
 import org.pankratzlab.unet.model.HaplotypeRow;
 import org.pankratzlab.unet.model.ValidationRow;
 import org.pankratzlab.unet.model.ValidationTable;
+import org.pankratzlab.unet.validation.ValidationTesting;
+import org.pankratzlab.unet.validation.ValidationTesting.TestInfo;
 import com.google.common.collect.ImmutableSet;
 import javafx.beans.binding.Bindings;
 import javafx.collections.ObservableList;
@@ -96,6 +98,9 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
 
   @FXML
   private MenuItem printOption;
+
+  @FXML
+  MenuItem addToValidationOption;
 
   @FXML
   private TableView<ValidationRow<?>> resultsTable;
@@ -220,6 +225,44 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
         }
       }
     }
+  }
+
+  @FXML
+  void addInputsToValidationSet() {
+
+    // show dialog with warning about avoiding PII
+    Alert alert = new Alert(AlertType.WARNING,
+        "Caution - DonorCheck will retain a copy of the current input files here:\n"
+            + ValidationTesting.VALIDATION_DIRECTORY
+            + "\n\nPlease ensure that input files do not contain Personally Identifiable Information (PII).",
+        ButtonType.OK, ButtonType.CANCEL);
+    alert.setTitle("PII Warning");
+    alert.setHeaderText("");
+    Optional<ButtonType> selVal = alert.showAndWait();
+    if (selVal.isPresent() && selVal.get() == ButtonType.CANCEL) {
+      return;
+    }
+
+    // disallow adding file-pairs if validation doesn't pass
+    boolean validInputs = getTable().isValidProperty().get();
+    if (!validInputs) {
+      Alert alert1 = new Alert(AlertType.ERROR,
+          "Only valid inputs can be added to the validation testing set.", ButtonType.OK,
+          ButtonType.CANCEL);
+      alert1.setTitle("Error - Invalid Inputs");
+      alert1.setHeaderText("");
+      alert1.showAndWait();
+      return;
+    }
+
+    TestInfo file1 = new TestInfo(getTable().getId(), getTable().firstColFile().get(),
+        getTable().getFirstRemappings(), getTable().firstColSourceType().get());
+    TestInfo file2 = new TestInfo(getTable().getId(), getTable().secondColFile().get(),
+        getTable().getSecondRemappings(), getTable().secondColSourceType().get());
+    ValidationTesting.addToValidationSet(file1, file2);
+
+    // TODO show message to user that inputs have been added to validation set
+
   }
 
   @FXML

--- a/src/main/java/org/pankratzlab/unet/jfx/wizard/ValidationResultsController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/wizard/ValidationResultsController.java
@@ -261,7 +261,13 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
         getTable().getSecondRemappings(), getTable().secondColSourceType().get());
     ValidationTesting.addToValidationSet(file1, file2);
 
-    // TODO show message to user that inputs have been added to validation set
+    Alert alert1 = new Alert(AlertType.INFORMATION,
+        "Successfully added " + getTable().getId() + " to validation testing set.",
+        ButtonType.CLOSE);
+    alert1.setTitle("Successfully Added.");
+    alert1.setHeaderText("");
+    alert1.showAndWait();
+    return;
 
   }
 

--- a/src/main/java/org/pankratzlab/unet/jfx/wizard/ValidationResultsController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/wizard/ValidationResultsController.java
@@ -40,8 +40,8 @@ import org.pankratzlab.unet.model.DRDQHaplotypeRow;
 import org.pankratzlab.unet.model.HaplotypeRow;
 import org.pankratzlab.unet.model.ValidationRow;
 import org.pankratzlab.unet.model.ValidationTable;
+import org.pankratzlab.unet.validation.TestInfo;
 import org.pankratzlab.unet.validation.ValidationTesting;
-import org.pankratzlab.unet.validation.ValidationTesting.TestInfo;
 import com.google.common.collect.ImmutableSet;
 import javafx.beans.binding.Bindings;
 import javafx.collections.ObservableList;
@@ -229,46 +229,20 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
 
   @FXML
   void addInputsToValidationSet() {
-
-    // show dialog with warning about avoiding PII
-    Alert alert = new Alert(AlertType.WARNING,
-        "Caution - DonorCheck will retain a copy of the current input files here:\n"
-            + ValidationTesting.VALIDATION_DIRECTORY
-            + "\n\nPlease ensure that input files do not contain Personally Identifiable Information (PII).",
-        ButtonType.OK, ButtonType.CANCEL);
-    alert.setTitle("PII Warning");
-    alert.setHeaderText("");
-    Optional<ButtonType> selVal = alert.showAndWait();
-    if (selVal.isPresent() && selVal.get() == ButtonType.CANCEL) {
-      return;
-    }
-
-    // disallow adding file-pairs if validation doesn't pass
-    boolean validInputs = getTable().isValidProperty().get();
-    if (!validInputs) {
-      Alert alert1 = new Alert(AlertType.ERROR,
-          "Only valid inputs can be added to the validation testing set.", ButtonType.OK,
-          ButtonType.CANCEL);
-      alert1.setTitle("Error - Invalid Inputs");
-      alert1.setHeaderText("");
-      alert1.showAndWait();
-      return;
-    }
-
     TestInfo file1 = new TestInfo(getTable().getId(), getTable().firstColFile().get(),
         getTable().getFirstRemappings(), getTable().firstColSourceType().get());
     TestInfo file2 = new TestInfo(getTable().getId(), getTable().secondColFile().get(),
         getTable().getSecondRemappings(), getTable().secondColSourceType().get());
-    ValidationTesting.addToValidationSet(file1, file2);
+    boolean added = ValidationTesting.addToValidationSet(file1, file2);
 
-    Alert alert1 = new Alert(AlertType.INFORMATION,
-        "Successfully added " + getTable().getId() + " to validation testing set.",
-        ButtonType.CLOSE);
-    alert1.setTitle("Successfully Added.");
-    alert1.setHeaderText("");
-    alert1.showAndWait();
-    return;
-
+    if (added) {
+      Alert alert1 = new Alert(AlertType.INFORMATION,
+          "Successfully added " + getTable().getId() + " to validation testing set.",
+          ButtonType.CLOSE);
+      alert1.setTitle("Successfully Added.");
+      alert1.setHeaderText("");
+      alert1.showAndWait();
+    }
   }
 
   @FXML

--- a/src/main/java/org/pankratzlab/unet/model/ValidationModel.java
+++ b/src/main/java/org/pankratzlab/unet/model/ValidationModel.java
@@ -50,6 +50,7 @@ import com.google.common.collect.Multimap;
 public class ValidationModel {
 
   private final String donorId;
+  private final String filepath;
   private final String source;
   private final SourceType sourceType;
   private final ImmutableSortedSet<SeroType> aLocus;
@@ -69,7 +70,7 @@ public class ValidationModel {
   private final ImmutableMultimap<RaceGroup, Haplotype> drdqHaplotypes;
   private final ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> remapping;
 
-  public ValidationModel(String donorId, String source, SourceType sourceType,
+  public ValidationModel(String donorId, String filepath, String source, SourceType sourceType,
       Collection<SeroType> a, Collection<SeroType> b, Collection<SeroType> c,
       Collection<SeroType> drb, Collection<SeroType> dqb, Collection<SeroType> dqa,
       Collection<SeroType> dpa, Collection<HLAType> dpb, boolean bw4, boolean bw6,
@@ -78,6 +79,7 @@ public class ValidationModel {
       Multimap<RaceGroup, Haplotype> drdqCwdHaplotypes,
       Map<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> remapping) {
     this.donorId = donorId;
+    this.filepath = filepath;
     this.source = source;
     this.sourceType = sourceType;
     aLocus = ImmutableSortedSet.copyOf(a);
@@ -107,6 +109,10 @@ public class ValidationModel {
 
   public String getDonorId() {
     return donorId;
+  }
+
+  public String getFile() {
+    return filepath;
   }
 
   public String getSource() {
@@ -419,14 +425,7 @@ public class ValidationModel {
     return remapping.containsKey(locus);
   }
 
-  public String[] getRemappings() {
-    return remapping.entrySet().stream().map(e -> {
-      final String collectFrom = e.getValue().getLeft().stream().sorted().map(TypePair::getHlaType)
-          .map((h) -> h.specString()).collect(Collectors.joining(" / "));
-      final String collectTo = e.getValue().getRight().stream().sorted().map(TypePair::getHlaType)
-          .map((h) -> h.specString()).collect(Collectors.joining(" / "));
-      return "HLA-" + e.getKey().name() + " was remapped from { " + collectFrom + " } to { "
-          + collectTo + " } in " + getSourceType();
-    }).sorted().distinct().toArray(String[]::new);
+  public ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> getRemappings() {
+    return remapping;
   }
 }

--- a/src/main/java/org/pankratzlab/unet/model/ValidationModelBuilder.java
+++ b/src/main/java/org/pankratzlab/unet/model/ValidationModelBuilder.java
@@ -656,8 +656,6 @@ public class ValidationModelBuilder {
 
     frequencyTable.clear();
 
-    System.out.println(dr52Locus);
-
     ValidationModel validationModel = new ValidationModel(donorId, filepath, source, sourceType,
         getFinalTypes(HLALocus.A), getFinalTypes(HLALocus.B), getFinalTypes(HLALocus.C),
         getFinalTypes(HLALocus.DRB1), getFinalTypes(HLALocus.DQB1), getFinalTypes(HLALocus.DQA1),

--- a/src/main/java/org/pankratzlab/unet/model/ValidationModelBuilder.java
+++ b/src/main/java/org/pankratzlab/unet/model/ValidationModelBuilder.java
@@ -100,6 +100,7 @@ public class ValidationModelBuilder {
   }
 
   private String donorId;
+  private String filepath;
   private String source;
   private SourceType sourceType;
 
@@ -164,6 +165,12 @@ public class ValidationModelBuilder {
   /** @param donorId Unique identifying string for this donor */
   public ValidationModelBuilder donorId(String donorId) {
     this.donorId = donorId;
+    return this;
+  }
+
+  /** @param source Name for the source of this model */
+  public ValidationModelBuilder file(String filepath) {
+    this.filepath = filepath;
     return this;
   }
 
@@ -649,7 +656,7 @@ public class ValidationModelBuilder {
 
     frequencyTable.clear();
 
-    ValidationModel validationModel = new ValidationModel(donorId, source, sourceType,
+    ValidationModel validationModel = new ValidationModel(donorId, filepath, source, sourceType,
         getFinalTypes(HLALocus.A), getFinalTypes(HLALocus.B), getFinalTypes(HLALocus.C),
         getFinalTypes(HLALocus.DRB1), getFinalTypes(HLALocus.DQB1), getFinalTypes(HLALocus.DQA1),
         getFinalTypes(HLALocus.DPA1), getFinalDPBTypes(), bw4, bw6, dr51Locus, dr52Locus, dr53Locus,

--- a/src/main/java/org/pankratzlab/unet/model/ValidationModelBuilder.java
+++ b/src/main/java/org/pankratzlab/unet/model/ValidationModelBuilder.java
@@ -593,8 +593,8 @@ public class ValidationModelBuilder {
 
   }
 
-  public ValidationResult validate() {
-    return ensureValidity();
+  public ValidationResult validate(boolean showAlertIfInvalid) {
+    return ensureValidity(showAlertIfInvalid);
   }
 
   private boolean test(Set<SeroType> set) {
@@ -1037,7 +1037,7 @@ public class ValidationModelBuilder {
    * @return Optional<String> Value is present if the model has not been fully populated, or
    *         populated incorrectly.
    */
-  private ValidationResult ensureValidity() {
+  private ValidationResult ensureValidity(boolean show) {
     // Ensure all fields have been set
     for (Object o : Lists.newArrayList(donorId, source, aLocusCWD, bLocusCWD, cLocusCWD, drbLocus,
         dqbLocus, dqaLocus, getFinalDPBTypes(), bw4, bw6)) {

--- a/src/main/java/org/pankratzlab/unet/model/ValidationModelBuilder.java
+++ b/src/main/java/org/pankratzlab/unet/model/ValidationModelBuilder.java
@@ -656,6 +656,8 @@ public class ValidationModelBuilder {
 
     frequencyTable.clear();
 
+    System.out.println(dr52Locus);
+
     ValidationModel validationModel = new ValidationModel(donorId, filepath, source, sourceType,
         getFinalTypes(HLALocus.A), getFinalTypes(HLALocus.B), getFinalTypes(HLALocus.C),
         getFinalTypes(HLALocus.DRB1), getFinalTypes(HLALocus.DQB1), getFinalTypes(HLALocus.DQA1),

--- a/src/main/java/org/pankratzlab/unet/model/ValidationRow.java
+++ b/src/main/java/org/pankratzlab/unet/model/ValidationRow.java
@@ -124,8 +124,6 @@ public abstract class ValidationRow<T> {
 
   /** @return true iff the XML and PDF column values are the same */
   private boolean isValid() {
-    System.out.println("Comp: " + firstColWrapper.get() + " == " + secondColWrapper.get() + "  "
-        + Objects.equals(firstColWrapper.get(), secondColWrapper.get()));
     return Objects.equals(firstColWrapper.get(), secondColWrapper.get());
   }
 

--- a/src/main/java/org/pankratzlab/unet/model/ValidationRow.java
+++ b/src/main/java/org/pankratzlab/unet/model/ValidationRow.java
@@ -22,9 +22,7 @@
 package org.pankratzlab.unet.model;
 
 import java.util.Objects;
-
 import javax.annotation.Nullable;
-
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
@@ -126,6 +124,8 @@ public abstract class ValidationRow<T> {
 
   /** @return true iff the XML and PDF column values are the same */
   private boolean isValid() {
+    System.out.println("Comp: " + firstColWrapper.get() + " == " + secondColWrapper.get() + "  "
+        + Objects.equals(firstColWrapper.get(), secondColWrapper.get()));
     return Objects.equals(firstColWrapper.get(), secondColWrapper.get());
   }
 

--- a/src/main/java/org/pankratzlab/unet/model/ValidationTable.java
+++ b/src/main/java/org/pankratzlab/unet/model/ValidationTable.java
@@ -29,6 +29,7 @@ import org.pankratzlab.unet.deprecated.hla.HLALocus;
 import org.pankratzlab.unet.deprecated.hla.HLAType;
 import org.pankratzlab.unet.deprecated.hla.SeroType;
 import org.pankratzlab.unet.deprecated.jfx.JFXPropertyHelper;
+import org.pankratzlab.unet.hapstats.HaplotypeFrequencies;
 import org.pankratzlab.unet.hapstats.RaceGroup;
 import org.pankratzlab.unet.model.ValidationRow.RowBuilder;
 import javafx.beans.binding.Bindings;
@@ -241,7 +242,7 @@ public class ValidationTable {
     drdqHaplotypeRows.clear();
 
     ValidationModel model = chooseHaplotypeModel(firstModelWrapper.get(), secondModelWrapper.get());
-    if (Objects.nonNull(model)) {
+    if (Objects.nonNull(model) && HaplotypeFrequencies.successfullyInitialized()) {
       makeBCHaplotypeRows(bcHaplotypeRows, model);
       makeDRDQHaplotypeRows(drdqHaplotypeRows, model);
     }

--- a/src/main/java/org/pankratzlab/unet/model/remap/GUIRemapProcessor.java
+++ b/src/main/java/org/pankratzlab/unet/model/remap/GUIRemapProcessor.java
@@ -1,7 +1,5 @@
 package org.pankratzlab.unet.model.remap;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -576,25 +574,9 @@ public class GUIRemapProcessor implements RemapProcessor {
       // Function<Supplier<TextFlow>, Supplier<TextFlow>> tooltipProvider) {
       this.tooltipProvider = tooltipProvider;
 
-      // hack for adjusting tooltip delay / etc
-      // from https://stackoverflow.com/a/43291239/875496
-      // TODO FIXME change when JavaFX9+ is available
-      try {
-        Class<?> clazz = tooltip.getClass().getDeclaredClasses()[0];
-        Constructor<?> constructor = clazz.getDeclaredConstructor(Duration.class, Duration.class,
-            Duration.class, boolean.class);
-        constructor.setAccessible(true);
-        Object tooltipBehavior = constructor.newInstance(new Duration(50), // open
-            new Duration(500000), // visible
-            new Duration(100), // close
-            false);
-        Field fieldBehavior = tooltip.getClass().getDeclaredField("BEHAVIOR");
-        fieldBehavior.setAccessible(true);
-        fieldBehavior.set(tooltip, tooltipBehavior);
-      } catch (Throwable t) {
-        t.printStackTrace();
-      }
-
+      tooltip.setShowDelay(new Duration(50));
+      tooltip.setShowDuration(new Duration(500000));
+      tooltip.setHideDelay(new Duration(100));
       tooltip.setWrapText(true);
       tooltip.setMaxWidth(600);
 

--- a/src/main/java/org/pankratzlab/unet/model/remap/GUIRemapProcessor.java
+++ b/src/main/java/org/pankratzlab/unet/model/remap/GUIRemapProcessor.java
@@ -70,12 +70,12 @@ public class GUIRemapProcessor implements RemapProcessor {
 
     if (allelePairs == null || donorPairs == null) {
       // TODO
-      System.out.println("No allele pairs for locus " + locus);
+      // System.out.println("No allele pairs for locus " + locus);
       return null;
     }
     if (typesSetNonCWD == null || typesSetNonCWD.isEmpty()) {
       // TODO
-      System.out.println("No types for locus " + locus);
+      // System.out.println("No types for locus " + locus);
       return null;
     }
 

--- a/src/main/java/org/pankratzlab/unet/parser/AbstractDonorFileParser.java
+++ b/src/main/java/org/pankratzlab/unet/parser/AbstractDonorFileParser.java
@@ -35,6 +35,7 @@ public abstract class AbstractDonorFileParser implements DonorFileParser {
       throw new InvalidParameterException("Unknown File Type: " + file.getName());
     }
 
+    builder.file(file.getAbsolutePath());
     builder.source(file.getName());
 
     doParse(builder, file);

--- a/src/main/java/org/pankratzlab/unet/parser/XmlDonorParser.java
+++ b/src/main/java/org/pankratzlab/unet/parser/XmlDonorParser.java
@@ -81,6 +81,29 @@ public class XmlDonorParser extends AbstractDonorFileParser {
     return EXTENSION_NAME;
   }
 
+  public static SourceType getSourceType(File file) {
+    try (FileInputStream xmlStream = new FileInputStream(file)) {
+      Document parsed = Jsoup.parse(xmlStream, "UTF-8", "http://example.com");
+      if (FilenameUtils.isExtension(file.getName(), EXTENSION_NAME)) {
+        final String rootElement = parsed.getElementsByTag(BODY_TAG).get(0).child(0).tagName();
+
+        // Based on XML contents, pass to specific XML parser
+        if (XmlDonorNetParser.ROOT_ELEMENT.equals(rootElement)) {
+          return SourceType.DonorNet;
+        } else if (XmlScore6Parser.ROOT_ELEMENT.equals(rootElement)) {
+          return SourceType.Score6;
+        } else if (XmlSureTyperParser.ROOT_ELEMENT.equals(rootElement)) {
+          return SourceType.SureTyper;
+        }
+      } else {
+        throw new InvalidParameterException("Unknown File Type: " + file.getName());
+      }
+    } catch (Throwable e) {
+      throw new IllegalStateException("Invalid XML file: " + file, e);
+    }
+    return null; // Unknown or unsupported file type
+  }
+
   @Override
   protected void doParse(ValidationModelBuilder builder, File file) {
     try (FileInputStream xmlStream = new FileInputStream(file)) {

--- a/src/main/java/org/pankratzlab/unet/parser/util/XmlScore6Parser.java
+++ b/src/main/java/org/pankratzlab/unet/parser/util/XmlScore6Parser.java
@@ -556,7 +556,7 @@ public class XmlScore6Parser {
       if (possibleAlleleRecordingMap.containsKey(locus)) {
         if (hlaLocus == null) {
           // TODO FIXME do something other than print to system out
-          System.out.println("Couldn't set alleles - no locus parsed from " + locus);
+          // System.out.println("Couldn't set alleles - no locus parsed from " + locus);
         } else {
           possibleAlleleRecordingMap.get(locus).accept(builder, hlaLocus, allPossibleAllelePairs);
           donorAlleleRecordingMap.get(locus).accept(builder, hlaLocus, donorAllelePairs);
@@ -1119,7 +1119,7 @@ public class XmlScore6Parser {
         Objects.requireNonNull(alleleCombination);
       } catch (NullPointerException e) {
         // TODO FIXME do something other than print to system out
-        System.out.println();
+        // System.out.println();
       }
       this.alleleCombination = alleleCombination;
       this.antigenCombination = antigenCombination;

--- a/src/main/java/org/pankratzlab/unet/validation/AlertHelper.java
+++ b/src/main/java/org/pankratzlab/unet/validation/AlertHelper.java
@@ -7,6 +7,25 @@ import javafx.scene.control.ButtonType;
 
 public final class AlertHelper {
 
+  public static void showMessage_ErrorUpdatingTestProperties(ValidationTestFileSet rowValue,
+      Throwable cause) {
+    Alert alert1 = new Alert(AlertType.ERROR, "Error - unable to update test properties for test "
+        + rowValue.id.get() + ". An exception occurred:\n" + cause.getMessage(), ButtonType.CLOSE);
+    alert1.setTitle("Failed to Update Test");
+    alert1.setHeaderText("");
+    alert1.showAndWait();
+  }
+
+  public static void showMessage_ErrorUpdatingTestID(String id, String newId, Throwable cause) {
+    Alert alert1 = new Alert(AlertType.ERROR,
+        "Error - unable to rename test from " + id + " to " + newId
+            + ". An exception occurred when moving the directory:\n" + cause.getMessage(),
+        ButtonType.CLOSE);
+    alert1.setTitle("Failed to Rename Test");
+    alert1.setHeaderText("");
+    alert1.showAndWait();
+  }
+
   static Optional<ButtonType> showMessage_PII() {
     Alert alert = new Alert(AlertType.WARNING,
         "Caution - DonorCheck will retain a copy of the current input files here:\n"
@@ -64,7 +83,6 @@ public final class AlertHelper {
   }
 
   static void showMessage_ErrorCopyingInputFile(TestInfo file, String subdir) {
-    // notify user, show directory path and cancel operation
     Alert alert1 = new Alert(AlertType.ERROR,
         "Error - could not copy input file to validation testing directory.\n\nFile: " + file.file
             + "\n\nDirectory: " + subdir,

--- a/src/main/java/org/pankratzlab/unet/validation/AlertHelper.java
+++ b/src/main/java/org/pankratzlab/unet/validation/AlertHelper.java
@@ -1,0 +1,77 @@
+package org.pankratzlab.unet.validation;
+
+import java.util.Optional;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.ButtonType;
+
+public final class AlertHelper {
+
+  static Optional<ButtonType> showMessage_PII() {
+    Alert alert = new Alert(AlertType.WARNING,
+        "Caution - DonorCheck will retain a copy of the current input files here:\n"
+            + ValidationTesting.VALIDATION_DIRECTORY
+            + "\n\nPlease ensure that input files do not contain Personally Identifiable Information (PII).",
+        ButtonType.OK, ButtonType.CANCEL);
+    alert.setTitle("PII Warning");
+    alert.setHeaderText("");
+    Optional<ButtonType> selVal = alert.showAndWait();
+    return selVal;
+  }
+
+  static void showMessage_TestAlreadyExists(TestInfo file1, String subdir) {
+    // notify user, show directory path and cancel operation
+    Alert alert1 = new Alert(AlertType.ERROR, "Error - a test with the same ID / Label ("
+        + file1.label
+        + ") already exists.\n\nIf this is an error, please remove the test in the DonorCheck Testing Management tool.\n\nOr remove the test manually by deleting this directory:\n\n"
+        + subdir, ButtonType.CLOSE);
+    alert1.setTitle("Failed to Add Test");
+    alert1.setHeaderText("");
+    alert1.showAndWait();
+  }
+
+  static void showMessage_ErrorCopyingRelFile(String relFile) {
+    // notify user, show directory path and cancel operation
+    Alert alert1 = new Alert(AlertType.ERROR,
+        "Error - could not copy serotype lookup file to validation testing directory.\n\nFile: "
+            + relFile,
+        ButtonType.CLOSE);
+    alert1.setTitle("Failed to Add Test");
+    alert1.setHeaderText("");
+    alert1.showAndWait();
+  }
+
+  static void showMessage_ErrorWritingRemapXMLFile(String remapFile) {
+    // notify user, show directory path and cancel operation
+    Alert alert1 = new Alert(AlertType.ERROR,
+        "Error - could not write locus remappings file to validation testing directory.\n\nFile: "
+            + remapFile,
+        ButtonType.CLOSE);
+    alert1.setTitle("Failed to Add Test");
+    alert1.setHeaderText("");
+    alert1.showAndWait();
+  }
+
+  static void showMessage_ErrorWritingPropertiesFile(String propsFile) {
+    // notify user, show directory path and cancel operation
+    Alert alert1 = new Alert(AlertType.ERROR,
+        "Error - could not write test properties file to validation testing directory.\n\nFile: "
+            + propsFile,
+        ButtonType.CLOSE);
+    alert1.setTitle("Failed to Add Test");
+    alert1.setHeaderText("");
+    alert1.showAndWait();
+  }
+
+  static void showMessage_ErrorCopyingInputFile(TestInfo file, String subdir) {
+    // notify user, show directory path and cancel operation
+    Alert alert1 = new Alert(AlertType.ERROR,
+        "Error - could not copy input file to validation testing directory.\n\nFile: " + file.file
+            + "\n\nDirectory: " + subdir,
+        ButtonType.CLOSE);
+    alert1.setTitle("Failed to Add Test");
+    alert1.setHeaderText("");
+    alert1.showAndWait();
+  }
+
+}

--- a/src/main/java/org/pankratzlab/unet/validation/AlertHelper.java
+++ b/src/main/java/org/pankratzlab/unet/validation/AlertHelper.java
@@ -28,9 +28,10 @@ public final class AlertHelper {
 
   static Optional<ButtonType> showMessage_PII() {
     Alert alert = new Alert(AlertType.WARNING,
-        "Caution - DonorCheck will retain a copy of the current input files here:\n"
-            + ValidationTesting.VALIDATION_DIRECTORY
-            + "\n\nPlease ensure that input files do not contain Personally Identifiable Information (PII).",
+        "Caution - DonorCheck will retain a copy of the current input files here:\n\n"
+            + ValidationTesting.VALIDATION_DIRECTORY + "\n\nPlease ensure that:\n\n"
+            + "1) The given input files do not contain Personally Identifiable Information (PII), or\n\n"
+            + "2) If the input files do contain PII, that this location is safe to store PII.",
         ButtonType.OK, ButtonType.CANCEL);
     alert.setTitle("PII Warning");
     alert.setHeaderText("");

--- a/src/main/java/org/pankratzlab/unet/validation/TEST_RESULT.java
+++ b/src/main/java/org/pankratzlab/unet/validation/TEST_RESULT.java
@@ -1,0 +1,20 @@
+package org.pankratzlab.unet.validation;
+
+public enum TEST_RESULT {
+  NO_TEST_FILES(false), // test directory doesn't contain any test files'
+  NOT_ENOUGH_TEST_FILES(false), // test directory only have one test file
+  INVALID_TEST_FILE(false), // input file is invalid
+  ERROR_LOADING_TEST_FILE(false), // error when loading file
+  MISSING_REMAP_FILE(false), // file requires remappings but remap file doesn't exist
+  INVALID_REMAP_FILE(false), // error when loading/parsing remap file
+  INVALID_REMAPPINGS(false), // remappings in file don't match required remappings
+  TEST_FAILURE(false), // validation failed
+  TEST_SUCCESS(true); // validation passed
+
+  public final boolean isPassing;
+
+  private TEST_RESULT(boolean passes) {
+    this.isPassing = passes;
+  }
+
+}

--- a/src/main/java/org/pankratzlab/unet/validation/TestExceptions.java
+++ b/src/main/java/org/pankratzlab/unet/validation/TestExceptions.java
@@ -1,0 +1,18 @@
+package org.pankratzlab.unet.validation;
+
+public final class TestExceptions {
+  public static final class XMLRemapFileException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public XMLRemapFileException(String string, Exception e) {
+      super(string, e);
+    }
+  }
+  public static final class SourceFileParsingException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public SourceFileParsingException(String string, Exception e) {
+      super(string, e);
+    }
+  }
+}

--- a/src/main/java/org/pankratzlab/unet/validation/TestInfo.java
+++ b/src/main/java/org/pankratzlab/unet/validation/TestInfo.java
@@ -1,0 +1,25 @@
+package org.pankratzlab.unet.validation;
+
+import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
+import org.pankratzlab.unet.deprecated.hla.HLALocus;
+import org.pankratzlab.unet.deprecated.hla.SourceType;
+import org.pankratzlab.unet.model.ValidationModelBuilder.TypePair;
+import com.google.common.collect.ImmutableMap;
+
+public class TestInfo {
+  public final String label;
+  public final String file;
+  public final ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> remappings;
+  public final SourceType sourceType;
+
+  public TestInfo(String label, String file,
+      ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> remappings,
+      SourceType sourceType) {
+    this.label = label;
+    this.file = file;
+    this.remappings = remappings;
+    this.sourceType = sourceType;
+  }
+
+}

--- a/src/main/java/org/pankratzlab/unet/validation/TestRun.java
+++ b/src/main/java/org/pankratzlab/unet/validation/TestRun.java
@@ -1,0 +1,16 @@
+package org.pankratzlab.unet.validation;
+
+import java.util.Date;
+
+public class TestRun {
+  public final ValidationTestFileSet testFileSet;
+  public final TEST_RESULT result;
+  public final Date runTime;
+
+  public TestRun(ValidationTestFileSet testFileSet, TEST_RESULT result, Date runTime) {
+    this.testFileSet = testFileSet;
+    this.result = result;
+    this.runTime = runTime;
+  }
+
+}

--- a/src/main/java/org/pankratzlab/unet/validation/ValidationTestFileSet.java
+++ b/src/main/java/org/pankratzlab/unet/validation/ValidationTestFileSet.java
@@ -1,0 +1,101 @@
+package org.pankratzlab.unet.validation;
+
+import java.util.Date;
+import java.util.List;
+import org.pankratzlab.unet.hapstats.CommonWellDocumented;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyListProperty;
+import javafx.beans.property.ReadOnlyListWrapper;
+import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.property.ReadOnlyObjectWrapper;
+import javafx.beans.property.ReadOnlyStringProperty;
+import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+
+public class ValidationTestFileSet {
+
+  public final ReadOnlyStringProperty id;
+
+  public final ReadOnlyListProperty<String> filePaths;
+
+  public final ReadOnlyStringProperty remapFile;
+
+  public final ReadOnlyObjectProperty<CommonWellDocumented.SOURCE> cwdSource;
+
+  public final ReadOnlyStringProperty relDnaSerFile;
+
+  // Last Run Date and Passing State are not read-only as they may change
+  public final ObjectProperty<Date> lastRunDate;
+
+  public final ObjectProperty<Boolean> lastPassingState;
+
+  public static class ValidationTestFileSetBuilder {
+    private String id;
+    private List<String> filePaths;
+    private String remapFile;
+    private CommonWellDocumented.SOURCE cwdSource;
+    private String relDnaSerFile;
+    private Date lastRunDate;
+    private Boolean lastPassingState;
+
+    public ValidationTestFileSetBuilder id(String id) {
+      this.id = id;
+      return this;
+    }
+
+    public ValidationTestFileSetBuilder filePaths(List<String> filePaths) {
+      this.filePaths = filePaths;
+      return this;
+    }
+
+    public ValidationTestFileSetBuilder remapFile(String remapFile) {
+      this.remapFile = remapFile;
+      return this;
+    }
+
+    public ValidationTestFileSetBuilder cwdSource(CommonWellDocumented.SOURCE cwdSource) {
+      this.cwdSource = cwdSource;
+      return this;
+    }
+
+    public ValidationTestFileSetBuilder relDnaSerFile(String relDnaSerFile) {
+      this.relDnaSerFile = relDnaSerFile;
+      return this;
+    }
+
+    public ValidationTestFileSetBuilder lastRunDate(Date lastRunDate) {
+      this.lastRunDate = lastRunDate;
+      return this;
+    }
+
+    public ValidationTestFileSetBuilder lastPassingState(Boolean lastPassingState) {
+      this.lastPassingState = lastPassingState;
+      return this;
+    }
+
+    public ValidationTestFileSet build() {
+      return new ValidationTestFileSet(id, filePaths, remapFile, cwdSource, relDnaSerFile,
+          lastRunDate, lastPassingState);
+    }
+
+  }
+
+  public static ValidationTestFileSetBuilder builder() {
+    return new ValidationTestFileSetBuilder();
+  }
+
+  private ValidationTestFileSet(String id, List<String> filePaths, String remapFile,
+      CommonWellDocumented.SOURCE cwdSource, String relDnaSerFile, Date lastRunDate,
+      Boolean lastPassingState) {
+    this.id = new ReadOnlyStringWrapper(id);
+    this.filePaths = new ReadOnlyListWrapper<>(FXCollections.observableList(filePaths));
+    this.remapFile = new ReadOnlyStringWrapper(remapFile);
+    this.cwdSource = new ReadOnlyObjectWrapper<>(cwdSource);
+    this.relDnaSerFile = new ReadOnlyStringWrapper(relDnaSerFile);
+    this.lastRunDate = new SimpleObjectProperty<>(lastRunDate);
+    this.lastPassingState = new SimpleObjectProperty<>(lastPassingState);
+  }
+
+
+}

--- a/src/main/java/org/pankratzlab/unet/validation/ValidationTestFileSet.java
+++ b/src/main/java/org/pankratzlab/unet/validation/ValidationTestFileSet.java
@@ -38,6 +38,8 @@ public class ValidationTestFileSet {
 
   public final ObjectProperty<Boolean> lastPassingState;
 
+  public final ObjectProperty<TEST_RESULT> lastTestResult;
+
   public static class ValidationTestFileSetBuilder {
     private String id;
     private List<String> filePaths;
@@ -46,6 +48,7 @@ public class ValidationTestFileSet {
     private String relDnaSerFile;
     private Date lastRunDate;
     private Boolean lastPassingState;
+    private TEST_RESULT lastPassingResult;
 
     public ValidationTestFileSetBuilder id(String id) {
       this.id = id;
@@ -82,9 +85,14 @@ public class ValidationTestFileSet {
       return this;
     }
 
+    public ValidationTestFileSetBuilder lastPassingResult(TEST_RESULT lastPassingResult) {
+      this.lastPassingResult = lastPassingResult;
+      return this;
+    }
+
     public ValidationTestFileSet build() {
       return new ValidationTestFileSet(id, filePaths, remapFile, cwdSource, relDnaSerFile,
-          lastRunDate, lastPassingState);
+          lastRunDate, lastPassingState, lastPassingResult);
     }
 
   }
@@ -95,7 +103,7 @@ public class ValidationTestFileSet {
 
   private ValidationTestFileSet(String id, List<String> filePaths, String remapFile,
       CommonWellDocumented.SOURCE cwdSource, String relDnaSerFile, Date lastRunDate,
-      Boolean lastPassingState) {
+      Boolean lastPassingState, TEST_RESULT lastTestResult) {
     this.id = new ReadOnlyStringWrapper(id);
     this.filePaths = new ReadOnlyListWrapper<>(FXCollections.observableList(filePaths));
     final ObservableSet<SourceType> observableSet =
@@ -113,7 +121,7 @@ public class ValidationTestFileSet {
     this.relDnaSerFile = new ReadOnlyStringWrapper(relDnaSerFile);
     this.lastRunDate = new SimpleObjectProperty<>(lastRunDate);
     this.lastPassingState = new SimpleObjectProperty<>(lastPassingState);
+    this.lastTestResult = new SimpleObjectProperty<>(lastTestResult);
   }
-
 
 }

--- a/src/main/java/org/pankratzlab/unet/validation/ValidationTestFileSet.java
+++ b/src/main/java/org/pankratzlab/unet/validation/ValidationTestFileSet.java
@@ -1,23 +1,31 @@
 package org.pankratzlab.unet.validation;
 
+import java.io.File;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
+import org.pankratzlab.unet.deprecated.hla.SourceType;
 import org.pankratzlab.unet.hapstats.CommonWellDocumented;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyListProperty;
 import javafx.beans.property.ReadOnlyListWrapper;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
+import javafx.beans.property.ReadOnlySetProperty;
+import javafx.beans.property.ReadOnlySetWrapper;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
+import javafx.collections.ObservableSet;
 
 public class ValidationTestFileSet {
 
   public final ReadOnlyStringProperty id;
 
   public final ReadOnlyListProperty<String> filePaths;
+
+  public final ReadOnlySetProperty<SourceType> sourceTypes;
 
   public final ReadOnlyStringProperty remapFile;
 
@@ -90,6 +98,16 @@ public class ValidationTestFileSet {
       Boolean lastPassingState) {
     this.id = new ReadOnlyStringWrapper(id);
     this.filePaths = new ReadOnlyListWrapper<>(FXCollections.observableList(filePaths));
+    final ObservableSet<SourceType> observableSet =
+        FXCollections.observableSet(filePaths.stream().map(s -> {
+          try {
+            return SourceType.parseType(new File(s));
+          } catch (IllegalArgumentException e) {
+            // TODO should deal with nulls somehow?
+            return null;
+          }
+        }).collect(Collectors.toSet()));
+    this.sourceTypes = new ReadOnlySetWrapper<>(observableSet);
     this.remapFile = new ReadOnlyStringWrapper(remapFile);
     this.cwdSource = new ReadOnlyObjectWrapper<>(cwdSource);
     this.relDnaSerFile = new ReadOnlyStringWrapper(relDnaSerFile);

--- a/src/main/java/org/pankratzlab/unet/validation/ValidationTestFileSet.java
+++ b/src/main/java/org/pankratzlab/unet/validation/ValidationTestFileSet.java
@@ -16,12 +16,16 @@ import javafx.beans.property.ReadOnlySetWrapper;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableSet;
 
 public class ValidationTestFileSet {
 
-  public final ReadOnlyStringProperty id;
+  public final StringProperty id;
+
+  public final StringProperty comment;
 
   public final ReadOnlyListProperty<String> filePaths;
 
@@ -42,6 +46,7 @@ public class ValidationTestFileSet {
 
   public static class ValidationTestFileSetBuilder {
     private String id;
+    private String comment;
     private List<String> filePaths;
     private String remapFile;
     private CommonWellDocumented.SOURCE cwdSource;
@@ -52,6 +57,11 @@ public class ValidationTestFileSet {
 
     public ValidationTestFileSetBuilder id(String id) {
       this.id = id;
+      return this;
+    }
+
+    public ValidationTestFileSetBuilder comment(String comment) {
+      this.comment = comment;
       return this;
     }
 
@@ -91,7 +101,7 @@ public class ValidationTestFileSet {
     }
 
     public ValidationTestFileSet build() {
-      return new ValidationTestFileSet(id, filePaths, remapFile, cwdSource, relDnaSerFile,
+      return new ValidationTestFileSet(id, comment, filePaths, remapFile, cwdSource, relDnaSerFile,
           lastRunDate, lastPassingState, lastPassingResult);
     }
 
@@ -101,10 +111,11 @@ public class ValidationTestFileSet {
     return new ValidationTestFileSetBuilder();
   }
 
-  private ValidationTestFileSet(String id, List<String> filePaths, String remapFile,
+  private ValidationTestFileSet(String id, String comment, List<String> filePaths, String remapFile,
       CommonWellDocumented.SOURCE cwdSource, String relDnaSerFile, Date lastRunDate,
       Boolean lastPassingState, TEST_RESULT lastTestResult) {
-    this.id = new ReadOnlyStringWrapper(id);
+    this.id = new SimpleStringProperty(id);
+    this.comment = new SimpleStringProperty(comment);
     this.filePaths = new ReadOnlyListWrapper<>(FXCollections.observableList(filePaths));
     final ObservableSet<SourceType> observableSet =
         FXCollections.observableSet(filePaths.stream().map(s -> {

--- a/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
+++ b/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
@@ -1,0 +1,571 @@
+package org.pankratzlab.unet.validation;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
+import org.pankratzlab.unet.deprecated.hla.AntigenDictionary;
+import org.pankratzlab.unet.deprecated.hla.HLALocus;
+import org.pankratzlab.unet.deprecated.hla.HLAProperties;
+import org.pankratzlab.unet.deprecated.hla.Info;
+import org.pankratzlab.unet.deprecated.hla.SourceType;
+import org.pankratzlab.unet.hapstats.CommonWellDocumented;
+import org.pankratzlab.unet.hapstats.CommonWellDocumented.SOURCE;
+import org.pankratzlab.unet.model.ValidationModel;
+import org.pankratzlab.unet.model.ValidationModelBuilder;
+import org.pankratzlab.unet.model.ValidationModelBuilder.TypePair;
+import org.pankratzlab.unet.model.ValidationTable;
+import org.pankratzlab.unet.model.remap.RemapProcessor;
+import org.pankratzlab.unet.parser.HtmlDonorParser;
+import org.pankratzlab.unet.parser.PdfDonorParser;
+import org.pankratzlab.unet.parser.XmlDonorParser;
+import org.pankratzlab.unet.validation.ValidationTestFileSet.ValidationTestFileSetBuilder;
+import com.google.common.base.Strings;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Table;
+import com.google.common.io.Files;
+
+public class ValidationTesting {
+
+  private static final String SURETYPER_PDF_FILE = "typer.pdf";
+  private static final String SCORE6_XML_FILE = "score6.xml";
+  private static final String DONORNET_XML_FILE = "donornet.xml";
+  private static final String DONORNET_HTML_FILE = "DonorEdit.html";
+  private static final String REMAP_XML = "remap.xml";
+  private static final String TEST_PROPERTIES = "test.properties";
+
+  public static final String VALIDATION_DIRECTORY = Info.HLA_HOME + "validation/";
+
+  private static final String CWD_PROP = "cwd";
+  private static final String REL = "rel";
+  private static final String LAST_RUN_PROP = "last_run";
+  private static final String LAST_RESULT_PROP = "last_result";
+  private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+  public static class TestInfo {
+    public final String label;
+    public final String file;
+    public final ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> remappings;
+    public final SourceType sourceType;
+
+    public TestInfo(String label, String file,
+        ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> remappings,
+        SourceType sourceType) {
+      this.label = label;
+      this.file = file;
+      this.remappings = remappings;
+      this.sourceType = sourceType;
+    }
+
+  }
+
+  public static ImmutableMap<ValidationTestFileSet, TestRun> runTests(
+      List<ValidationTestFileSet> tests) {
+
+    Map<ValidationTestFileSet, TestRun> results = new HashMap<>();
+
+    Table<CommonWellDocumented.SOURCE, String, List<ValidationTestFileSet>> table =
+        HashBasedTable.create();
+
+    for (ValidationTestFileSet test : tests) {
+      addTestSetToTable(table, test);
+    }
+
+    SOURCE current = CommonWellDocumented.loadPropertyCWDSource();
+    String currentRel = HLAProperties.get().getProperty(AntigenDictionary.REL_DNA_SER_PROP);
+
+    for (SOURCE source : SOURCE.values()) {
+      Map<String, List<ValidationTestFileSet>> relMap = table.row(source);
+      if (relMap.isEmpty()) {
+        continue;
+      }
+
+      if (current != source || !CommonWellDocumented.isLoaded()) {
+        CommonWellDocumented.loadCIWDVersion(source);
+      }
+
+      for (String rel : relMap.keySet()) {
+        List<ValidationTestFileSet> testFiles = relMap.get(rel);
+
+        if (!new File(currentRel).equals(new File(rel))) {
+          HLAProperties.get().setProperty(AntigenDictionary.REL_DNA_SER_PROP, rel);
+          AntigenDictionary.clearCache();
+        }
+
+        for (ValidationTestFileSet test : testFiles) {
+          // TODO log test run
+          System.out.println("Running test: " + test.filePaths.toString());
+
+          TEST_RESULT result = runTest(test);
+
+          // TODO log test result
+          System.out.println("Result: " + result);
+
+          results.put(test, new TestRun(test, result, new Date()));
+        }
+      }
+    }
+
+    CommonWellDocumented.loadCIWDVersion(current);
+    HLAProperties.get().setProperty(AntigenDictionary.REL_DNA_SER_PROP, currentRel);
+
+    updateTestResults(results);
+
+    return ImmutableMap.copyOf(results);
+  }
+
+  public enum TEST_RESULT {
+    NO_TEST_FILES(false), // test directory doesn't contain any test files'
+    NOT_ENOUGH_TEST_FILES(false), // test directory only have one test file
+    INVALID_TEST_FILE(false), // error when loading/parsing file
+    MISSING_REMAP_FILE(false), // file requires remappings but remap file doesn't exist
+    INVALID_REMAP_FILE(false), // error when loading/parsing remap file
+    INVALID_REMAPPINGS(false), // remappings in file don't match required remappings
+    TEST_FAILURE(false), // validation failed
+    TEST_SUCCESS(true); // validation passed
+
+    public final boolean isPassing;
+
+    private TEST_RESULT(boolean passes) {
+      this.isPassing = passes;
+    }
+
+  }
+
+  private static TEST_RESULT runTest(ValidationTestFileSet test) {
+    List<ValidationModelBuilder> modelBuilders = new ArrayList<>();
+    XMLRemapProcessor remapProcessor = null;
+
+    for (String filePath : test.filePaths) {
+      ValidationModelBuilder builder = new ValidationModelBuilder();
+      File file = new File(filePath);
+
+      try {
+        // TODO make this an enum to avoid cascading ifs
+        if (filePath.toLowerCase().endsWith(DONORNET_HTML_FILE.toLowerCase())) {
+          new HtmlDonorParser().parseModel(builder, file);
+        } else if (filePath.endsWith(DONORNET_XML_FILE) || filePath.endsWith(SCORE6_XML_FILE)) {
+          new XmlDonorParser().parseModel(builder, file);
+        } else if (filePath.endsWith(SURETYPER_PDF_FILE)) {
+          new PdfDonorParser().parseModel(builder, file);
+        }
+      } catch (Exception e) {
+        // TODO include which file is invalid (will need to test both if first is invalid)
+        e.printStackTrace(); // TODO log exception somehow
+        return TEST_RESULT.INVALID_TEST_FILE;
+      }
+
+      modelBuilders.add(builder);
+    }
+
+    if (test.remapFile != null && test.remapFile.get() != null) {
+
+      // check to make sure remap file exists
+      if (!new File(test.remapFile.get()).exists()) {
+        return TEST_RESULT.MISSING_REMAP_FILE;
+      }
+
+      try {
+        remapProcessor = new XMLRemapProcessor(test.remapFile.get());
+      } catch (IllegalStateException e) {
+        // TODO respond appropriately to invalid remap file
+        e.printStackTrace();
+        return TEST_RESULT.INVALID_REMAP_FILE;
+      }
+
+    }
+
+    List<ValidationModel> models = new ArrayList<>();
+    for (ValidationModelBuilder builder : modelBuilders) {
+
+      if (builder.hasCorrections()) {
+        // assertion check if builder *should* have corrections
+        RemapProcessor remapper;
+        if (remapProcessor != null) {
+
+          if (!remapProcessor.hasRemappings(builder.getSourceType())) {
+            // TODO test to ensure this is correct behavior
+            // if the remap file doesn't have the correct remappings
+            return TEST_RESULT.INVALID_REMAPPINGS;
+          }
+          // assertTrue();
+          remapper = remapProcessor;
+        } else {
+          remapper = new XMLRemapProcessor.NoRemapProcessor();
+        }
+
+        // TODO determine if result is necessary or not
+        /* ValidationResult result = */builder.processCorrections(remapper);
+
+        // TODO replace asserts with actual behavior
+        // assertTrue(result.valid);
+        // assertFalse(result.validationMessage.isPresent());
+      } else {
+        if (remapProcessor != null && remapProcessor.hasRemappings(builder.getSourceType())) {
+          // builder says no remappings, but remap file says remappings do exist
+          return TEST_RESULT.INVALID_REMAPPINGS;
+        }
+      }
+
+      models.add(builder.build());
+    }
+
+    // TODO do something with eventual return value
+    boolean valid = testIfModelsAgree(models);
+    return valid ? TEST_RESULT.TEST_SUCCESS : TEST_RESULT.TEST_FAILURE;
+  }
+
+  private static boolean testIfModelsAgree(List<ValidationModel> individualModels) {
+    ValidationModel base = individualModels.get(0);
+    ValidationTable table = new ValidationTable();
+    table.setFirstModel(base);
+
+    // TODO defaulting to true means a test case with only one input file is automatically valid
+    boolean valid = true;
+    for (int index = 1; index < individualModels.size(); index++) {
+      ValidationModel test = individualModels.get(index);
+      table.setSecondModel(test);
+      table.getValidationRows();
+      valid &= table.isValidProperty().get();
+    }
+    return valid;
+  }
+
+  public static void addToValidationSet(TestInfo file1, TestInfo file2) {
+    // TODO ensure labels match between file1 and file2
+
+    File valDir = new File(VALIDATION_DIRECTORY);
+    if (!valDir.exists()) {
+      valDir.mkdir();
+    }
+
+    // TODO invalid characters from label
+    String reldir = VALIDATION_DIRECTORY + REL + "/";
+    String subdir = VALIDATION_DIRECTORY + safeFilename(file1.label) + "/";
+
+    final File testDir = new File(subdir);
+
+    if (testDir.exists()) {
+      // TODO notify user, show directory path and cancel operation
+    }
+
+    testDir.mkdirs();
+
+    try {
+      Files.copy(new File(file1.file), new File(subdir + new File(file1.file).getName()));
+      Files.copy(new File(file2.file), new File(subdir + new File(file2.file).getName()));
+    } catch (Exception e) {
+      // TODO handle exceptions appropriately;
+      // notify user of inability to add files and cleanup appropriately
+      e.printStackTrace();
+    }
+
+    File relDirFile = new File(reldir);
+    if (!relDirFile.exists()) {
+      relDirFile.mkdir();
+    }
+
+    String relDnaSerFile = HLAProperties.get().getProperty(AntigenDictionary.REL_DNA_SER_PROP);
+    String newRelFileName;
+    String newRelDnaSerFile;
+    if (!Strings.isNullOrEmpty(relDnaSerFile) && new File(relDnaSerFile).exists()) {
+      File file = new File(relDnaSerFile);
+      String fileName = file.getName();
+      String version = AntigenDictionary.getVersion(file.getAbsolutePath()).trim();
+
+      newRelFileName = version + "_" + fileName;
+
+      // make sure new filename is filename-safe
+      newRelFileName = safeFilename(newRelFileName);
+
+      newRelDnaSerFile = reldir + newRelFileName;
+
+      // copy file to testDir
+      File newRelFile = new File(newRelDnaSerFile);
+      if (!newRelFile.exists()) {
+        try {
+          Files.copy(file, newRelFile);
+        } catch (Exception e) {
+          // TODO handle exceptions appropriately;
+          // notify user of inability to copy rel_dna_ser file, and cleanup appropriately
+          e.printStackTrace();
+        }
+      }
+
+    } else {
+      String fileName = AntigenDictionary.MASTER_MAP_RECORDS;
+      String bundledVersion = AntigenDictionary.getBundledVersion();
+
+      newRelFileName = bundledVersion + "_" + fileName;
+      // make sure new filename is platform-safe
+      newRelFileName = safeFilename(newRelFileName);
+
+      newRelDnaSerFile = reldir + newRelFileName;
+
+      // Copy internal file to testDir
+      File newRelFile = new File(reldir + newRelFileName);
+      if (!newRelFile.exists()) {
+        try (InputStream is = AntigenDictionary.class.getClassLoader()
+            .getResourceAsStream(AntigenDictionary.MASTER_MAP_RECORDS)) {
+          java.nio.file.Files.copy(is, newRelFile.toPath(), StandardCopyOption.ATOMIC_MOVE);
+        } catch (Exception e) {
+          // TODO handle exceptions appropriately;
+          // notify user of inability to copy bundled rel_dna_ser file, and cleanup appropriately
+          e.printStackTrace();
+        }
+      }
+    }
+
+    if (!file1.remappings.isEmpty() || !file2.remappings.isEmpty()) {
+
+      Document doc = Jsoup.parse("", "", Parser.xmlParser());
+      // Set the output settings to XML syntax
+      doc.outputSettings().syntax(Document.OutputSettings.Syntax.xml);
+
+      // Create the root element <remappings>
+      Element remappings = doc.appendElement("remappings");
+
+      if (!file1.remappings.isEmpty()) {
+        addXMLInfo(remappings, file1);
+      }
+
+      if (!file2.remappings.isEmpty()) {
+        addXMLInfo(remappings, file2);
+      }
+
+      // create remapping file
+      try (FileWriter writer = new FileWriter(subdir + REMAP_XML)) {
+        writer.write(doc.outerHtml());
+      } catch (IOException e) {
+        // TODO handle exceptions appropriately;
+        // notify user of inability to copy bundled rel_dna_ser file, and cleanup appropriately
+        e.printStackTrace();
+      }
+    }
+
+    // write test properties file containing CWD type and rel_dna_ser filename
+    Properties props = new Properties();
+    props.setProperty(CWD_PROP, CommonWellDocumented.loadPropertyCWDSource().name());
+    props.setProperty(REL, newRelFileName);
+    try (FileOutputStream fos = new FileOutputStream(new File(subdir + TEST_PROPERTIES))) {
+      props.store(fos, null);
+    } catch (Exception e) {
+      // TODO handle exceptions appropriately;
+      // notify user of inability to copy bundled rel_dna_ser file, and cleanup appropriately
+      e.printStackTrace();
+    }
+
+  }
+
+  private static String safeFilename(String newRelFileName) {
+    newRelFileName = newRelFileName.replaceAll("[^a-zA-Z0-9-_\\\\.]", "");
+    return newRelFileName;
+  }
+
+  private static void addXMLInfo(Element remappings, TestInfo file) {
+    Element remap = remappings.appendElement("remap");
+
+    // Add <sourceType>Score6</sourceType> under <remap>
+    remap.appendElement("sourceType").text(file.sourceType.name());
+
+
+    file.remappings.entrySet().forEach(e -> {
+      // Create <remapLocus> under <remap>
+      Element remapLocus = remap.appendElement("remapLocus");
+      remapLocus.appendElement("locus").text(e.getKey().name());
+
+      // Add multiple <fromAllele> elements under <remapLocus>
+      e.getValue().getLeft().stream().forEach(allele -> {
+        remapLocus.appendElement("fromAllele").text(allele.getHlaType().specString());
+      });
+
+      // Add multiple <toAllele> elements under <remapLocus>
+      e.getValue().getLeft().stream().forEach(allele -> {
+        remapLocus.appendElement("toAllele").text(allele.getHlaType().specString());
+      });
+    });
+
+  }
+
+  public static class TestRun {
+    public final ValidationTestFileSet testFileSet;
+    public final TEST_RESULT result;
+    public final Date runTime;
+
+    public TestRun(ValidationTestFileSet testFileSet, TEST_RESULT result, Date runTime) {
+      this.testFileSet = testFileSet;
+      this.result = result;
+      this.runTime = runTime;
+    }
+
+  }
+
+  public static void updateTestResults(Map<ValidationTestFileSet, TestRun> newResults) {
+    for (Entry<ValidationTestFileSet, TestRun> entry : newResults.entrySet()) {
+      String subdir = VALIDATION_DIRECTORY + safeFilename(entry.getKey().id.get()) + "/";
+      File testPropertiesFile = new File(subdir + TEST_PROPERTIES);
+      Properties props = new Properties();
+      if (testPropertiesFile.exists()) {
+        try (FileInputStream fis = new FileInputStream(testPropertiesFile)) {
+          props.load(fis);
+        } catch (Exception e) {
+          // TODO Auto-generated catch block
+          e.printStackTrace();
+        }
+      } else {
+        props.setProperty(CWD_PROP, entry.getKey().cwdSource.get().name());
+        String relName = entry.getKey().relDnaSerFile.get();
+        if (relName.startsWith(VALIDATION_DIRECTORY + REL + "/")) {
+          relName = relName.substring((VALIDATION_DIRECTORY + REL + "/").length());
+        }
+        props.getProperty(REL, relName);
+      }
+
+      entry.getKey().lastRunDate.set(entry.getValue().runTime);
+      props.setProperty(LAST_RUN_PROP, DATE_FORMAT.format(entry.getValue().runTime));
+
+      entry.getKey().lastPassingState.set(entry.getValue().result.isPassing);
+      props.setProperty(LAST_RESULT_PROP, Boolean.toString(entry.getValue().result.isPassing));
+
+      try (FileOutputStream fos = new FileOutputStream(new File(subdir + TEST_PROPERTIES))) {
+        props.store(fos, null);
+      } catch (Exception e) {
+        // TODO handle exceptions appropriately;
+        // notify user of inability to copy bundled rel_dna_ser file, and cleanup appropriately
+        e.printStackTrace();
+      }
+    }
+
+  }
+
+  public static Table<SOURCE, String, List<ValidationTestFileSet>> loadValidationDirectory() {
+    Table<CommonWellDocumented.SOURCE, String, List<ValidationTestFileSet>> testSets =
+        HashBasedTable.create();
+
+    File dir = new File(VALIDATION_DIRECTORY);
+    if (dir.exists() && dir.isDirectory()) {
+      // The test directory is a test root, where child directories correspond to individuals.
+      // Each individual should be tested individually
+      for (File individualFile : dir.listFiles()) {
+        if (individualFile.isDirectory() && !individualFile.getName().equals(REL)) {
+
+          ValidationTestFileSetBuilder builder = ValidationTestFileSet.builder();
+          builder.id(individualFile.getName());
+
+          loadTestMetadata(individualFile, builder);
+
+          String remapFile = null;
+          Builder<String> inputFilesBuilder = ImmutableList.builder();
+          for (File testFile : individualFile.listFiles()) {
+            if (testFile.getName().equals(REMAP_XML)) {
+              remapFile = testFile.getAbsolutePath();
+            } else if (testFile.getName().equals(TEST_PROPERTIES)) {
+              // skip
+            } else {
+              inputFilesBuilder.add(testFile.getAbsolutePath());
+            }
+          }
+          builder.filePaths(inputFilesBuilder.build());
+          builder.remapFile(remapFile);
+
+          // TODO ensure testSet has at least two input files
+
+          ValidationTestFileSet testSet = builder.build();
+
+          addTestSetToTable(testSets, testSet);
+        }
+      }
+    }
+
+    return testSets;
+  }
+
+  private static void addTestSetToTable(
+      Table<CommonWellDocumented.SOURCE, String, List<ValidationTestFileSet>> testSets,
+      ValidationTestFileSet testSet) {
+    if (!testSets.contains(testSet.cwdSource.get(), testSet.relDnaSerFile.get())) {
+      testSets.put(testSet.cwdSource.get(), testSet.relDnaSerFile.get(), new ArrayList<>());
+    }
+    testSets.get(testSet.cwdSource.get(), testSet.relDnaSerFile.get()).add(testSet);
+  }
+
+  private static void loadTestMetadata(File individualFile, ValidationTestFileSetBuilder builder) {
+    File testPropertiesFile = new File(individualFile, TEST_PROPERTIES);
+    Properties props = new Properties();
+    if (testPropertiesFile.exists()) {
+      try (FileInputStream fis = new FileInputStream(testPropertiesFile)) {
+        props.load(fis);
+      } catch (Exception e) {
+        // TODO Auto-generated catch block
+        e.printStackTrace();
+      }
+    }
+    String cwdStr = props.getProperty(CWD_PROP);
+    String relStr = props.getProperty(REL);
+
+    // TODO check that properties are valid
+
+    CommonWellDocumented.SOURCE cwdSource = null;
+    try {
+      cwdSource = CommonWellDocumented.SOURCE.valueOf(cwdStr);
+    } catch (Exception e) {
+      // TODO not a valid CWD Source, respond appropriately
+      e.printStackTrace();
+    }
+    builder.cwdSource(cwdSource);
+
+    String relPath = VALIDATION_DIRECTORY + REL + "/" + relStr;
+    builder.relDnaSerFile(relPath);
+
+
+    // TODO currently saving only one run date & result
+    // TODO store results for multiple runs in a new file
+    String lastRunStr = props.getProperty(LAST_RUN_PROP);
+    String lastPassingStr = props.getProperty(LAST_RESULT_PROP);
+
+    // load last run date
+    Date lastRunDate = null;
+    if (lastRunStr != null) {
+      try {
+        lastRunDate = DATE_FORMAT.parse(lastRunStr);
+      } catch (ParseException e) {
+        // TODO Auto-generated catch block
+        e.printStackTrace();
+      }
+    }
+    builder.lastRunDate(lastRunDate);
+
+    // load last passing state
+    Boolean lastPassingState = lastPassingStr == null ? null : Boolean.parseBoolean(lastPassingStr);
+    builder.lastPassingState(lastPassingState);
+
+  }
+
+  public static void deleteTests(List<ValidationTestFileSet> toRemove) {
+    // TODO Auto-generated method stub
+
+  }
+
+}

--- a/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
+++ b/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
@@ -64,7 +64,8 @@ public class ValidationTesting {
   private static final String TEST_LOG = "test.log";
 
   public static final String REL_DIRECTORY = Info.HLA_HOME + "rel_dna_ser_files/";
-  public static final String VALIDATION_DIRECTORY = Info.HLA_HOME + "validation/";
+  public static final String VALIDATION_DIRECTORY =
+      new File(Info.HLA_HOME + "validation/").getAbsolutePath() + File.separator;
 
   private static final String CWD_PROP = "cwd";
   private static final String REL = "rel";
@@ -92,7 +93,7 @@ public class ValidationTesting {
     }
 
     String reldir = REL_DIRECTORY;
-    String subdir = VALIDATION_DIRECTORY + safeFilename(file1.label) + "/";
+    String subdir = getTestDirectory(file1.label);
 
     final File testDir = new File(subdir);
 
@@ -286,7 +287,7 @@ public class ValidationTesting {
 
   public static void updateTestResults(Map<ValidationTestFileSet, TestRun> newResults) {
     for (Entry<ValidationTestFileSet, TestRun> entry : newResults.entrySet()) {
-      String subdir = VALIDATION_DIRECTORY + safeFilename(entry.getKey().id.get()) + "/";
+      String subdir = getTestDirectory(entry.getKey());
 
       entry.getKey().lastRunDate.set(entry.getValue().runTime);
       entry.getKey().lastTestResult.set(entry.getValue().result);
@@ -319,7 +320,7 @@ public class ValidationTesting {
    * @param test
    */
   public static void updateTestProperties(ValidationTestFileSet test) {
-    String subdir = VALIDATION_DIRECTORY + safeFilename(test.id.get()) + "/";
+    String subdir = getTestDirectory(test);
     File testPropertiesFile = new File(subdir + TEST_PROPERTIES);
     Properties props = new Properties();
 
@@ -350,6 +351,15 @@ public class ValidationTesting {
     }
   }
 
+  public static String getTestDirectory(ValidationTestFileSet test) {
+    final String testId = test.id.get();
+    return getTestDirectory(testId);
+  }
+
+  public static String getTestDirectory(final String testId) {
+    return VALIDATION_DIRECTORY + safeFilename(testId) + "/";
+  }
+
   public static TestLoadingResults loadValidationDirectory() {
     Table<CommonWellDocumented.SOURCE, String, List<ValidationTestFileSet>> testSets =
         HashBasedTable.create();
@@ -365,7 +375,7 @@ public class ValidationTesting {
           ValidationTestFileSet testSet;
           try {
             testSet = loadIndividualTest(individualFile);
-          } catch (IllegalStateException e) {
+          } catch (Exception e) {
             // catch exceptions and skip loading test, but will report later
             invalidTests.add(individualFile.getName());
             continue;
@@ -414,7 +424,7 @@ public class ValidationTesting {
       List<ValidationTestFileSet> toRemove) {
     Map<ValidationTestFileSet, Boolean> success = new HashMap<>();
     for (ValidationTestFileSet testSet : toRemove) {
-      String dir = VALIDATION_DIRECTORY + safeFilename(testSet.id.get()) + "/";
+      String dir = getTestDirectory(testSet);
       boolean successDel = deleteTestDirectory(dir);
       success.put(testSet, successDel);
     }
@@ -669,8 +679,8 @@ public class ValidationTesting {
   }
 
   public static ValidationTestFileSet updateTestID(String oldId, ValidationTestFileSet test) {
-    String oldSubdir = VALIDATION_DIRECTORY + safeFilename(oldId) + "/";
-    String newSubdir = VALIDATION_DIRECTORY + safeFilename(test.id.get()) + "/";
+    String oldSubdir = getTestDirectory(oldId);
+    String newSubdir = getTestDirectory(test);
 
     try {
       java.nio.file.Files.move(Path.of(oldSubdir), Path.of(newSubdir));

--- a/src/main/java/org/pankratzlab/unet/validation/XMLRemapProcessor.java
+++ b/src/main/java/org/pankratzlab/unet/validation/XMLRemapProcessor.java
@@ -1,0 +1,92 @@
+package org.pankratzlab.unet.validation;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.pankratzlab.unet.deprecated.hla.HLALocus;
+import org.pankratzlab.unet.deprecated.hla.HLAType;
+import org.pankratzlab.unet.deprecated.hla.SourceType;
+import org.pankratzlab.unet.model.ValidationModelBuilder;
+import org.pankratzlab.unet.model.ValidationModelBuilder.TypePair;
+import org.pankratzlab.unet.model.remap.CancellationException;
+import org.pankratzlab.unet.model.remap.RemapProcessor;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Table;
+
+public class XMLRemapProcessor implements RemapProcessor {
+
+  public static class NoRemapProcessor implements RemapProcessor {
+    @Override
+    public Pair<Set<TypePair>, Set<TypePair>> processRemapping(HLALocus locus,
+        ValidationModelBuilder builder) throws CancellationException {
+      Set<HLAType> types = builder.getAllTypesForLocus(locus);
+      if (types == null || types.size() == 0) {
+        // no types available for remapping, so return null to indicate locus should use
+        // default-assigned types
+        return null;
+      }
+      HLAType[] tp = types.toArray(new HLAType[types.size()]);
+      if (tp.length == 1) {
+        tp = new HLAType[] {tp[0], tp[0]};
+      }
+      return Pair.of(
+          ImmutableSet.of(new TypePair(tp[0], tp[0].equivSafe()),
+              new TypePair(tp[1], tp[1].equivSafe())),
+          ImmutableSet.of(new TypePair(tp[0], tp[0].equivSafe()),
+              new TypePair(tp[1], tp[1].equivSafe())));
+    }
+  }
+
+  private Table<SourceType, HLALocus, Pair<Set<TypePair>, Set<TypePair>>> remappings =
+      HashBasedTable.create();
+
+  public XMLRemapProcessor(String file) {
+    try (FileInputStream xmlStream = new FileInputStream(new File(file))) {
+      Document parsed = Jsoup.parse(xmlStream, "UTF-8", "http://example.com");
+      Elements remapElements = parsed.getElementsByTag("remappings");
+      remapElements = remapElements.get(0).getElementsByTag("remap");
+      SourceType source =
+          SourceType.valueOf(remapElements.get(0).getElementsByTag("sourceType").get(0).text());
+      remapElements.forEach(e -> {
+        e.getElementsByTag("remapLocus").forEach(locusElement -> {
+          // TODO catch missing or malformed SourceType values and report
+          // TODO catch missing or malformed locus values and report
+          HLALocus locus = HLALocus.valueOf(locusElement.getElementsByTag("locus").get(0).text());
+          HLAType[] fromAlleles =
+              locusElement.getElementsByTag("fromAllele").stream().map(Element::text)
+                  .map(s -> locus.name() + "*" + s).map(HLAType::valueOf).toArray(HLAType[]::new);
+          HLAType[] toAlleles =
+              locusElement.getElementsByTag("toAllele").stream().map(Element::text)
+                  .map(s -> locus.name() + "*" + s).map(HLAType::valueOf).toArray(HLAType[]::new);
+          // TODO catch missing or malformed allele values and report
+          remappings.put(source, locus,
+              Pair.of(
+                  ImmutableSet.of(new TypePair(fromAlleles[0], fromAlleles[0].equivSafe()),
+                      new TypePair(fromAlleles[1], fromAlleles[1].equivSafe())),
+                  ImmutableSet.of(new TypePair(toAlleles[0], toAlleles[0].equivSafe()),
+                      new TypePair(toAlleles[1], toAlleles[1].equivSafe()))));
+
+        });
+      });
+    } catch (Throwable e) {
+      throw new IllegalStateException("Invalid XML file: " + file, e);
+    }
+  }
+
+  @Override
+  public Pair<Set<TypePair>, Set<TypePair>> processRemapping(HLALocus locus,
+      ValidationModelBuilder builder) throws CancellationException {
+    return remappings.get(builder.getSourceType(), locus);
+  }
+
+  public boolean hasRemappings(SourceType sourceType) {
+    return remappings.containsRow(sourceType);
+  }
+
+}

--- a/src/main/resources/FileInput.fxml
+++ b/src/main/resources/FileInput.fxml
@@ -6,31 +6,66 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 <?import javafx.scene.text.TextFlow?>
+<?import javafx.scene.control.Menu?>
+<?import javafx.scene.control.MenuBar?>
+<?import javafx.scene.control.MenuItem?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.ColumnConstraints?>
 <?import org.pankratzlab.unet.jfx.wizard.ValidatingWizardPane?>
 
-<ValidatingWizardPane fx:id="rootPane" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
-   <header>
-      <Label text="Input Donor Files for Comparison">
-         <font>
-            <Font size="20.0" />
-         </font>
-      </Label>
-   </header>
-   <padding>
-      <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-   </padding>
-   <content>
-      <VBox fx:id="inputFiles_VBox" spacing="15.0">
-         <children>
-            <TextFlow>
-               <children>
-                  <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Select two typing files from a single donor.&#10;See Tutorials menu for XML/HTML instructions.">
-                     <font>
-                        <Font size="16.0" />
-                     </font></Text>
-               </children>
-            </TextFlow>
-         </children>
-      </VBox>
-   </content>
+<ValidatingWizardPane fx:id="rootPane"
+	xmlns="http://javafx.com/javafx/8.0.171"
+	xmlns:fx="http://javafx.com/fxml/1">
+	<header>
+		<GridPane alignment="center">
+			<columnConstraints>
+				<ColumnConstraints hgrow="ALWAYS" />
+			</columnConstraints>
+			<children>
+				<MenuBar GridPane.columnIndex="0" GridPane.rowIndex="0">
+					<menus>
+						<Menu mnemonicParsing="false" text="Tutorials">
+							<items>
+								<MenuItem mnemonicParsing="false"
+									onAction="#tutorialXMLDownload" text="XML DonorNet Download" />
+								<MenuItem mnemonicParsing="false"
+									onAction="#tutorialHTMLDownload" text="HTML DonorNet Download" />
+							</items>
+						</Menu>
+					</menus>
+				</MenuBar>
+				<Label text="Input Donor Files for Comparison"
+					GridPane.columnIndex="0" GridPane.rowIndex="1">
+					<padding>
+						<Insets bottom="0" left="20.0" right="20.0" top="10.0" />
+					</padding>
+					<font>
+						<Font size="20.0" />
+					</font>
+				</Label>
+			</children>
+		</GridPane>
+	</header>
+	<padding>
+		<Insets bottom="0" left="0" right="0" top="0" />
+	</padding>
+	<content>
+		<VBox fx:id="inputFiles_VBox" spacing="15.0">
+			<padding>
+				<Insets bottom="10.0" left="20.0" right="20.0" top="20.0" />
+			</padding>
+			<children>
+				<TextFlow>
+					<children>
+						<Text strokeType="OUTSIDE" strokeWidth="0.0"
+							text="Select two typing files from a single donor.&#10;&#10;For XML/HTML instructions, see Tutorials menu.">
+							<font>
+								<Font size="16.0" />
+							</font>
+						</Text>
+					</children>
+				</TextFlow>
+			</children>
+		</VBox>
+	</content>
 </ValidatingWizardPane>

--- a/src/main/resources/TypeValidationLanding.fxml
+++ b/src/main/resources/TypeValidationLanding.fxml
@@ -193,6 +193,12 @@
                         <MenuItem mnemonicParsing="false" onAction="#tutorialHTMLDownload" text="HTML DonorNet Download" />
                     </items>
                   </Menu>
+                  <Menu mnemonicParsing="false" text="Testing">
+                    <items>
+                      <MenuItem mnemonicParsing="false" onAction="#manageTestingFiles" text="Manage Test Files" />
+                      <MenuItem mnemonicParsing="false" onAction="#runTesting" text="Validate Test Files" />
+                    </items>
+                  </Menu>
                   <Menu mnemonicParsing="false" text="MAC Conversion">
                      <items>
                         <MenuItem mnemonicParsing="false" onAction="#macConversionScore6" text="Score6" />

--- a/src/main/resources/TypeValidationLanding.fxml
+++ b/src/main/resources/TypeValidationLanding.fxml
@@ -196,7 +196,7 @@
                   <Menu mnemonicParsing="false" text="Testing">
                     <items>
                       <MenuItem mnemonicParsing="false" onAction="#manageTestingFiles" text="Manage Test Files" />
-                      <MenuItem mnemonicParsing="false" onAction="#runTesting" text="Validate Test Files" />
+                      <MenuItem mnemonicParsing="false" onAction="#runTesting" text="Quick-Run Tests" />
                     </items>
                   </Menu>
                   <Menu mnemonicParsing="false" text="MAC Conversion">

--- a/src/main/resources/ValidationResults.fxml
+++ b/src/main/resources/ValidationResults.fxml
@@ -34,6 +34,9 @@
 									onAction="#savePNGResults" text="Save to Image" />
 								<MenuItem fx:id="saveCSVOption" mnemonicParsing="false"
 									onAction="#saveCSVResults" text="Save to CSV" />
+								<MenuItem fx:id="addToValidationOption"
+									mnemonicParsing="false" onAction="#addInputsToValidationSet"
+									text="Add Input Files to Testing Suite" />
 								<MenuItem fx:id="printOption" mnemonicParsing="false"
 									onAction="#printResults" text="Print..." />
 							</items>
@@ -48,28 +51,32 @@
 	</padding>
 	<content>
 		<GridPane hgap="10" GridPane.vgrow="ALWAYS"
-			GridPane.fillHeight="true" GridPane.valignment="TOP" >
+			GridPane.fillHeight="true" GridPane.valignment="TOP">
 			<columnConstraints>
 				<ColumnConstraints hgrow="ALWAYS" />
 				<ColumnConstraints halignment="RIGHT"
 					hgrow="NEVER" />
 			</columnConstraints>
 			<rowConstraints>
-				<RowConstraints vgrow="ALWAYS" fillHeight="true" valignment="TOP" />
+				<RowConstraints vgrow="ALWAYS" fillHeight="true"
+					valignment="TOP" />
 			</rowConstraints>
 			<children>
-				<GridPane GridPane.fillHeight="true" GridPane.vgrow="ALWAYS" VBox.vgrow="ALWAYS"
+				<GridPane GridPane.fillHeight="true"
+					GridPane.vgrow="ALWAYS" VBox.vgrow="ALWAYS"
 					GridPane.fillWidth="true" GridPane.columnIndex="0"
 					GridPane.rowIndex="0" alignment="TOP_RIGHT" hgap="10">
 					<columnConstraints>
 						<ColumnConstraints hgrow="ALWAYS" />
 					</columnConstraints>
 					<rowConstraints>
-						<RowConstraints vgrow="ALWAYS" fillHeight="true" valignment="TOP" />
+						<RowConstraints vgrow="ALWAYS" fillHeight="true"
+							valignment="TOP" />
 					</rowConstraints>
 					<children>
 						<TableView fx:id="resultsTable" fixedCellSize="30.0"
-							prefHeight="780.0" GridPane.columnIndex="0" GridPane.rowIndex="0" GridPane.vgrow="ALWAYS">
+							prefHeight="780.0" GridPane.columnIndex="0" GridPane.rowIndex="0"
+							GridPane.vgrow="ALWAYS">
 							<columns>
 								<TableColumn fx:id="rowLabelCol" editable="false"
 									prefWidth="125.0" sortable="false" styleClass="row-labels" />
@@ -94,12 +101,12 @@
 								<Insets top="15.0" />
 							</VBox.margin>
 						</Label>
-						<Label fx:id="auditLog" minWidth="200"
-							wrapText="false" focusTraversable="false"
-							GridPane.columnIndex="0" GridPane.rowIndex="2"
-							GridPane.columnSpan="1" GridPane.halignment="CENTER" 
-							GridPane.valignment="TOP" GridPane.fillHeight="true"
-							GridPane.vgrow="ALWAYS" VBox.vgrow="ALWAYS" />
+						<Label fx:id="auditLog" minWidth="200" wrapText="false"
+							focusTraversable="false" GridPane.columnIndex="0"
+							GridPane.rowIndex="2" GridPane.columnSpan="1"
+							GridPane.halignment="CENTER" GridPane.valignment="TOP"
+							GridPane.fillHeight="true" GridPane.vgrow="ALWAYS"
+							VBox.vgrow="ALWAYS" />
 					</children>
 				</GridPane>
 				<GridPane GridPane.fillHeight="true"

--- a/src/main/resources/ValidationTestMgmt.fxml
+++ b/src/main/resources/ValidationTestMgmt.fxml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Copyright (c) 2015, 2019, Gluon and/or its affiliates. All rights reserved. 
+	Use is subject to license terms. This file is available and licensed under 
+	the following license: Redistribution and use in source and binary forms, 
+	with or without modification, are permitted provided that the following conditions 
+	are met: - Redistributions of source code must retain the above copyright 
+	notice, this list of conditions and the following disclaimer. - Redistributions 
+	in binary form must reproduce the above copyright notice, this list of conditions 
+	and the following disclaimer in the documentation and/or other materials 
+	provided with the distribution. - Neither the name of Oracle Corporation 
+	nor the names of its contributors may be used to endorse or promote products 
+	derived from this software without specific prior written permission. THIS 
+	SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+	ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+	IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+	INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+	BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF 
+	USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+	THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+	NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+	EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. -->
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.control.TableColumn?>
+<?import javafx.scene.control.TableView?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+
+
+<VBox prefHeight="400.0" prefWidth="640.0" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
+	<children>
+		<ScrollPane fitToHeight="true" fitToWidth="true" prefHeight="200.0" prefWidth="200.0" VBox.vgrow="ALWAYS">
+			<content>
+				<TableView fx:id="testTable" prefHeight="200.0" prefWidth="200.0">
+					<columns>
+						<TableColumn id="testIdColumn" fx:id="testIDColumn" editable="false" minWidth="30.0" prefWidth="75.0" text="Test ID" />
+						<TableColumn id="lastRunColumn" fx:id="lastRunColumn" editable="false" minWidth="30.0" prefWidth="125.0" text="Last Run" />
+						<TableColumn id="passingStatusColumn" fx:id="passingStatusColumn" editable="false" minWidth="30.0" prefWidth="65.0" text="Passed?" />
+						<TableColumn id="testFileTypesColumn" fx:id="testFileTypesColumn" editable="false" minWidth="30.0" prefWidth="150.0" text="Test File Types" />
+                  <TableColumn id="ciwdVersionColumn" fx:id="ciwdVersionColumn" prefWidth="100.0" text="CIWD Version" />
+                  <TableColumn id="relDnaSerVersion" fx:id="relDnaSerVersion" prefWidth="125.0" text="Serotype Version" />
+					</columns>
+				</TableView>
+			</content>
+		</ScrollPane>
+		<HBox spacing="10.0">
+			<VBox.margin>
+				<Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+			</VBox.margin>
+			<children>
+				<Button fx:id="closeButton" onAction="#close" mnemonicParsing="false" text="Close" />
+				<Region HBox.hgrow="ALWAYS" />
+           		<Button fx:id="removeSelectedButton" onAction="#removeSelected" mnemonicParsing="false" prefWidth="150.0" text="Remove Selected Tests" />
+				<Button fx:id="runSelectedButton" onAction="#runSelected" mnemonicParsing="false" prefWidth="150.0" text="Run Selected Tests" />
+				<Button fx:id="runAllButton" onAction="#runAll" mnemonicParsing="false" prefWidth="150.0" text="Run All Tests" />
+			</children>
+		</HBox>
+	</children>
+</VBox>

--- a/src/main/resources/ValidationTestMgmt.fxml
+++ b/src/main/resources/ValidationTestMgmt.fxml
@@ -40,6 +40,7 @@
 						<TableColumn id="testIdColumn" fx:id="testIDColumn" editable="false" minWidth="30.0" prefWidth="75.0" text="Test ID" />
 						<TableColumn id="lastRunColumn" fx:id="lastRunColumn" editable="false" minWidth="30.0" prefWidth="125.0" text="Last Run" />
 						<TableColumn id="passingStatusColumn" fx:id="passingStatusColumn" editable="false" minWidth="30.0" prefWidth="65.0" text="Passed?" />
+						<TableColumn id="lastRunResultColumn" fx:id="lastRunResultColumn" editable="false" minWidth="30.0" prefWidth="65.0" text="Result" />
 						<TableColumn id="testFileTypesColumn" fx:id="testFileTypesColumn" editable="false" minWidth="30.0" prefWidth="150.0" text="Test File Types" />
                   <TableColumn id="ciwdVersionColumn" fx:id="ciwdVersionColumn" prefWidth="100.0" text="CIWD Version" />
                   <TableColumn id="relDnaSerVersion" fx:id="relDnaSerVersion" prefWidth="125.0" text="Serotype Version" />

--- a/src/main/resources/ValidationTestMgmt.fxml
+++ b/src/main/resources/ValidationTestMgmt.fxml
@@ -31,8 +31,7 @@
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 
-
-<VBox prefHeight="400.0" prefWidth="640.0" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
+<VBox prefHeight="400.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
 	<children>
 		<ScrollPane fitToHeight="true" fitToWidth="true" prefHeight="200.0" prefWidth="200.0" VBox.vgrow="ALWAYS">
 			<content>
@@ -53,11 +52,13 @@
 				<Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
 			</VBox.margin>
 			<children>
-				<Button fx:id="closeButton" onAction="#close" mnemonicParsing="false" text="Close" />
+				<Button fx:id="closeButton" mnemonicParsing="false" onAction="#close" text="Close" />
 				<Region HBox.hgrow="ALWAYS" />
-           		<Button fx:id="removeSelectedButton" onAction="#removeSelected" mnemonicParsing="false" prefWidth="150.0" text="Remove Selected Tests" />
-				<Button fx:id="runSelectedButton" onAction="#runSelected" mnemonicParsing="false" prefWidth="150.0" text="Run Selected Tests" />
-				<Button fx:id="runAllButton" onAction="#runAll" mnemonicParsing="false" prefWidth="150.0" text="Run All Tests" />
+           		<Button fx:id="removeSelectedButton" mnemonicParsing="false" onAction="#removeSelected" prefWidth="150.0" text="Remove Selected Tests" />
+				<Button fx:id="runSelectedButton" mnemonicParsing="false" onAction="#runSelected" prefWidth="150.0" text="Run Selected Tests" />
+				<Button fx:id="runAllButton" mnemonicParsing="false" onAction="#runAll" prefWidth="150.0" text="Run All Tests" />
+            	<Region HBox.hgrow="ALWAYS" />
+            	<Button fx:id="openTestButton" mnemonicParsing="false" onAction="#openSelectedTest" text="Open Test" />
 			</children>
 		</HBox>
 	</children>

--- a/src/main/resources/ValidationTestMgmt.fxml
+++ b/src/main/resources/ValidationTestMgmt.fxml
@@ -60,6 +60,7 @@
 				<Button fx:id="runSelectedButton" mnemonicParsing="false" onAction="#runSelected" prefWidth="150.0" text="Run Selected Tests" />
 				<Button fx:id="runAllButton" mnemonicParsing="false" onAction="#runAll" prefWidth="150.0" text="Run All Tests" />
             	<Region HBox.hgrow="ALWAYS" />
+            	<Button fx:id="openDirectoryButton" mnemonicParsing="false" onAction="#openTestDirectory" text="Open Directory" />
             	<Button fx:id="openTestButton" mnemonicParsing="false" onAction="#openSelectedTest" text="Open Test" />
 			</children>
 		</HBox>

--- a/src/main/resources/ValidationTestMgmt.fxml
+++ b/src/main/resources/ValidationTestMgmt.fxml
@@ -31,19 +31,20 @@
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox prefHeight="400.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
+<VBox prefHeight="400.0" prefWidth="915.0" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
 	<children>
 		<ScrollPane fitToHeight="true" fitToWidth="true" prefHeight="200.0" prefWidth="200.0" VBox.vgrow="ALWAYS">
 			<content>
 				<TableView fx:id="testTable" prefHeight="200.0" prefWidth="200.0">
 					<columns>
-						<TableColumn id="testIdColumn" fx:id="testIDColumn" editable="false" minWidth="30.0" prefWidth="75.0" text="Test ID" />
-						<TableColumn id="lastRunColumn" fx:id="lastRunColumn" editable="false" minWidth="30.0" prefWidth="125.0" text="Last Run" />
+						<TableColumn id="testIdColumn" fx:id="testIDColumn" editable="true" minWidth="30.0" prefWidth="75.0" text="Test ID" />
+						<TableColumn id="testCommentColumn" fx:id="testCommentColumn" editable="true" minWidth="30.0" prefWidth="150.0" text="Comment" />
+						<TableColumn id="lastRunColumn" fx:id="lastRunColumn" editable="false" minWidth="30.0" prefWidth="185.0" text="Last Run" />
 						<TableColumn id="passingStatusColumn" fx:id="passingStatusColumn" editable="false" minWidth="30.0" prefWidth="65.0" text="Passed?" />
-						<TableColumn id="lastRunResultColumn" fx:id="lastRunResultColumn" editable="false" minWidth="30.0" prefWidth="65.0" text="Result" />
-						<TableColumn id="testFileTypesColumn" fx:id="testFileTypesColumn" editable="false" minWidth="30.0" prefWidth="150.0" text="Test File Types" />
-                  <TableColumn id="ciwdVersionColumn" fx:id="ciwdVersionColumn" prefWidth="100.0" text="CIWD Version" />
-                  <TableColumn id="relDnaSerVersion" fx:id="relDnaSerVersion" prefWidth="125.0" text="Serotype Version" />
+						<TableColumn id="lastRunResultColumn" fx:id="lastRunResultColumn" editable="false" minWidth="30.0" prefWidth="75.0" text="Result" />
+						<TableColumn id="testFileTypesColumn" fx:id="testFileTypesColumn" editable="false" minWidth="30.0" prefWidth="140.0" text="Test File Types" />
+                  		<TableColumn id="ciwdVersionColumn" fx:id="ciwdVersionColumn" prefWidth="100.0" text="CIWD Version" />
+                  		<TableColumn id="relDnaSerVersion" fx:id="relDnaSerVersion" prefWidth="125.0" text="Serotype Version" />
 					</columns>
 				</TableView>
 			</content>

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -1,1 +1,1 @@
-version = 1.1.15
+version = 1.2.15

--- a/src/test/java/org/pankratzlab/unet/integration/IntegrationTest.java
+++ b/src/test/java/org/pankratzlab/unet/integration/IntegrationTest.java
@@ -57,6 +57,7 @@ public class IntegrationTest {
     assumeTrue(Objects.nonNull(System.getProperty(TEST_DIR_PROPERTY)));
     assumeTrue(Objects.nonNull(individualDir));
 
+
     CommonWellDocumented.loadCIWD300();
   }
 

--- a/src/test/java/org/pankratzlab/unet/unit/tests/DRAssociationsTest.java
+++ b/src/test/java/org/pankratzlab/unet/unit/tests/DRAssociationsTest.java
@@ -1,12 +1,22 @@
 package org.pankratzlab.unet.unit.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.Set;
 import org.junit.Test;
+import org.pankratzlab.unet.deprecated.hla.AntigenDictionary;
 import org.pankratzlab.unet.deprecated.hla.HLALocus;
+import org.pankratzlab.unet.deprecated.hla.HLAType;
 import org.pankratzlab.unet.deprecated.hla.SeroType;
 import org.pankratzlab.unet.parser.util.DRAssociations;
 
 public class DRAssociationsTest {
+
+  @Test
+  public void DRAssociations_getDRBGroup() {
+    SeroType type = new SeroType("DRB3", 3);
+    Set<HLAType> s = AntigenDictionary.lookup(type);
+    System.out.println(s);
+  }
 
   @Test
   public void DRAssociations_getDRBLocus() {


### PR DESCRIPTION
# DonorCheck v1.2.15  

### Major Changes:

* Implemented user-facing batch testing / validation module
  * DonorCheck now allows users to save pairs of input files as a 'test' through the 'File' menu in the results screen.
  * Tests in the testing suite can be accessed / viewed through the new "Testing" menu on the landing screen. 
  * Tests can be run individually or in groups by selecting table rows in the test management screen, or all at once with the "Run All" button.
  * Users can view the results screen for a test with the 'Open Test' button
  * Users can rename tests by directly editing the value in the 'Test ID' column
  * Users can add comments for tests by directly editing the 'Comment' column

### Minor Changes

* Add menubar to File Input screen to allow users to view Tutorials without closing the File Input screen.
* If NMDP data is not provided, show message in Haplotype Frequency results rather than showing zero's or NaNs.
