### PR TITLE
SureTyper LinkSeq XML Updates

### DIFF
--- a/src/main/java/org/pankratzlab/unet/parser/util/XmlSureTyperParser.java
+++ b/src/main/java/org/pankratzlab/unet/parser/util/XmlSureTyperParser.java
@@ -217,7 +217,7 @@ public class XmlSureTyperParser {
     } else if (locus.equals("DR53")) {
       l = "DRB4";
     } else if (locus.equals("DR51")) {
-      l = "DRB4";
+      l = "DRB5";
     }
     return l;
   }


### PR DESCRIPTION
### Updates to support SureTyper LinkSeq XML reports

* Parse "AUTOMATICALLY chosen" haplotypes if no manual choice present;
* Allow DQA1* allele names to be parsed as DQA (e.g. DQA03 instead of DQA1*03);
* Translate DR52/53/51 into DRB3/4/5 when parsing loci;