### PR TITLE
DonorCheck v1.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>org.pankratzlab</groupId>
 	<artifactId>donorcheck</artifactId>
 	<!-- if version number changes, be sure to update in project.properties file also -->
-	<version>1.2.3</version>
+	<version>1.2.4</version>
 	<packaging>jar</packaging>
 
 	<description>A stand-alone tool for validating DonorNet typing entries.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>org.pankratzlab</groupId>
 	<artifactId>donorcheck</artifactId>
 	<!-- if version number changes, be sure to update in project.properties file also -->
-	<version>1.2.4</version>
+	<version>1.2.5</version>
 	<packaging>jar</packaging>
 
 	<description>A stand-alone tool for validating DonorNet typing entries.</description>

--- a/src/main/java/org/pankratzlab/unet/deprecated/hla/Antigen.java
+++ b/src/main/java/org/pankratzlab/unet/deprecated/hla/Antigen.java
@@ -234,7 +234,13 @@ public abstract class Antigen<L extends Locus<L>, A extends Antigen<L, A>>
 
       // Extracts value outside of parentheses if they were present (changed from returning value
       // inside parens, 5/24 - @rcoleb)
-      String val = matcher.group(1);
+      String val;
+      try {
+        val = matcher.group(1);
+      } catch (IllegalArgumentException e) {
+        // throw an exception with useful information
+        throw new IllegalArgumentException("Invalid antigen name format: " + spec, e);
+      }
 
       if (val.contains(SPEC_DELIM)) {
         // Was passed XX:YY

--- a/src/main/java/org/pankratzlab/unet/deprecated/hla/Antigen.java
+++ b/src/main/java/org/pankratzlab/unet/deprecated/hla/Antigen.java
@@ -237,9 +237,9 @@ public abstract class Antigen<L extends Locus<L>, A extends Antigen<L, A>>
       String val;
       try {
         val = matcher.group(1);
-      } catch (IllegalArgumentException e) {
+      } catch (IllegalStateException e) {
         // throw an exception with useful information
-        throw new IllegalArgumentException("Invalid antigen name format: " + spec, e);
+        throw new IllegalStateException("Invalid antigen name format: " + spec, e);
       }
 
       if (val.contains(SPEC_DELIM)) {

--- a/src/main/java/org/pankratzlab/unet/deprecated/hla/LoggingPlaceholder.java
+++ b/src/main/java/org/pankratzlab/unet/deprecated/hla/LoggingPlaceholder.java
@@ -58,7 +58,7 @@ public final class LoggingPlaceholder {
    * @see #reportError(Exception, String)
    */
   public static void reportError(Exception exc) {
-    reportError(exc, "Unexpected Error");
+    reportError(exc, "Unexpected error");
   }
 
   /**

--- a/src/main/java/org/pankratzlab/unet/deprecated/hla/SourceType.java
+++ b/src/main/java/org/pankratzlab/unet/deprecated/hla/SourceType.java
@@ -7,7 +7,17 @@ import org.pankratzlab.unet.parser.PdfDonorParser;
 import org.pankratzlab.unet.parser.XmlDonorParser;
 
 public enum SourceType {
-  Score6, SureTyper, DonorNet;
+  Score6("SCORE 6"), SureTyper("SureTyper"), DonorNet("DonorNet");
+
+  private final String displayName;
+
+  SourceType(String displayName) {
+    this.displayName = displayName;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
 
   public static SourceType parseType(File file) {
     if (file.getName().toLowerCase().endsWith(".html")) {

--- a/src/main/java/org/pankratzlab/unet/hapstats/CommonWellDocumented.java
+++ b/src/main/java/org/pankratzlab/unet/hapstats/CommonWellDocumented.java
@@ -143,7 +143,7 @@ public final class CommonWellDocumented {
     SOURCE def = loadPropertyCWDSource();
 
     ChoiceDialog<SOURCE> cd = new ChoiceDialog<>(def, SOURCE.values());
-    cd.setTitle("Select CWD/CIWD Database");
+    cd.setTitle("Select CWD/CIWD database");
     cd.setHeaderText("Select a Database from which to load CWD/CIWD data.");
     cd.setContentText("You may change this selection from the DonorCheck menu bar.");
     Optional<SOURCE> result = cd.showAndWait();

--- a/src/main/java/org/pankratzlab/unet/hapstats/CommonWellDocumented.java
+++ b/src/main/java/org/pankratzlab/unet/hapstats/CommonWellDocumented.java
@@ -83,28 +83,34 @@ public final class CommonWellDocumented {
   }
 
   public static enum SOURCE {
-    CWD_200("CWD 2.0.0") {
+    CWD_200("CWD", "2.0.0") {
       @Override
       public void load() {
         loadCWD200();
       }
     },
-    CIWD_300("CIWD 3.0.0") {
+    CIWD_300("CIWD", "3.0.0") {
       @Override
       public void load() {
         loadCIWD300();
       }
     };
 
-    SOURCE(String d) {
-      displayName = d;
+    SOURCE(String d, String v) {
+      displayName = d + " " + v;
+      versionString = v;
     }
 
     private final String displayName;
+    private final String versionString;
 
     @Override
     public String toString() {
       return displayName;
+    }
+
+    public String getVersion() {
+      return versionString;
     }
 
     public abstract void load();

--- a/src/main/java/org/pankratzlab/unet/jfx/BatchTestMgmtController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/BatchTestMgmtController.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Random;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -40,7 +39,6 @@ import com.google.common.collect.Table;
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.ReadOnlyStringProperty;
-import javafx.beans.property.SimpleSetProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -166,7 +164,7 @@ public class BatchTestMgmtController {
     testTable.setEditable(true);
 
     testIDColumn.setCellValueFactory(p -> {
-      return /* p.getValue().id */ new SimpleStringProperty("******");
+      return p.getValue().id;
     });
 
     testIDColumn.setOnEditCommit(ev -> {
@@ -308,10 +306,6 @@ public class BatchTestMgmtController {
     });
 
     testFileTypesColumn.setCellValueFactory(p -> {
-      if ((new Random()).nextInt(100) < 10) {
-        return new SimpleSetProperty<>(
-            FXCollections.observableSet(SourceType.DonorNet, SourceType.SureTyper));
-      }
       return p.getValue().sourceTypes;
     });
 

--- a/src/main/java/org/pankratzlab/unet/jfx/BatchTestMgmtController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/BatchTestMgmtController.java
@@ -403,7 +403,7 @@ public class BatchTestMgmtController {
     Alert alert =
         new Alert(AlertType.CONFIRMATION, "Are you sure you'd like to remove " + toRemove.size()
             + " test" + (toRemove.size() > 1 ? "s" : "") + "?", ButtonType.OK, ButtonType.CANCEL);
-    alert.setTitle("Remove Tests");
+    alert.setTitle("Remove tests");
     alert.setHeaderText("");
     Optional<ButtonType> selVal = alert.showAndWait();
 
@@ -419,7 +419,7 @@ public class BatchTestMgmtController {
         Alert alert1 = new Alert(AlertType.INFORMATION,
             "Successfully removed " + toRemove.size() + " test" + (toRemove.size() > 1 ? "s" : ""),
             ButtonType.CLOSE);
-        alert1.setTitle("Successfully Removed Tests");
+        alert1.setTitle("Successfully removed tests");
         alert1.setHeaderText("");
         alert1.showAndWait();
       } else {
@@ -428,7 +428,7 @@ public class BatchTestMgmtController {
                 + "\n\nSuccessfully removed " + removed.size() + " test"
                 + (removed.size() > 1 ? "s" : ""),
             ButtonType.CLOSE);
-        alert1.setTitle("Failed to Remove Tests");
+        alert1.setTitle("Failed to remove tests");
         alert1.setHeaderText("");
         alert1.showAndWait();
       }
@@ -471,7 +471,7 @@ public class BatchTestMgmtController {
         } else if (!Strings.isNullOrEmpty(HaplotypeFrequencies.getMissingTableMessage())) {
           Alert alert =
               new Alert(AlertType.INFORMATION, HaplotypeFrequencies.getMissingTableMessage());
-          alert.setTitle("Missing Haplotype Table(s)");
+          alert.setTitle("Missing haplotype frequency table(s)");
           alert.setHeaderText("");
           alert.showAndWait();
         }

--- a/src/main/java/org/pankratzlab/unet/jfx/DownloadNMDPController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/DownloadNMDPController.java
@@ -27,14 +27,11 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.ResourceBundle;
-
 import org.pankratzlab.unet.deprecated.hla.CurrentDirectoryProvider;
 import org.pankratzlab.unet.deprecated.hla.HLAProperties;
 import org.pankratzlab.unet.deprecated.jfx.JFXUtilHelper;
 import org.pankratzlab.unet.hapstats.HaplotypeFrequencies;
-
 import com.google.common.base.Strings;
-
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.event.ActionEvent;
@@ -108,7 +105,7 @@ public class DownloadNMDPController {
 
   void selectFile(ActionEvent event, String tableTitle, StringProperty localProp) {
     FileChooser fc = CurrentDirectoryProvider.getFileChooser();
-    fc.setTitle("Select " + tableTitle + " Frequency Table");
+    fc.setTitle("Select " + tableTitle + " frequency table");
     fc.getExtensionFilters().setAll(new ExtensionFilter("Excel", "*.xls"));
     File tableFile = fc.showOpenDialog(rootPane.getScene().getWindow());
     if (Objects.nonNull(tableFile) && tableFile.exists()) {

--- a/src/main/java/org/pankratzlab/unet/jfx/LandingController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/LandingController.java
@@ -172,7 +172,7 @@ public class LandingController {
           textArea.setEditable(false);
           textArea.setWrapText(true);
 
-          alert1.setTitle("Error Loading Tests");
+          alert1.setTitle("Error loading tests");
           alert1.setHeaderText("Failed to Load " + testLoad.invalidTests.size() + " Tests");
           alert1.getDialogPane().setContent(textArea);
           alert1.setResizable(true);
@@ -181,7 +181,7 @@ public class LandingController {
 
         Table<SOURCE, String, List<ValidationTestFileSet>> testData = testLoad.testSets;
 
-        ValidationTestMgmtController controller = new ValidationTestMgmtController();
+        BatchTestMgmtController controller = new BatchTestMgmtController();
 
         FXMLLoader loader = new FXMLLoader(LandingController.class.getResource(TESTING_MGMT));
         loader.setController(controller);
@@ -192,7 +192,8 @@ public class LandingController {
           Stage inputStage = new Stage();
           inputStage.initOwner(rootPane.getScene().getWindow());
           inputStage.initModality(Modality.APPLICATION_MODAL);
-          inputStage.setTitle("Manage Testing Files");
+          inputStage
+              .setTitle("DonorCheck " + (version.isEmpty() ? "" : version) + ": batch validation");
           inputStage.setResizable(true);
           inputStage.setScene(newScene);
           controller.setTable(testData);
@@ -269,7 +270,7 @@ public class LandingController {
 
       Alert alert = new Alert(AlertType.NONE, "", ButtonType.OK);
       alert.getDialogPane().setContent(loader.load(is));
-      alert.setTitle("Select Donor Score6 analysis file");
+      alert.setTitle("Select donor SCORE 6 analysis file");
       alert.setHeaderText("");
       alert.showAndWait();
     } catch (IOException e) {
@@ -318,7 +319,7 @@ public class LandingController {
         } else if (!Strings.isNullOrEmpty(HaplotypeFrequencies.getMissingTableMessage())) {
           Alert alert =
               new Alert(AlertType.INFORMATION, HaplotypeFrequencies.getMissingTableMessage());
-          alert.setTitle("Missing Haplotype Table(s)");
+          alert.setTitle("Missing haplotype table(s)");
           alert.setHeaderText("");
           alert.showAndWait();
         }

--- a/src/main/java/org/pankratzlab/unet/jfx/LandingController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/LandingController.java
@@ -389,9 +389,8 @@ public class LandingController {
     assert rootPane != null : "fx:id=\"rootPane\" was not injected: check your FXML file 'TypeValidationLanding.fxml'.";
 
     version = Info.getVersion();
-    String value = "Version: " + version + " ";
-    versionLabel.setText(value);
-    menuVersionLabel.setText("DonorCheck " + value);
+    versionLabel.setText("Version: " + version + " ");
+    menuVersionLabel.setText("DonorCheck version: " + version + " ");
 
     System.setProperty(CurrentDirectoryProvider.BASE_DIR_PROP_NAME, UNET_BASE_DIR_PROP);
   }

--- a/src/main/java/org/pankratzlab/unet/jfx/SerotypeLookupFileController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/SerotypeLookupFileController.java
@@ -65,7 +65,7 @@ public class SerotypeLookupFileController {
         copyLink.setVisited(true);
       });
       JFXUtilHelper.makeContentOnlyAlert(AlertType.INFORMATION,
-          "Please visit this URL to download the HLA Serotype Lookup file", copyLink, ButtonType.OK)
+          "Please visit this URL to download the HLA serotype lookup file", copyLink, ButtonType.OK)
           .showAndWait();
     }
   }
@@ -73,7 +73,7 @@ public class SerotypeLookupFileController {
   @FXML
   void selectFile(ActionEvent event) {
     FileChooser fc = CurrentDirectoryProvider.getFileChooser();
-    fc.setTitle("Select HLA Serotype Lookup file");
+    fc.setTitle("Select HLA serotype lookup file");
     fc.getExtensionFilters().setAll(new ExtensionFilter("Text", "*.txt"));
     File relSerFile = fc.showOpenDialog(rootPane.getScene().getWindow());
     if (Objects.nonNull(relSerFile) && relSerFile.exists()) {

--- a/src/main/java/org/pankratzlab/unet/jfx/TutorialHelper.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/TutorialHelper.java
@@ -39,11 +39,11 @@ public final class TutorialHelper {
   }
 
   public static void tutorialHTMLDownload(ActionEvent event) {
-    showTutorial(HTML_TUTORIAL, new DownloadTutorialController(), "Donor Download Instructions");
+    showTutorial(HTML_TUTORIAL, new DownloadTutorialController(), "Donor download instructions");
   }
 
   public static void tutorialXMLDownload(ActionEvent event) {
-    showTutorial(XML_TUTORIAL, new DownloadTutorialController(), "Donor Download Instructions");
+    showTutorial(XML_TUTORIAL, new DownloadTutorialController(), "Donor download instructions");
   }
 
   /** TODO */

--- a/src/main/java/org/pankratzlab/unet/jfx/ValidationTestMgmtController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/ValidationTestMgmtController.java
@@ -35,6 +35,8 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Table;
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
+import javafx.beans.property.ReadOnlyStringProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -85,6 +87,9 @@ public class ValidationTestMgmtController {
 
   @FXML
   TableColumn<ValidationTestFileSet, ObservableSet<SourceType>> testFileTypesColumn;
+
+  @FXML
+  TableColumn<ValidationTestFileSet, Boolean> hasRemappingsColumn;
 
   @FXML
   TableColumn<ValidationTestFileSet, CommonWellDocumented.SOURCE> ciwdVersionColumn;
@@ -266,6 +271,35 @@ public class ValidationTestMgmtController {
                 } else {
                   setText(value.stream().sorted().map(SourceType::name)
                       .collect(Collectors.joining(", ")));
+                }
+              }
+            };
+          }
+        });
+
+    hasRemappingsColumn.setCellValueFactory(
+        new Callback<CellDataFeatures<ValidationTestFileSet, Boolean>, ObservableValue<Boolean>>() {
+          public ObservableValue<Boolean> call(CellDataFeatures<ValidationTestFileSet, Boolean> p) {
+            ReadOnlyStringProperty valueSafe = p.getValue().remapFile;
+            return new SimpleObjectProperty<>(valueSafe != null && valueSafe.get() != null
+                && !valueSafe.get().isBlank() && new File(valueSafe.get()).exists());
+          }
+        });
+
+    hasRemappingsColumn.setCellFactory(
+        new Callback<TableColumn<ValidationTestFileSet, Boolean>, TableCell<ValidationTestFileSet, Boolean>>() {
+
+          @Override
+          public TableCell<ValidationTestFileSet, Boolean> call(
+              TableColumn<ValidationTestFileSet, Boolean> param) {
+            return new TableCell<ValidationTestFileSet, Boolean>() {
+              @Override
+              protected void updateItem(Boolean value, boolean empty) {
+                super.updateItem(value, empty);
+                if (value == null) {
+                  setText(null);
+                } else {
+                  setText(value ? "Yes" : "");
                 }
               }
             };

--- a/src/main/java/org/pankratzlab/unet/jfx/wizard/FileInputController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/wizard/FileInputController.java
@@ -147,7 +147,7 @@ public class FileInputController extends AbstractValidatingWizardController {
 
     hbox.getChildren().add(fileDisplay);
 
-    Button chooseFileButton = new Button("Choose File");
+    Button chooseFileButton = new Button("Choose file");
     chooseFileButton.setFont(Font.font(16.0));
     chooseFileButton.setOnAction(e -> selectDonorFile(e,
         comboBox.getSelectionModel().getSelectedItem(), setter, linkedFile));

--- a/src/main/java/org/pankratzlab/unet/jfx/wizard/ValidationResultsController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/wizard/ValidationResultsController.java
@@ -162,7 +162,7 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
   /** Write the given {@link ValidationTable#getValidationImage()} to disk */
   @FXML
   void savePNGResults(ActionEvent event) {
-    Optional<File> destination = DonorNetUtils.getFile(rootPane, "Save Validation Results",
+    Optional<File> destination = DonorNetUtils.getFile(rootPane, "Save validation results",
         getTable().getId() + "_donor_valid", "PNG", ".png", false);
 
     if (destination.isPresent()) {
@@ -184,7 +184,7 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
   @FXML
   private void saveCSVResults(ActionEvent event) {
     ValidationTable vt = getTable();
-    Optional<File> destination = DonorNetUtils.getFile(rootPane, "Save Validation Results",
+    Optional<File> destination = DonorNetUtils.getFile(rootPane, "Save validation results",
         vt.getId() + "_results_csv", "CSV", ".csv", false);
 
     if (destination.isPresent()) {
@@ -209,7 +209,7 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
         new ChoiceDialog<>(Printer.getDefaultPrinter(), Printer.getAllPrinters());
     dialog.setHeaderText("Select a printer");
     dialog.setContentText("Choose a printer from available printers");
-    dialog.setTitle("Printer Choice");
+    dialog.setTitle("Printer choice");
     Optional<Printer> opt = dialog.showAndWait();
     if (opt.isPresent()) {
       Printer printer = opt.get();
@@ -239,7 +239,7 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
       Alert alert1 = new Alert(AlertType.INFORMATION,
           "Successfully added " + getTable().getId() + " to validation testing set.",
           ButtonType.CLOSE);
-      alert1.setTitle("Successfully Added.");
+      alert1.setTitle("Successfully added.");
       alert1.setHeaderText("");
       alert1.showAndWait();
     }

--- a/src/main/java/org/pankratzlab/unet/model/ValidationRow.java
+++ b/src/main/java/org/pankratzlab/unet/model/ValidationRow.java
@@ -50,7 +50,7 @@ public abstract class ValidationRow<T> {
   public static final String FIRST_COL_PROP = "firstCol";
   public static final String ID_PROP = "id";
 
-  private final ReadOnlyStringWrapper rowLabelWRapper;
+  private final ReadOnlyStringWrapper rowLabelWrapper;
   private final ReadOnlyObjectWrapper<T> firstColWrapper;
   private final ReadOnlyObjectWrapper<T> secondColWrapper;
   private final ReadOnlyStringWrapper firstColStringWrapper;
@@ -61,7 +61,7 @@ public abstract class ValidationRow<T> {
 
   public ValidationRow(String rowLabel, T firstCol, T secondCol, boolean wasRemappedFirst,
       boolean wasRemappedSecond) {
-    this.rowLabelWRapper = new ReadOnlyStringWrapper(rowLabel);
+    this.rowLabelWrapper = new ReadOnlyStringWrapper(rowLabel);
     firstColWrapper = new ReadOnlyObjectWrapper<>(firstCol);
     secondColWrapper = new ReadOnlyObjectWrapper<>(secondCol);
     firstColStringWrapper = new ReadOnlyStringWrapper();
@@ -87,7 +87,7 @@ public abstract class ValidationRow<T> {
 
   /** @return {@link StringProperty} for the identifying name of this row */
   public ReadOnlyStringProperty idProperty() {
-    return rowLabelWRapper.getReadOnlyProperty();
+    return rowLabelWrapper.getReadOnlyProperty();
   }
 
   /** @return {@link StringProperty} for the XML value of this row */

--- a/src/main/java/org/pankratzlab/unet/model/remap/GUIRemapProcessor.java
+++ b/src/main/java/org/pankratzlab/unet/model/remap/GUIRemapProcessor.java
@@ -106,7 +106,7 @@ public class GUIRemapProcessor implements RemapProcessor {
     HBox assignedPane = new HBox(10);
     assignedPane.setMaxWidth(Double.MAX_VALUE);
     assignedPane.setAlignment(Pos.CENTER_LEFT);
-    Label assignedHeader = new Label("Assigned allele pair: ");
+    Label assignedHeader = new Label("First allele pair: ");
     TextFlow assignedTextFlow = new TextFlow();
     CIWDAlleleStringPresentationUtils.addTextNodes(assignedTextFlow, hlaType1_First.toString(),
         true);
@@ -123,7 +123,7 @@ public class GUIRemapProcessor implements RemapProcessor {
     HBox ciwdPane = new HBox(10);
     ciwdPane.setMaxWidth(Double.MAX_VALUE);
     ciwdPane.setAlignment(Pos.CENTER_LEFT);
-    Label ciwdHeader = new Label("Common / Well-Documented allele pair: ");
+    Label ciwdHeader = new Label("First Common / Well-Documented allele pair: ");
     TextFlow ciwdTextFlow = new TextFlow();
     CIWDAlleleStringPresentationUtils.addTextNodes(ciwdTextFlow, hlaType1_CIWD.toString(), true);
     ciwdTextFlow.getChildren().add(new Text(" | "));

--- a/src/main/java/org/pankratzlab/unet/model/remap/GUIRemapProcessor.java
+++ b/src/main/java/org/pankratzlab/unet/model/remap/GUIRemapProcessor.java
@@ -166,7 +166,7 @@ public class GUIRemapProcessor implements RemapProcessor {
     StyleableContingentChoiceDialog<Supplier<TextFlow>> cd = new StyleableContingentChoiceDialog<>(
         null, allChoices, Lists.newArrayList(), choices.getAllSecondChoices(), choices.dataMap,
         filterName, filter/* , textEntryMatcher */, opt1, opt2, manualChoice);
-    cd.setTitle("Select HLA-" + locus.name() + " Alleles");
+    cd.setTitle("Select HLA-" + locus.name() + " alleles");
 
     cd.setHeaderText(
         "Assigned allele pair for HLA-" + locus.name() + " locus is not Common / Well-Documented.");

--- a/src/main/java/org/pankratzlab/unet/parser/HtmlDonorParser.java
+++ b/src/main/java/org/pankratzlab/unet/parser/HtmlDonorParser.java
@@ -46,7 +46,7 @@ public class HtmlDonorParser extends AbstractDonorFileParser {
   private static final String HTML_SUFFIX = "_label";
   private static final String HTML_PREFIX = "ddl";
   private static final String DISPLAY_STRING = "HTML";
-  private static final String FILE_CHOOSER_HEADER = "Select Donor Typing HTML";
+  private static final String FILE_CHOOSER_HEADER = "Select donor typing HTML";
   private static final String INITIAL_NAME = "DonorEdit";
   private static final String EXTENSION_DESC = "DonorNet";
   private static final String EXTENSION_NAME = "html";

--- a/src/main/java/org/pankratzlab/unet/parser/PdfDonorParser.java
+++ b/src/main/java/org/pankratzlab/unet/parser/PdfDonorParser.java
@@ -33,7 +33,7 @@ import org.pankratzlab.unet.parser.util.PdfSureTyperParser;
 /** {@link DonorFileParser} entry point for PDF files. */
 public class PdfDonorParser extends AbstractDonorFileParser {
   private static final String DISPLAY_STRING = "PDF";
-  private static final String FILE_CHOOSER_HEADER = "Select Donor Typing PDF";
+  private static final String FILE_CHOOSER_HEADER = "Select donor typing PDF";
   private static final String INITIAL_NAME = "";
   private static final String EXTENSION_DESC = "LinkSeq";
   private static final String EXTENSION_NAME = "pdf";

--- a/src/main/java/org/pankratzlab/unet/parser/XmlDonorParser.java
+++ b/src/main/java/org/pankratzlab/unet/parser/XmlDonorParser.java
@@ -40,9 +40,9 @@ public class XmlDonorParser extends AbstractDonorFileParser {
 
   private static final String DISPLAY_STRING = "XML";
 
-  private static final String FILE_CHOOSER_HEADER = "Select Donor Typing XML";
+  private static final String FILE_CHOOSER_HEADER = "Select donor typing XML";
   private static final String INITIAL_NAME = "";
-  private static final String EXTENSION_DESC = "DonorNet, SCORE6, LinkSeq";
+  private static final String EXTENSION_DESC = "DonorNet, SCORE 6, SureTyper";
   private static final String EXTENSION_NAME = "xml";
   private static final String EXTENSION = "*." + EXTENSION_NAME;
 

--- a/src/main/java/org/pankratzlab/unet/validation/AlertHelper.java
+++ b/src/main/java/org/pankratzlab/unet/validation/AlertHelper.java
@@ -11,7 +11,7 @@ public final class AlertHelper {
       Throwable cause) {
     Alert alert1 = new Alert(AlertType.ERROR, "Error - unable to update test properties for test "
         + rowValue.id.get() + ". An exception occurred:\n" + cause.getMessage(), ButtonType.CLOSE);
-    alert1.setTitle("Failed to Update Test");
+    alert1.setTitle("Failed to update test");
     alert1.setHeaderText("");
     alert1.showAndWait();
   }
@@ -21,7 +21,7 @@ public final class AlertHelper {
         "Error - unable to rename test from " + id + " to " + newId
             + ". An exception occurred when moving the directory:\n" + cause.getMessage(),
         ButtonType.CLOSE);
-    alert1.setTitle("Failed to Rename Test");
+    alert1.setTitle("Failed to rename test");
     alert1.setHeaderText("");
     alert1.showAndWait();
   }
@@ -33,7 +33,7 @@ public final class AlertHelper {
             + "1) The given input files do not contain Personally Identifiable Information (PII), or\n\n"
             + "2) If the input files do contain PII, that this location is safe to store PII.",
         ButtonType.OK, ButtonType.CANCEL);
-    alert.setTitle("PII Warning");
+    alert.setTitle("PII warning");
     alert.setHeaderText("");
     Optional<ButtonType> selVal = alert.showAndWait();
     return selVal;
@@ -45,7 +45,7 @@ public final class AlertHelper {
         + file1.label
         + ") already exists.\n\nIf this is an error, please remove the test in the DonorCheck Testing Management tool.\n\nOr remove the test manually by deleting this directory:\n\n"
         + subdir, ButtonType.CLOSE);
-    alert1.setTitle("Failed to Add Test");
+    alert1.setTitle("Failed to add test");
     alert1.setHeaderText("");
     alert1.showAndWait();
   }
@@ -56,7 +56,7 @@ public final class AlertHelper {
         "Error - could not copy serotype lookup file to validation testing directory.\n\nFile: "
             + relFile,
         ButtonType.CLOSE);
-    alert1.setTitle("Failed to Add Test");
+    alert1.setTitle("Failed to add test");
     alert1.setHeaderText("");
     alert1.showAndWait();
   }
@@ -67,7 +67,7 @@ public final class AlertHelper {
         "Error - could not write locus remappings file to validation testing directory.\n\nFile: "
             + remapFile,
         ButtonType.CLOSE);
-    alert1.setTitle("Failed to Add Test");
+    alert1.setTitle("Failed to add test");
     alert1.setHeaderText("");
     alert1.showAndWait();
   }
@@ -78,7 +78,7 @@ public final class AlertHelper {
         "Error - could not write test properties file to validation testing directory.\n\nFile: "
             + propsFile,
         ButtonType.CLOSE);
-    alert1.setTitle("Failed to Add Test");
+    alert1.setTitle("Failed to add test");
     alert1.setHeaderText("");
     alert1.showAndWait();
   }
@@ -88,7 +88,7 @@ public final class AlertHelper {
         "Error - could not copy input file to validation testing directory.\n\nFile: " + file.file
             + "\n\nDirectory: " + subdir,
         ButtonType.CLOSE);
-    alert1.setTitle("Failed to Add Test");
+    alert1.setTitle("Failed to add test");
     alert1.setHeaderText("");
     alert1.showAndWait();
   }

--- a/src/main/java/org/pankratzlab/unet/validation/TEST_EXPECTATION.java
+++ b/src/main/java/org/pankratzlab/unet/validation/TEST_EXPECTATION.java
@@ -1,5 +1,5 @@
 package org.pankratzlab.unet.validation;
 
 public enum TEST_EXPECTATION {
-  PASS, FAIL, ERROR;
+  Pass, Fail, Error;
 }

--- a/src/main/java/org/pankratzlab/unet/validation/TEST_EXPECTATION.java
+++ b/src/main/java/org/pankratzlab/unet/validation/TEST_EXPECTATION.java
@@ -1,0 +1,5 @@
+package org.pankratzlab.unet.validation;
+
+public enum TEST_EXPECTATION {
+  PASS, FAIL, ERROR;
+}

--- a/src/main/java/org/pankratzlab/unet/validation/TestRun.java
+++ b/src/main/java/org/pankratzlab/unet/validation/TestRun.java
@@ -1,16 +1,20 @@
 package org.pankratzlab.unet.validation;
 
 import java.util.Date;
+import java.util.Optional;
 
 public class TestRun {
   public final ValidationTestFileSet testFileSet;
   public final TEST_RESULT result;
   public final Date runTime;
+  public final Optional<Exception> error;
 
-  public TestRun(ValidationTestFileSet testFileSet, TEST_RESULT result, Date runTime) {
+  public TestRun(ValidationTestFileSet testFileSet, TEST_RESULT result, Date runTime,
+      Optional<Exception> error) {
     this.testFileSet = testFileSet;
     this.result = result;
     this.runTime = runTime;
+    this.error = error;
   }
 
 }

--- a/src/main/java/org/pankratzlab/unet/validation/ValidationTestFileSet.java
+++ b/src/main/java/org/pankratzlab/unet/validation/ValidationTestFileSet.java
@@ -27,6 +27,8 @@ public class ValidationTestFileSet {
 
   public final StringProperty comment;
 
+  public final ObjectProperty<TEST_EXPECTATION> expectedResult;
+
   public final ReadOnlyListProperty<String> filePaths;
 
   public final ReadOnlySetProperty<SourceType> sourceTypes;
@@ -42,20 +44,18 @@ public class ValidationTestFileSet {
 
   public final ObjectProperty<Date> lastRunDate;
 
-  public final ObjectProperty<Boolean> lastPassingState;
-
   public final ObjectProperty<TEST_RESULT> lastTestResult;
 
   public static class ValidationTestFileSetBuilder {
     private String id;
     private String comment;
+    private TEST_EXPECTATION expectedResult;
     private List<String> filePaths;
     private String remapFile;
     private CommonWellDocumented.SOURCE cwdSource;
     private String relDnaSerFile;
     private String donorCheckVersion;
     private Date lastRunDate;
-    private Boolean lastPassingState;
     private TEST_RESULT lastPassingResult;
 
     public ValidationTestFileSetBuilder id(String id) {
@@ -65,6 +65,11 @@ public class ValidationTestFileSet {
 
     public ValidationTestFileSetBuilder comment(String comment) {
       this.comment = comment;
+      return this;
+    }
+
+    public ValidationTestFileSetBuilder expectedResult(TEST_EXPECTATION expectedResult) {
+      this.expectedResult = expectedResult;
       return this;
     }
 
@@ -98,19 +103,14 @@ public class ValidationTestFileSet {
       return this;
     }
 
-    public ValidationTestFileSetBuilder lastPassingState(Boolean lastPassingState) {
-      this.lastPassingState = lastPassingState;
-      return this;
-    }
-
     public ValidationTestFileSetBuilder lastPassingResult(TEST_RESULT lastPassingResult) {
       this.lastPassingResult = lastPassingResult;
       return this;
     }
 
     public ValidationTestFileSet build() {
-      return new ValidationTestFileSet(id, comment, filePaths, remapFile, cwdSource, relDnaSerFile,
-          donorCheckVersion, lastRunDate, lastPassingState, lastPassingResult);
+      return new ValidationTestFileSet(id, comment, expectedResult, filePaths, remapFile, cwdSource,
+          relDnaSerFile, donorCheckVersion, lastRunDate, lastPassingResult);
     }
 
   }
@@ -119,11 +119,13 @@ public class ValidationTestFileSet {
     return new ValidationTestFileSetBuilder();
   }
 
-  private ValidationTestFileSet(String id, String comment, List<String> filePaths, String remapFile,
-      CommonWellDocumented.SOURCE cwdSource, String relDnaSerFile, String donorCheckVersion,
-      Date lastRunDate, Boolean lastPassingState, TEST_RESULT lastTestResult) {
+  private ValidationTestFileSet(String id, String comment, TEST_EXPECTATION expectedResult,
+      List<String> filePaths, String remapFile, CommonWellDocumented.SOURCE cwdSource,
+      String relDnaSerFile, String donorCheckVersion, Date lastRunDate,
+      TEST_RESULT lastTestResult) {
     this.id = new SimpleStringProperty(id);
     this.comment = new SimpleStringProperty(comment);
+    this.expectedResult = new SimpleObjectProperty<>(expectedResult);
     this.filePaths = new ReadOnlyListWrapper<>(FXCollections.observableList(filePaths));
     final ObservableSet<SourceType> observableSet =
         FXCollections.observableSet(filePaths.stream().map(s -> {
@@ -140,7 +142,6 @@ public class ValidationTestFileSet {
     this.relDnaSerFile = new ReadOnlyStringWrapper(relDnaSerFile);
     this.donorCheckVersion = new SimpleStringProperty(donorCheckVersion);
     this.lastRunDate = new SimpleObjectProperty<>(lastRunDate);
-    this.lastPassingState = new SimpleObjectProperty<>(lastPassingState);
     this.lastTestResult = new SimpleObjectProperty<>(lastTestResult);
   }
 

--- a/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
+++ b/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
@@ -353,7 +353,7 @@ public class ValidationTesting {
         Objects.toString(props.setProperty(DC_VER_PROP, test.donorCheckVersion.getValueSafe()), "");
 
     String prevExpectStr =
-        Objects.toString(props.setProperty(EXPECTED_PROP, test.expectedResult.getName()));
+        Objects.toString(props.setProperty(EXPECTED_PROP, test.expectedResult.get().name()));
 
     TEST_EXPECTATION prevExpect = TEST_EXPECTATION.PASS;
     if (prevExpectStr != null && !prevExpectStr.isEmpty()) {

--- a/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
+++ b/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
@@ -278,7 +278,7 @@ public class ValidationTesting {
         }
       }
       Alert alert1 = new Alert(AlertType.INFORMATION, contentText, ButtonType.CLOSE);
-      alert1.setTitle("Test Results");
+      alert1.setTitle("Test results");
       alert1.setHeaderText("");
       alert1.showAndWait();
     };

--- a/src/main/java/org/pankratzlab/unet/validation/XMLRemapProcessor.java
+++ b/src/main/java/org/pankratzlab/unet/validation/XMLRemapProcessor.java
@@ -2,6 +2,7 @@ package org.pankratzlab.unet.validation;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.util.Collections;
 import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jsoup.Jsoup;
@@ -77,6 +78,10 @@ public class XMLRemapProcessor implements RemapProcessor {
     } catch (Throwable e) {
       throw new IllegalStateException("Invalid XML file: " + file, e);
     }
+  }
+
+  public Set<HLALocus> getAllRemappedLoci() {
+    return Collections.unmodifiableSet(remappings.columnKeySet());
   }
 
   @Override

--- a/src/main/resources/TypeValidationLanding.fxml
+++ b/src/main/resources/TypeValidationLanding.fxml
@@ -63,7 +63,7 @@
                         </TextFlow>
                         <TextFlow style="-fx-background-color: lightgray; -fx-border-color: black; -fx-border-width: 0 0 1 0;" textAlignment="CENTER" GridPane.columnIndex="1">
                            <children>
-                              <Text strokeType="OUTSIDE" strokeWidth="0.0" text="File Type(s)">
+                              <Text strokeType="OUTSIDE" strokeWidth="0.0" text="File type(s)">
                                  <font>
                                     <Font size="24.0" />
                                  </font>
@@ -152,7 +152,7 @@
    <bottom>
       <ButtonBar buttonOrder="L_HEU+FBIX_NCYOA_R" BorderPane.alignment="CENTER_RIGHT">
         <buttons>
-          <Button defaultButton="true" mnemonicParsing="false" onAction="#runValidation" prefHeight="80.0" style="-fx-background-color: #FFCC00;" text="Start Validation">
+          <Button defaultButton="true" mnemonicParsing="false" onAction="#runValidation" prefHeight="80.0" style="-fx-background-color: #FFCC00;" text="Start validation">
                <font>
                   <Font size="24.0" />
                </font>
@@ -175,32 +175,32 @@
                 </Menu>
                   <Menu mnemonicParsing="false" text="Haplotypes">
                     <items>
-                      <MenuItem mnemonicParsing="false" onAction="#chooseFreqTables" text="Set Allele Frequency Tables..." />
+                      <MenuItem mnemonicParsing="false" onAction="#chooseFreqTables" text="Set allele frequency tables..." />
                     </items>
                   </Menu>
                   <Menu mnemonicParsing="false" text="Serotypes">
                     <items>
-                      <MenuItem mnemonicParsing="false" onAction="#chooseRelSerLookupFile" text="Set Serotype Lookup File..." />
+                      <MenuItem mnemonicParsing="false" onAction="#chooseRelSerLookupFile" text="Set serotype lookup file..." />
                     </items>
                   </Menu>
                   <Menu mnemonicParsing="false" text="CIWD">
                     <items>
-                      <MenuItem mnemonicParsing="false" onAction="#chooseCIWDSource" text="Set Common / Well-Documented Allele Source..." />
+                      <MenuItem mnemonicParsing="false" onAction="#chooseCIWDSource" text="Set Common / Well-Documented allele source..." />
                     </items>
                   </Menu>
                   <Menu mnemonicParsing="false" text="Tutorials">
                     <items>
-                      <MenuItem mnemonicParsing="false" onAction="#tutorialXMLDownload" text="XML DonorNet Download" />
-                        <MenuItem mnemonicParsing="false" onAction="#tutorialHTMLDownload" text="HTML DonorNet Download" />
+                      <MenuItem mnemonicParsing="false" onAction="#tutorialXMLDownload" text="XML DonorNet download" />
+                        <MenuItem mnemonicParsing="false" onAction="#tutorialHTMLDownload" text="HTML DonorNet download" />
                     </items>
                   </Menu>
-                  <Menu mnemonicParsing="false" text="Batch Validation">
+                  <Menu mnemonicParsing="false" text="Batch validation">
                     <items>
-                      <MenuItem mnemonicParsing="false" onAction="#manageTestingFiles" text="Manage Test Files" />
-                      <MenuItem mnemonicParsing="false" onAction="#runTesting" text="Quick-Run Tests" />
+                      <MenuItem mnemonicParsing="false" onAction="#manageTestingFiles" text="Manage test files" />
+                      <MenuItem mnemonicParsing="false" onAction="#runTesting" text="Quick-run tests" />
                     </items>
                   </Menu>
-                  <Menu mnemonicParsing="false" text="MAC Conversion">
+                  <Menu mnemonicParsing="false" text="MAC conversion">
                      <items>
                         <MenuItem mnemonicParsing="false" onAction="#macConversionScore6" text="SCORE 6" />
                      </items>
@@ -212,7 +212,7 @@
 						        <Label fx:id="menuVersionLabel" text="Version: "   />
 						    </content>
 						</CustomMenuItem>
-                        <MenuItem mnemonicParsing="false" onAction="#openWebsiteCompPath" text="Open UMN Computational Pathology Website" />
+                        <MenuItem mnemonicParsing="false" onAction="#openWebsiteCompPath" text="Open UMN Computational Pathology website" />
                         <MenuItem mnemonicParsing="false" onAction="#openWebsiteGitHub" text="Open DonorCheck GitHub" />
                      </items>
                   </Menu>

--- a/src/main/resources/TypeValidationLanding.fxml
+++ b/src/main/resources/TypeValidationLanding.fxml
@@ -175,7 +175,7 @@
                 </Menu>
                   <Menu mnemonicParsing="false" text="Haplotypes">
                     <items>
-                      <MenuItem mnemonicParsing="false" onAction="#chooseFreqTables" text="Set Frequency Tables..." />
+                      <MenuItem mnemonicParsing="false" onAction="#chooseFreqTables" text="Set Allele Frequency Tables..." />
                     </items>
                   </Menu>
                   <Menu mnemonicParsing="false" text="Serotypes">
@@ -194,7 +194,7 @@
                         <MenuItem mnemonicParsing="false" onAction="#tutorialHTMLDownload" text="HTML DonorNet Download" />
                     </items>
                   </Menu>
-                  <Menu mnemonicParsing="false" text="Testing">
+                  <Menu mnemonicParsing="false" text="Batch Validation">
                     <items>
                       <MenuItem mnemonicParsing="false" onAction="#manageTestingFiles" text="Manage Test Files" />
                       <MenuItem mnemonicParsing="false" onAction="#runTesting" text="Quick-Run Tests" />
@@ -202,7 +202,7 @@
                   </Menu>
                   <Menu mnemonicParsing="false" text="MAC Conversion">
                      <items>
-                        <MenuItem mnemonicParsing="false" onAction="#macConversionScore6" text="Score6" />
+                        <MenuItem mnemonicParsing="false" onAction="#macConversionScore6" text="SCORE 6" />
                      </items>
                   </Menu>
                   <Menu mnemonicParsing="false" text="About" >

--- a/src/main/resources/ValidationTestMgmt.fxml
+++ b/src/main/resources/ValidationTestMgmt.fxml
@@ -43,6 +43,7 @@
 						<TableColumn id="passingStatusColumn" fx:id="passingStatusColumn" editable="false" minWidth="30.0" prefWidth="65.0" text="Passed?" />
 						<TableColumn id="lastRunResultColumn" fx:id="lastRunResultColumn" editable="false" minWidth="30.0" prefWidth="75.0" text="Result" />
 						<TableColumn id="testFileTypesColumn" fx:id="testFileTypesColumn" editable="false" minWidth="30.0" prefWidth="140.0" text="Test File Types" />
+						<TableColumn id="hasRemappingsColumn" fx:id="hasRemappingsColumn" editable="false" minWidth="30.0" prefWidth="140.0" text="Has Remappings?" />
                   		<TableColumn id="ciwdVersionColumn" fx:id="ciwdVersionColumn" editable="false" prefWidth="100.0" text="CIWD Version" />
                   		<TableColumn id="relDnaSerVersion" fx:id="relDnaSerVersion" editable="false" prefWidth="125.0" text="Serotype Version" />
                   		<TableColumn id="donorCheckVersion" fx:id="donorCheckVersion" editable="false" prefWidth="125.0" text="DonorCheck Version" />

--- a/src/main/resources/ValidationTestMgmt.fxml
+++ b/src/main/resources/ValidationTestMgmt.fxml
@@ -28,42 +28,37 @@
 <?import javafx.scene.control.TableColumn?>
 <?import javafx.scene.control.TableView?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox prefHeight="400.0" prefWidth="915.0" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
+<VBox prefHeight="600.0" prefWidth="1200.0" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
 	<children>
 		<ScrollPane fitToHeight="true" fitToWidth="true" prefHeight="200.0" prefWidth="200.0" VBox.vgrow="ALWAYS">
 			<content>
 				<TableView fx:id="testTable" prefHeight="200.0" prefWidth="200.0">
 					<columns>
 						<TableColumn id="testIdColumn" fx:id="testIDColumn" editable="true" minWidth="30.0" prefWidth="75.0" text="Test ID" />
-						<TableColumn id="testCommentColumn" fx:id="testCommentColumn" editable="true" minWidth="30.0" prefWidth="150.0" text="Comment" />
-						<TableColumn id="lastRunColumn" fx:id="lastRunColumn" editable="false" minWidth="30.0" prefWidth="185.0" text="Last Run" />
-						<TableColumn id="passingStatusColumn" fx:id="passingStatusColumn" editable="false" minWidth="30.0" prefWidth="65.0" text="Passed?" />
-						<TableColumn id="lastRunResultColumn" fx:id="lastRunResultColumn" editable="false" minWidth="30.0" prefWidth="75.0" text="Result" />
-						<TableColumn id="testFileTypesColumn" fx:id="testFileTypesColumn" editable="false" minWidth="30.0" prefWidth="140.0" text="Test File Types" />
-						<TableColumn id="hasRemappingsColumn" fx:id="hasRemappingsColumn" editable="false" minWidth="30.0" prefWidth="140.0" text="Has Remappings?" />
-                  		<TableColumn id="ciwdVersionColumn" fx:id="ciwdVersionColumn" editable="false" prefWidth="100.0" text="CIWD Version" />
-                  		<TableColumn id="relDnaSerVersion" fx:id="relDnaSerVersion" editable="false" prefWidth="125.0" text="Serotype Version" />
-                  		<TableColumn id="donorCheckVersion" fx:id="donorCheckVersion" editable="false" prefWidth="125.0" text="DonorCheck Version" />
+						<TableColumn id="testFileTypesColumn" fx:id="testFileTypesColumn" editable="false" minWidth="30.0" prefWidth="124.0" text="Test File Types" />
+						<TableColumn id="manualEditsColumn" fx:id="manualEditsColumn" editable="false" minWidth="30.0" prefWidth="120.0" text="Manual Edits" />
+                  		<TableColumn id="ciwdVersionColumn" fx:id="ciwdVersionColumn" editable="false" prefWidth="105.0" text="CIWD Version" />
+                  		<TableColumn id="relDnaSerVersion" fx:id="relDnaSerVersion" editable="false" prefWidth="119.0" text="Serotype Version" />
+						<TableColumn id="expectingPassFailColumn" fx:id="expectingPassFailColumn" editable="true" minWidth="30.0" prefWidth="100.0" text="Expected Result" />
+						<TableColumn id="lastRunResultColumn" fx:id="lastRunResultColumn" editable="false" minWidth="25.0" prefWidth="148.0" text="Most Recent Run Result" />
+						<TableColumn id="testCommentColumn" fx:id="testCommentColumn" editable="true" minWidth="30.0" prefWidth="226.0" text="Comment" />
+						<TableColumn id="lastRunDetailsColumn" fx:id="lastRunDetailsColumn" editable="false" minWidth="30.0" prefWidth="175.0" text="Details of Most Recent Run" />
 					</columns>
 				</TableView>
 			</content>
 		</ScrollPane>
-		<HBox spacing="10.0">
+		<HBox alignment="CENTER" spacing="10.0">
 			<VBox.margin>
 				<Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
 			</VBox.margin>
 			<children>
-				<Button fx:id="closeButton" mnemonicParsing="false" onAction="#close" text="Close" />
-				<Region HBox.hgrow="ALWAYS" />
-           		<Button fx:id="removeSelectedButton" mnemonicParsing="false" onAction="#removeSelected" prefWidth="150.0" text="Remove Selected Tests" />
-				<Button fx:id="runSelectedButton" mnemonicParsing="false" onAction="#runSelected" prefWidth="150.0" text="Run Selected Tests" />
-				<Button fx:id="runAllButton" mnemonicParsing="false" onAction="#runAll" prefWidth="150.0" text="Run All Tests" />
-            	<Region HBox.hgrow="ALWAYS" />
-            	<Button fx:id="openDirectoryButton" mnemonicParsing="false" onAction="#openTestDirectory" text="Open Directory" />
-            	<Button fx:id="openTestButton" mnemonicParsing="false" onAction="#openSelectedTest" text="Open Test" />
+            	<Button fx:id="openDirectoryButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#openTestDirectory" prefWidth="150.0" text="Open Directory" />
+            	<Button fx:id="openTestButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#openSelectedTest" prefWidth="150.0" text="Open Test" />
+           		<Button fx:id="removeSelectedButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#removeSelected" prefWidth="150.0" text="Remove Selected Test(s)" />
+				<Button fx:id="runSelectedButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#runSelected" prefWidth="150.0" text="Run Selected Test(s)" />
+				<Button fx:id="runAllButton" defaultButton="true" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#runAll" prefWidth="150.0" text="Run All Tests" />
 			</children>
 		</HBox>
 	</children>

--- a/src/main/resources/ValidationTestMgmt.fxml
+++ b/src/main/resources/ValidationTestMgmt.fxml
@@ -37,14 +37,14 @@
 				<TableView fx:id="testTable" prefHeight="200.0" prefWidth="200.0">
 					<columns>
 						<TableColumn id="testIdColumn" fx:id="testIDColumn" editable="true" minWidth="30.0" prefWidth="75.0" text="Test ID" />
-						<TableColumn id="testFileTypesColumn" fx:id="testFileTypesColumn" editable="false" minWidth="30.0" prefWidth="124.0" text="Test File Types" />
-						<TableColumn id="manualEditsColumn" fx:id="manualEditsColumn" editable="false" minWidth="30.0" prefWidth="120.0" text="Manual Edits" />
-                  		<TableColumn id="ciwdVersionColumn" fx:id="ciwdVersionColumn" editable="false" prefWidth="105.0" text="CIWD Version" />
-                  		<TableColumn id="relDnaSerVersion" fx:id="relDnaSerVersion" editable="false" prefWidth="119.0" text="Serotype Version" />
-						<TableColumn id="expectingPassFailColumn" fx:id="expectingPassFailColumn" editable="true" minWidth="30.0" prefWidth="100.0" text="Expected Result" />
-						<TableColumn id="lastRunResultColumn" fx:id="lastRunResultColumn" editable="false" minWidth="25.0" prefWidth="148.0" text="Most Recent Run Result" />
+						<TableColumn id="testFileTypesColumn" fx:id="testFileTypesColumn" editable="false" minWidth="30.0" prefWidth="124.0" text="Test file types" />
+						<TableColumn id="manualEditsColumn" fx:id="manualEditsColumn" editable="false" minWidth="30.0" prefWidth="120.0" text="Manual edits" />
+                  		<TableColumn id="ciwdVersionColumn" fx:id="ciwdVersionColumn" editable="false" prefWidth="105.0" text="CIWD version" />
+                  		<TableColumn id="relDnaSerVersion" fx:id="relDnaSerVersion" editable="false" prefWidth="119.0" text="Serotype version" />
+						<TableColumn id="expectingPassFailColumn" fx:id="expectingPassFailColumn" editable="true" minWidth="30.0" prefWidth="100.0" text="Expected result" />
+						<TableColumn id="lastRunResultColumn" fx:id="lastRunResultColumn" editable="false" minWidth="25.0" prefWidth="148.0" text="Most recent run result" />
 						<TableColumn id="testCommentColumn" fx:id="testCommentColumn" editable="true" minWidth="30.0" prefWidth="226.0" text="Comment" />
-						<TableColumn id="lastRunDetailsColumn" fx:id="lastRunDetailsColumn" editable="false" minWidth="30.0" prefWidth="175.0" text="Details of Most Recent Run" />
+						<TableColumn id="lastRunDetailsColumn" fx:id="lastRunDetailsColumn" editable="false" minWidth="30.0" prefWidth="175.0" text="Details of most recent run" />
 					</columns>
 				</TableView>
 			</content>
@@ -54,11 +54,11 @@
 				<Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
 			</VBox.margin>
 			<children>
-            	<Button fx:id="openDirectoryButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#openTestDirectory" prefWidth="150.0" text="Open Directory" />
-            	<Button fx:id="openTestButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#openSelectedTest" prefWidth="150.0" text="Open Test" />
-           		<Button fx:id="removeSelectedButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#removeSelected" prefWidth="150.0" text="Remove Selected Test(s)" />
-				<Button fx:id="runSelectedButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#runSelected" prefWidth="150.0" text="Run Selected Test(s)" />
-				<Button fx:id="runAllButton" defaultButton="true" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#runAll" prefWidth="150.0" text="Run All Tests" />
+            	<Button fx:id="openDirectoryButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#openTestDirectory" prefWidth="150.0" text="Open directory" />
+            	<Button fx:id="openTestButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#openSelectedTest" prefWidth="150.0" text="Open test" />
+           		<Button fx:id="removeSelectedButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#removeSelected" prefWidth="150.0" text="Remove selected test(s)" />
+				<Button fx:id="runSelectedButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#runSelected" prefWidth="150.0" text="Run selected test(s)" />
+				<Button fx:id="runAllButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#runAll" prefWidth="150.0" text="Run all tests" />
 			</children>
 		</HBox>
 	</children>

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -1,1 +1,1 @@
-version = 1.2.3
+version = 1.2.4

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -1,1 +1,1 @@
-version = 1.2.4
+version = 1.2.5


### PR DESCRIPTION
# DonorCheck v1.2.5

## Moderate Changes

* Restructure batch validation information display.
* Add test result expectation.
* Color-code test result based on expectation.
* If test has manual reassignments, display list of reassigned loci.


**SureTyper LinkSeq XML Changes:**
* Parse "AUTOMATICALLY chosen" haplotypes if no manual choice present.
* Allow DQA1* allele names to be parsed as DQA (e.g. DQA03 instead of DQA1*03).
* Translate DR52/53/51 into DRB3/4/5 when parsing loci.

## Minor Changes

* Report more useful information in the event of failing to parse a proper antigen / allele from a string.
* Switch UI to consistently use sentence-case.
