### PR TITLE
DonorCheck v1.2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This project is open source, distributed under the GPL v2 license. The applicati
 
 ## Code Style
 
-We use Google's java code format. Current version: [1.6](https://github.com/google/google-java-format/releases/download/google-java-format-1.6/google-java-format-eclipse-plugin_1.6.0.jar)
+We use Google's java code format. Current version: [1.25.2](https://github.com/google/google-java-format/releases/download/v1.25.2/google-java-format-eclipse-plugin-1.25.2.jar)
 
 
 # Building DonorCheck

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.pankratzlab</groupId>
@@ -76,6 +76,30 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>2.1.0-alpha1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.5.16</version>
+		</dependency>
+
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-core</artifactId>
+			<version>1.5.16</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.12.1</version>
+		</dependency>
+		
+		<dependency>
 			<groupId>org.pankratzlab</groupId>
 			<artifactId>BackgroundDataProcessor-java11</artifactId>
 			<version>1.0-SNAPSHOT</version>
@@ -131,18 +155,7 @@
 			<groupId>org.apache.poi</groupId>
 			<artifactId>ooxml-schemas</artifactId>
 			<version>1.3</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>2.18.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>2.18.0</version>
-		</dependency>
-		
+		</dependency>		
 		
 		<dependency>
   			<groupId>com.dlsc.preferencesfx</groupId>
@@ -175,7 +188,7 @@
 			<artifactId>javafx-swing</artifactId>
 			<version>22.0.2</version>
 		</dependency>
-		
+
 		<!-- Test scope dependencies - not included in .jars built with Maven -->
 		<!-- JUnit - http://junit.org/ -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>org.pankratzlab</groupId>
 	<artifactId>donorcheck</artifactId>
 	<!-- if version number changes, be sure to update in project.properties file also -->
-	<version>1.2.5</version>
+	<version>1.2.6</version>
 	<packaging>jar</packaging>
 
 	<description>A stand-alone tool for validating DonorNet typing entries.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
 		<dependency>
 			<groupId>org.controlsfx</groupId>
 			<artifactId>controlsfx</artifactId>
-			<version>8.40.14</version>
+			<version>11.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -142,6 +142,40 @@
 			<artifactId>log4j-core</artifactId>
 			<version>2.18.0</version>
 		</dependency>
+		
+		
+		<dependency>
+  			<groupId>com.dlsc.preferencesfx</groupId>
+  			<artifactId>preferencesfx-core</artifactId>
+  			<version>11.17.0</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-controls</artifactId>
+			<version>22.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-fxml</artifactId>
+			<version>22.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-graphics</artifactId>
+			<version>22.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-base</artifactId>
+			<version>22.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-swing</artifactId>
+			<version>22.0.2</version>
+		</dependency>
+		
 		<!-- Test scope dependencies - not included in .jars built with Maven -->
 		<!-- JUnit - http://junit.org/ -->
 		<dependency>
@@ -187,31 +221,7 @@
 			<version>2.27.0</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.openjfx</groupId>
-			<artifactId>javafx-controls</artifactId>
-			<version>22.0.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjfx</groupId>
-			<artifactId>javafx-fxml</artifactId>
-			<version>22.0.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjfx</groupId>
-			<artifactId>javafx-graphics</artifactId>
-			<version>22.0.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjfx</groupId>
-			<artifactId>javafx-base</artifactId>
-			<version>22.0.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjfx</groupId>
-			<artifactId>javafx-swing</artifactId>
-			<version>22.0.2</version>
-		</dependency>
+		
 	</dependencies>
 
 

--- a/src/main/java/org/pankratzlab/unet/deprecated/hla/AntigenDictionary.java
+++ b/src/main/java/org/pankratzlab/unet/deprecated/hla/AntigenDictionary.java
@@ -47,7 +47,7 @@ public final class AntigenDictionary implements Serializable {
 
   public static final String REL_DNA_SER_PROP = "rel.dna.ser.file";
 
-  public static final String SERIALIZED_MAP = Info.HLA_HOME + ".hla/map.ser";
+  public static final String SERIALIZED_MAP = Info.DONOR_CHECK_HOME + ".hla/map.ser";
   public static final String MASTER_MAP_RECORDS = "rel_dna_ser.txt";
   private static final String COMMENT = "#";
   private static final String COL_DELIM = ";";
@@ -151,7 +151,7 @@ public final class AntigenDictionary implements Serializable {
 
   /** Build the dictionaries. Synchronized to ensured they are initialized only once */
   private static synchronized void loadDictionaries() {
-    String filePath = HLAProperties.get().getProperty(REL_DNA_SER_PROP);
+    String filePath = DonorCheckProperties.get().getProperty(REL_DNA_SER_PROP);
     if (map == null) {
       if (!Strings.isNullOrEmpty(filePath) && (new File(filePath)).exists()) {
         parseDictionaries(() -> new FileReader(filePath));
@@ -291,7 +291,7 @@ public final class AntigenDictionary implements Serializable {
   }
 
   public static String getVersion() {
-    String filePath = HLAProperties.get().getProperty(REL_DNA_SER_PROP);
+    String filePath = DonorCheckProperties.get().getProperty(REL_DNA_SER_PROP);
     if (filePath == null || Strings.isNullOrEmpty(filePath) || !(new File(filePath)).exists()) {
       return getBundledVersion() + " (bundled)";
     }

--- a/src/main/java/org/pankratzlab/unet/deprecated/hla/CurrentDirectoryProvider.java
+++ b/src/main/java/org/pankratzlab/unet/deprecated/hla/CurrentDirectoryProvider.java
@@ -49,7 +49,7 @@ public final class CurrentDirectoryProvider {
   public static FileChooser getFileChooser() {
     FileChooser fc = new FileChooser();
 
-    File baseDir = new File(HLAProperties.get().getProperty(baseDirProp(), DEFAULT_BASE_DIR));
+    File baseDir = new File(DonorCheckProperties.get().getProperty(baseDirProp(), DEFAULT_BASE_DIR));
     if (baseDir.exists() && baseDir.isDirectory()) {
       fc.setInitialDirectory(baseDir);
     }
@@ -59,7 +59,7 @@ public final class CurrentDirectoryProvider {
   }
 
   public static void setBaseDir(File dir) {
-    HLAProperties.get().put(baseDirProp(), dir.getAbsolutePath());
+    DonorCheckProperties.get().put(baseDirProp(), dir.getAbsolutePath());
   }
 
   public static void setInitialFileName(String name) {

--- a/src/main/java/org/pankratzlab/unet/deprecated/hla/DonorCheckProperties.java
+++ b/src/main/java/org/pankratzlab/unet/deprecated/hla/DonorCheckProperties.java
@@ -35,6 +35,11 @@ import java.util.Properties;
  */
 public final class DonorCheckProperties {
   private static final String PROP_FILE = Info.DONOR_CHECK_HOME + "hla.properties";
+
+  public static final String FIRST_TYPE = "FIRST_TYPE";
+  public static final String SECOND_TYPE = "SECOND_TYPE";
+  public static final String USE_ALLELE_CALL = "USE_ALLELE_CALL";
+
   private static Properties hlaProps;
 
   public static Properties get() {

--- a/src/main/java/org/pankratzlab/unet/deprecated/hla/DonorCheckProperties.java
+++ b/src/main/java/org/pankratzlab/unet/deprecated/hla/DonorCheckProperties.java
@@ -65,6 +65,7 @@ public final class DonorCheckProperties {
   }
 
   public static String getOrDefault(String key) {
+    get();
     switch (key) {
       case FIRST_TYPE:
         return hlaProps.getProperty(FIRST_TYPE, FIRST_TYPE_DEFAULT);

--- a/src/main/java/org/pankratzlab/unet/deprecated/hla/DonorCheckProperties.java
+++ b/src/main/java/org/pankratzlab/unet/deprecated/hla/DonorCheckProperties.java
@@ -27,6 +27,8 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Properties;
+import org.pankratzlab.unet.parser.PdfDonorParser;
+import org.pankratzlab.unet.parser.XmlDonorParser;
 
 /**
  * Helper class for managing persistent properties from a central location. Use {@link #get()} to
@@ -37,8 +39,21 @@ public final class DonorCheckProperties {
   private static final String PROP_FILE = Info.DONOR_CHECK_HOME + "hla.properties";
 
   public static final String FIRST_TYPE = "FIRST_TYPE";
+  public static final String FIRST_TYPE_DEFAULT = PdfDonorParser.getTypeString();
+
   public static final String SECOND_TYPE = "SECOND_TYPE";
+  public static final String SECOND_TYPE_DEFAULT = XmlDonorParser.getTypeString();
+
   public static final String USE_ALLELE_CALL = "USE_ALLELE_CALL";
+  public static final String USE_ALLELE_CALL_DEFAULT = "true";
+
+  public static final String SURETYPER_ALLOW_INVALID_DQA_ALLELES = "ALLOW_INVALID_SURETYPER_ALLELES";
+  public static final String SURETYPER_ALLOW_INVALID_DQA_ALLELES_DEFAULT = "true";
+
+  public static final String FAIL_OR_DISCARD_IF_AC_INVALID = "FAIL_OR_DISCARD_IF_AC_INVALID";
+  public static final String AC_INVALID_FAIL = "Fail";
+  public static final String AC_INVALID_DISCARD = "Discard";
+  public static final String FAIL_OR_DISCARD_IF_AC_INVALID_DEFAULT = AC_INVALID_FAIL;
 
   private static Properties hlaProps;
 
@@ -47,6 +62,23 @@ public final class DonorCheckProperties {
       loadProps();
     }
     return hlaProps;
+  }
+
+  public static String getOrDefault(String key) {
+    switch (key) {
+      case FIRST_TYPE:
+        return hlaProps.getProperty(FIRST_TYPE, FIRST_TYPE_DEFAULT);
+      case SECOND_TYPE:
+        return hlaProps.getProperty(SECOND_TYPE, SECOND_TYPE_DEFAULT);
+      case USE_ALLELE_CALL:
+        return hlaProps.getProperty(USE_ALLELE_CALL, USE_ALLELE_CALL_DEFAULT);
+      case SURETYPER_ALLOW_INVALID_DQA_ALLELES:
+        return hlaProps.getProperty(SURETYPER_ALLOW_INVALID_DQA_ALLELES, SURETYPER_ALLOW_INVALID_DQA_ALLELES_DEFAULT);
+      case FAIL_OR_DISCARD_IF_AC_INVALID:
+        return hlaProps.getProperty(FAIL_OR_DISCARD_IF_AC_INVALID, FAIL_OR_DISCARD_IF_AC_INVALID_DEFAULT);
+      default:
+        return null;
+    }
   }
 
   /**

--- a/src/main/java/org/pankratzlab/unet/deprecated/hla/DonorCheckProperties.java
+++ b/src/main/java/org/pankratzlab/unet/deprecated/hla/DonorCheckProperties.java
@@ -33,8 +33,8 @@ import java.util.Properties;
  * get the application-specific property values for the HLA suite. These will automatically be
  * updated on app shutdown.
  */
-public final class HLAProperties {
-  private static final String PROP_FILE = Info.HLA_HOME + "hla.properties";
+public final class DonorCheckProperties {
+  private static final String PROP_FILE = Info.DONOR_CHECK_HOME + "hla.properties";
   private static Properties hlaProps;
 
   public static Properties get() {

--- a/src/main/java/org/pankratzlab/unet/deprecated/hla/Info.java
+++ b/src/main/java/org/pankratzlab/unet/deprecated/hla/Info.java
@@ -32,8 +32,7 @@ import org.pankratzlab.unet.jfx.LandingController;
  */
 public class Info {
   public static final String MANIFEST_MAIN = "Main-Class";
-  public static final String DONOR_CHECK_HOME =
-      System.getProperty("user.home") + File.separator + ".donor_check" + File.separator;
+  public static final String DONOR_CHECK_HOME = System.getProperty("user.home") + File.separator + ".donor_check" + File.separator;
   /** Filename of the last requested version */
   public static final String VERSION_TO_LOAD = DONOR_CHECK_HOME + ".version.load.ser";
 
@@ -51,8 +50,7 @@ public class Info {
     if (version == null) {
       try {
         final Properties properties = new Properties();
-        properties.load(
-            LandingController.class.getClassLoader().getResourceAsStream("project.properties"));
+        properties.load(LandingController.class.getClassLoader().getResourceAsStream("project.properties"));
         version = properties.getProperty("version");
       } catch (IOException e) {
         throw new RuntimeException(e);

--- a/src/main/java/org/pankratzlab/unet/deprecated/hla/Info.java
+++ b/src/main/java/org/pankratzlab/unet/deprecated/hla/Info.java
@@ -32,18 +32,18 @@ import org.pankratzlab.unet.jfx.LandingController;
  */
 public class Info {
   public static final String MANIFEST_MAIN = "Main-Class";
-  public static final String HLA_HOME =
+  public static final String DONOR_CHECK_HOME =
       System.getProperty("user.home") + File.separator + ".donor_check" + File.separator;
   /** Filename of the last requested version */
-  public static final String VERSION_TO_LOAD = HLA_HOME + ".version.load.ser";
+  public static final String VERSION_TO_LOAD = DONOR_CHECK_HOME + ".version.load.ser";
 
   /** List of all available versions */
-  public static final String VERSIONS_KNOWN_LIST = HLA_HOME + ".version.avail.ser";
+  public static final String VERSIONS_KNOWN_LIST = DONOR_CHECK_HOME + ".version.avail.ser";
 
   public static final String REMOTE_URL = "http://www.genvisis.org/";
   public static final String REMOTE_VERSION_FILE = REMOTE_URL + "hla_releases.txt";
 
-  public static final String LOCAL_VERSIONS_DIR = HLA_HOME + ".hlaversions" + File.separator;
+  public static final String LOCAL_VERSIONS_DIR = DONOR_CHECK_HOME + ".hlaversions" + File.separator;
 
   private static String version = null;
 

--- a/src/main/java/org/pankratzlab/unet/hapstats/CommonWellDocumented.java
+++ b/src/main/java/org/pankratzlab/unet/hapstats/CommonWellDocumented.java
@@ -33,7 +33,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
-import org.pankratzlab.unet.deprecated.hla.HLAProperties;
+import org.pankratzlab.unet.deprecated.hla.DonorCheckProperties;
 import org.pankratzlab.unet.deprecated.hla.HLAType;
 import org.pankratzlab.unet.parser.XmlDonorParser;
 import com.google.common.cache.CacheBuilder;
@@ -120,8 +120,8 @@ public final class CommonWellDocumented {
 
   public static void initFromProperty() {
     boolean valid = false;
-    if (HLAProperties.get().containsKey(CWD_PROP)) {
-      String propVal = HLAProperties.get().getProperty(CWD_PROP);
+    if (DonorCheckProperties.get().containsKey(CWD_PROP)) {
+      String propVal = DonorCheckProperties.get().getProperty(CWD_PROP);
       try {
         SOURCE src = SOURCE.valueOf(propVal);
         switch (src) {
@@ -171,8 +171,8 @@ public final class CommonWellDocumented {
   public static SOURCE loadPropertyCWDSource() {
     SOURCE def = SOURCE.CIWD_300;
 
-    if (HLAProperties.get().containsKey(CWD_PROP)) {
-      String propVal = HLAProperties.get().getProperty(CWD_PROP);
+    if (DonorCheckProperties.get().containsKey(CWD_PROP)) {
+      String propVal = DonorCheckProperties.get().getProperty(CWD_PROP);
       try {
         def = SOURCE.valueOf(propVal);
       } catch (IllegalArgumentException e) {
@@ -188,7 +188,7 @@ public final class CommonWellDocumented {
       r.load();
 
       // save the selected value
-      HLAProperties.get().setProperty(CWD_PROP, r.name());
+      DonorCheckProperties.get().setProperty(CWD_PROP, r.name());
 
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/main/java/org/pankratzlab/unet/hapstats/HaplotypeFrequencies.java
+++ b/src/main/java/org/pankratzlab/unet/hapstats/HaplotypeFrequencies.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
-import org.pankratzlab.unet.deprecated.hla.HLAProperties;
+import org.pankratzlab.unet.deprecated.hla.DonorCheckProperties;
 import org.pankratzlab.unet.deprecated.hla.HLAType;
 import org.pankratzlab.unet.deprecated.hla.NullType;
 import com.google.common.base.Strings;
@@ -97,8 +97,8 @@ public final class HaplotypeFrequencies {
    * @return true if at least one haplotype is read successfully.
    */
   public static boolean doInitialization() {
-    String bcTablePath = HLAProperties.get().getProperty(NMDP_CB_PROP);
-    String drdqTablePath = HLAProperties.get().getProperty(NMDP_DRDQ_PROP);
+    String bcTablePath = DonorCheckProperties.get().getProperty(NMDP_CB_PROP);
+    String drdqTablePath = DonorCheckProperties.get().getProperty(NMDP_DRDQ_PROP);
     return completeDoInitialization(bcTablePath, drdqTablePath);
   }
 

--- a/src/main/java/org/pankratzlab/unet/jfx/BatchTestMgmtController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/BatchTestMgmtController.java
@@ -243,7 +243,10 @@ public class BatchTestMgmtController {
           return Bindings.createStringBinding(
               () -> {
                 String ver = value.donorCheckVersion.getValueSafe();
-                String date = format.format(value.lastRunDate.getValue());
+                String date =
+                    value.lastRunDate.getValue() == null
+                        ? "---"
+                        : format.format(value.lastRunDate.getValue());
                 return date + (ver.isBlank() ? "" : " (" + ver + ")");
               },
               value.donorCheckVersion,
@@ -255,6 +258,9 @@ public class BatchTestMgmtController {
           return Bindings.createStringBinding(
               () -> {
                 TEST_RESULT testResult = p.getValue().lastTestResult.get();
+                if (testResult == null) {
+                  return "---";
+                }
 
                 String v = "";
                 switch (p.getValue().expectedResult.get()) {

--- a/src/main/java/org/pankratzlab/unet/jfx/BatchTestMgmtController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/BatchTestMgmtController.java
@@ -286,7 +286,7 @@ public class BatchTestMgmtController {
         protected void updateItem(String value, boolean empty) {
           super.updateItem(value, empty);
           if (value == null) {
-            setText(null);
+            setText("");
             setStyle("");
           } else {
             String color = null;
@@ -320,7 +320,7 @@ public class BatchTestMgmtController {
         protected void updateItem(ObservableSet<SourceType> value, boolean empty) {
           super.updateItem(value, empty);
           if (value == null) {
-            setText(null);
+            setText("");
           } else {
             setText(value.stream().sorted().map(SourceType::getDisplayName).collect(Collectors.joining(", ")));
           }
@@ -409,7 +409,7 @@ public class BatchTestMgmtController {
       @Override
       protected void updateItem(T value, boolean empty) {
         super.updateItem(value, empty);
-        setText(Objects.toString(value).trim());
+        setText(value == null ? "" : Objects.toString(value).trim());
       }
     });
   }

--- a/src/main/java/org/pankratzlab/unet/jfx/BatchTestMgmtController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/BatchTestMgmtController.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import org.controlsfx.dialog.Wizard;
 import org.controlsfx.dialog.Wizard.LinearFlow;
 import org.controlsfx.dialog.WizardPane;
@@ -35,10 +34,8 @@ import org.pankratzlab.unet.validation.TEST_RESULT;
 import org.pankratzlab.unet.validation.ValidationTestFileSet;
 import org.pankratzlab.unet.validation.ValidationTesting;
 import org.pankratzlab.unet.validation.XMLRemapProcessor;
-
 import com.google.common.base.Strings;
 import com.google.common.collect.Table;
-
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.ReadOnlyStringProperty;
@@ -61,6 +58,7 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.cell.ComboBoxTableCell;
 import javafx.scene.control.cell.TextFieldTableCell;
+import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import javafx.stage.Window;
 import javafx.util.Callback;
@@ -75,61 +73,73 @@ public class BatchTestMgmtController {
   private static final String UNEXPECTED_ERROR = "Unexpected error";
   private static final String EXPECTED_ERROR = "Expected error";
 
-  @FXML private ResourceBundle resources;
+  @FXML
+  private ResourceBundle resources;
 
-  @FXML private URL location;
+  @FXML
+  private URL location;
 
-  @FXML TableView<ValidationTestFileSet> testTable;
+  @FXML
+  private VBox rootPane;
 
-  @FXML TableColumn<ValidationTestFileSet, String> testIDColumn;
+  @FXML
+  TableView<ValidationTestFileSet> testTable;
 
-  @FXML TableColumn<ValidationTestFileSet, ObservableSet<SourceType>> testFileTypesColumn;
+  @FXML
+  TableColumn<ValidationTestFileSet, String> testIDColumn;
 
-  @FXML TableColumn<ValidationTestFileSet, String> manualEditsColumn;
+  @FXML
+  TableColumn<ValidationTestFileSet, ObservableSet<SourceType>> testFileTypesColumn;
 
-  @FXML TableColumn<ValidationTestFileSet, CommonWellDocumented.SOURCE> ciwdVersionColumn;
+  @FXML
+  TableColumn<ValidationTestFileSet, String> manualEditsColumn;
 
-  @FXML TableColumn<ValidationTestFileSet, String> relDnaSerVersion;
+  @FXML
+  TableColumn<ValidationTestFileSet, CommonWellDocumented.SOURCE> ciwdVersionColumn;
 
-  @FXML TableColumn<ValidationTestFileSet, TEST_EXPECTATION> expectingPassFailColumn;
+  @FXML
+  TableColumn<ValidationTestFileSet, String> relDnaSerVersion;
 
-  @FXML TableColumn<ValidationTestFileSet, String> lastRunResultColumn;
+  @FXML
+  TableColumn<ValidationTestFileSet, TEST_EXPECTATION> expectingPassFailColumn;
 
-  @FXML TableColumn<ValidationTestFileSet, String> testCommentColumn;
+  @FXML
+  TableColumn<ValidationTestFileSet, String> lastRunResultColumn;
+
+  @FXML
+  TableColumn<ValidationTestFileSet, String> testCommentColumn;
 
   @FXML
   TableColumn<ValidationTestFileSet, String> lastRunDetailsColumn; // date and version of last run
 
-  @FXML Button openDirectoryButton;
+  @FXML
+  Button openDirectoryButton;
 
-  @FXML Button openTestButton;
+  @FXML
+  Button openTestButton;
 
-  @FXML Button removeSelectedButton;
+  @FXML
+  Button removeSelectedButton;
 
-  @FXML Button runSelectedButton;
+  @FXML
+  Button runSelectedButton;
 
-  @FXML Button runAllButton;
+  @FXML
+  Button runAllButton;
 
   private <K, V> TableCell<K, V> configureTableCell(TableCell<K, V> cell) {
     cell.setAlignment(Pos.CENTER);
     return cell;
   }
 
-  private <V>
-      Callback<TableColumn<ValidationTestFileSet, String>, TableCell<ValidationTestFileSet, String>>
-          getEditableCellFactory() {
-    Callback<TableColumn<ValidationTestFileSet, String>, TableCell<ValidationTestFileSet, String>>
-        c1 =
-            list ->
-                configureTableCell(
-                    new TextFieldTableCell<ValidationTestFileSet, String>(
-                        new DefaultStringConverter()));
+  private <V> Callback<TableColumn<ValidationTestFileSet, String>, TableCell<ValidationTestFileSet, String>> getEditableCellFactory() {
+    Callback<TableColumn<ValidationTestFileSet, String>, TableCell<ValidationTestFileSet, String>> c1 =
+        list -> configureTableCell(new TextFieldTableCell<ValidationTestFileSet, String>(new DefaultStringConverter()));
     return c1;
   }
 
-  private <T>
-      Callback<TableColumn<ValidationTestFileSet, T>, TableCell<ValidationTestFileSet, T>>
-          getComboBoxCellFactory(@SuppressWarnings("unchecked") T... values) {
+  private <T> Callback<TableColumn<ValidationTestFileSet, T>, TableCell<ValidationTestFileSet, T>> getComboBoxCellFactory(
+      @SuppressWarnings("unchecked") T... values) {
     return list -> configureTableCell(new ComboBoxTableCell<>(values));
   }
 
@@ -137,347 +147,271 @@ public class BatchTestMgmtController {
 
   @FXML
   void initialize() {
-    assert ciwdVersionColumn != null
-        : "fx:id=\"ciwdVersionColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert expectingPassFailColumn != null
-        : "fx:id=\"expectingPassFailColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert lastRunDetailsColumn != null
-        : "fx:id=\"lastRunDetailsColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert lastRunResultColumn != null
-        : "fx:id=\"lastRunResultColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert manualEditsColumn != null
-        : "fx:id=\"manualEditsColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert openDirectoryButton != null
-        : "fx:id=\"openDirectoryButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert openTestButton != null
-        : "fx:id=\"openTestButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert relDnaSerVersion != null
-        : "fx:id=\"relDnaSerVersion\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert removeSelectedButton != null
-        : "fx:id=\"removeSelectedButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert runAllButton != null
-        : "fx:id=\"runAllButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert runSelectedButton != null
-        : "fx:id=\"runSelectedButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert testCommentColumn != null
-        : "fx:id=\"testCommentColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert testFileTypesColumn != null
-        : "fx:id=\"testFileTypesColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert testIDColumn != null
-        : "fx:id=\"testIDColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert testTable != null
-        : "fx:id=\"testTable\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert ciwdVersionColumn != null : "fx:id=\"ciwdVersionColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert expectingPassFailColumn != null : "fx:id=\"expectingPassFailColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert lastRunDetailsColumn != null : "fx:id=\"lastRunDetailsColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert lastRunResultColumn != null : "fx:id=\"lastRunResultColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert manualEditsColumn != null : "fx:id=\"manualEditsColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert openDirectoryButton != null : "fx:id=\"openDirectoryButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert openTestButton != null : "fx:id=\"openTestButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert relDnaSerVersion != null : "fx:id=\"relDnaSerVersion\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert removeSelectedButton != null : "fx:id=\"removeSelectedButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert runAllButton != null : "fx:id=\"runAllButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert runSelectedButton != null : "fx:id=\"runSelectedButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert testCommentColumn != null : "fx:id=\"testCommentColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert testFileTypesColumn != null : "fx:id=\"testFileTypesColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert testIDColumn != null : "fx:id=\"testIDColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert testTable != null : "fx:id=\"testTable\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+
 
     testTable.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
     testTable.setEditable(true);
 
-    testIDColumn.setCellValueFactory(
-        p -> {
-          return p.getValue().id;
-        });
+    testIDColumn.setCellValueFactory(p -> {
+      return p.getValue().id;
+    });
 
-    testIDColumn.setOnEditCommit(
-        ev -> {
-          String oldId = ev.getOldValue();
-          ValidationTestFileSet oldTest = ev.getRowValue();
-          ValidationTestFileSet newTest;
-          try {
-            oldTest.id.set(ev.getNewValue());
-            newTest = ValidationTesting.updateTestID(oldId, oldTest);
-            testTable
-                .itemsProperty()
-                .get()
-                .set(testTable.itemsProperty().get().indexOf(oldTest), newTest);
-            testTable.refresh();
-          } catch (IllegalStateException e) {
-            AlertHelper.showMessage_ErrorUpdatingTestID(ev.getNewValue(), oldId, e.getCause());
-            testTable.refresh();
-          }
-        });
+    testIDColumn.setOnEditCommit(ev -> {
+      String oldId = ev.getOldValue();
+      ValidationTestFileSet oldTest = ev.getRowValue();
+      ValidationTestFileSet newTest;
+      try {
+        oldTest.id.set(ev.getNewValue());
+        newTest = ValidationTesting.updateTestID(oldId, oldTest);
+        testTable.itemsProperty().get().set(testTable.itemsProperty().get().indexOf(oldTest), newTest);
+        testTable.refresh();
+      } catch (IllegalStateException e) {
+        AlertHelper.showMessage_ErrorUpdatingTestID(ev.getNewValue(), oldId, e.getCause());
+        testTable.refresh();
+      }
+    });
 
     testIDColumn.setCellFactory(getEditableCellFactory());
 
-    testCommentColumn.setCellValueFactory(
-        cdf -> {
-          return cdf.getValue().comment;
-        });
+    testCommentColumn.setCellValueFactory(cdf -> {
+      return cdf.getValue().comment;
+    });
 
-    testCommentColumn.setOnEditCommit(
-        ev -> {
-          try {
-            ev.getRowValue().comment.set(ev.getNewValue());
-            ValidationTesting.updateTestProperties(ev.getRowValue());
-            testTable.refresh();
-          } catch (IllegalStateException e) {
-            AlertHelper.showMessage_ErrorUpdatingTestProperties(ev.getRowValue(), e.getCause());
-            testTable.refresh();
-          }
-        });
+    testCommentColumn.setOnEditCommit(ev -> {
+      try {
+        ev.getRowValue().comment.set(ev.getNewValue());
+        ValidationTesting.updateTestProperties(ev.getRowValue());
+        testTable.refresh();
+      } catch (IllegalStateException e) {
+        AlertHelper.showMessage_ErrorUpdatingTestProperties(ev.getRowValue(), e.getCause());
+        testTable.refresh();
+      }
+    });
 
     testCommentColumn.setCellFactory(getEditableCellFactory());
 
     expectingPassFailColumn.setCellFactory(getComboBoxCellFactory(TEST_EXPECTATION.values()));
 
-    expectingPassFailColumn.setCellValueFactory(
-        p -> {
-          return p.getValue().expectedResult;
-        });
+    expectingPassFailColumn.setCellValueFactory(p -> {
+      return p.getValue().expectedResult;
+    });
 
-    expectingPassFailColumn.setOnEditCommit(
-        ev -> {
-          try {
-            ev.getRowValue().expectedResult.set(ev.getNewValue());
-            ValidationTesting.updateTestProperties(ev.getRowValue());
-            testTable.refresh();
-          } catch (Throwable e) {
-            AlertHelper.showMessage_ErrorUpdatingTestProperties(ev.getRowValue(), e.getCause());
-            testTable.refresh();
-          }
-        });
+    expectingPassFailColumn.setOnEditCommit(ev -> {
+      try {
+        ev.getRowValue().expectedResult.set(ev.getNewValue());
+        ValidationTesting.updateTestProperties(ev.getRowValue());
+        testTable.refresh();
+      } catch (Throwable e) {
+        AlertHelper.showMessage_ErrorUpdatingTestProperties(ev.getRowValue(), e.getCause());
+        testTable.refresh();
+      }
+    });
 
     lastRunDetailsColumn.setCellFactory(getDefaultTextTableCellFactory());
 
-    lastRunDetailsColumn.setCellValueFactory(
-        p -> {
-          ValidationTestFileSet value = p.getValue();
-          return Bindings.createStringBinding(
-              () -> {
-                String ver = value.donorCheckVersion.getValueSafe();
-                String date =
-                    value.lastRunDate.getValue() == null
-                        ? "---"
-                        : format.format(value.lastRunDate.getValue());
-                return date + (ver.isBlank() ? "" : " (" + ver + ")");
-              },
-              value.donorCheckVersion,
-              value.lastRunDate);
-        });
+    lastRunDetailsColumn.setCellValueFactory(p -> {
+      ValidationTestFileSet value = p.getValue();
+      return Bindings.createStringBinding(() -> {
+        String ver = value.donorCheckVersion.getValueSafe();
+        String date = value.lastRunDate.getValue() == null ? "---" : format.format(value.lastRunDate.getValue());
+        return date + (ver.isBlank() ? "" : " (" + ver + ")");
+      }, value.donorCheckVersion, value.lastRunDate);
+    });
 
-    lastRunResultColumn.setCellValueFactory(
-        p -> {
-          return Bindings.createStringBinding(
-              () -> {
-                TEST_RESULT testResult = p.getValue().lastTestResult.get();
-                if (testResult == null) {
-                  return "---";
-                }
+    lastRunResultColumn.setCellValueFactory(p -> {
+      return Bindings.createStringBinding(() -> {
+        TEST_RESULT testResult = p.getValue().lastTestResult.get();
+        if (testResult == null) {
+          return "---";
+        }
 
-                String v = "";
-                switch (p.getValue().expectedResult.get()) {
-                  case Error:
-                    // expecting an error
-                    if (testResult != TEST_RESULT.TEST_SUCCESS
-                        && testResult != TEST_RESULT.TEST_FAILURE) {
-                      // got an error
-                      v = EXPECTED_ERROR;
-                    } else {
-                      if (testResult == TEST_RESULT.TEST_SUCCESS) {
-                        // didn't get an error
-                        v = UNEXPECTED_PASS;
-                      } else if (testResult == TEST_RESULT.TEST_FAILURE) {
-                        // didn't get an error
-                        v = UNEXPECTED_FAILURE;
-                      }
-                    }
-                    break;
-                  case Pass:
-                    if (testResult == TEST_RESULT.TEST_SUCCESS) {
-                      v = PASS;
-                    } else if (testResult == TEST_RESULT.TEST_FAILURE) {
-                      v = UNEXPECTED_FAILURE;
-                    } else {
-                      v = UNEXPECTED_ERROR + " (" + convert(testResult.name()) + ")";
-                    }
-                    break;
-                  case Fail:
-                    if (testResult == TEST_RESULT.TEST_SUCCESS) {
-                      v = UNEXPECTED_PASS;
-                    } else if (testResult == TEST_RESULT.TEST_FAILURE) {
-                      v = EXPECTED_FAILURE;
-                    } else {
-                      v = UNEXPECTED_ERROR + " (" + convert(testResult.name()) + ")";
-                    }
-                    break;
-                }
-                ;
-                return v;
-              },
-              p.getValue().expectedResult,
-              p.getValue().lastTestResult);
-        });
+        String v = "";
+        switch (p.getValue().expectedResult.get()) {
+          case Error:
+            // expecting an error
+            if (testResult != TEST_RESULT.TEST_SUCCESS && testResult != TEST_RESULT.TEST_FAILURE) {
+              // got an error
+              v = EXPECTED_ERROR;
+            } else {
+              if (testResult == TEST_RESULT.TEST_SUCCESS) {
+                // didn't get an error
+                v = UNEXPECTED_PASS;
+              } else if (testResult == TEST_RESULT.TEST_FAILURE) {
+                // didn't get an error
+                v = UNEXPECTED_FAILURE;
+              }
+            }
+            break;
+          case Pass:
+            if (testResult == TEST_RESULT.TEST_SUCCESS) {
+              v = PASS;
+            } else if (testResult == TEST_RESULT.TEST_FAILURE) {
+              v = UNEXPECTED_FAILURE;
+            } else {
+              v = UNEXPECTED_ERROR + " (" + convert(testResult.name()) + ")";
+            }
+            break;
+          case Fail:
+            if (testResult == TEST_RESULT.TEST_SUCCESS) {
+              v = UNEXPECTED_PASS;
+            } else if (testResult == TEST_RESULT.TEST_FAILURE) {
+              v = EXPECTED_FAILURE;
+            } else {
+              v = UNEXPECTED_ERROR + " (" + convert(testResult.name()) + ")";
+            }
+            break;
+        };
+        return v;
+      }, p.getValue().expectedResult, p.getValue().lastTestResult);
+    });
 
-    lastRunResultColumn.setCellFactory(
-        param -> {
-          return configureTableCell(
-              new TableCell<ValidationTestFileSet, String>() {
-                @Override
-                protected void updateItem(String value, boolean empty) {
-                  super.updateItem(value, empty);
-                  if (value == null) {
-                    setText(null);
-                    setStyle("");
-                  } else {
-                    String color = null;
-                    if (value.startsWith(PASS)
-                        || value.startsWith(EXPECTED_FAILURE)
-                        || value.startsWith(EXPECTED_ERROR)) {
-                      color = "LimeGreen";
-                    } else if (value.startsWith(UNEXPECTED_FAILURE)) {
-                      color = "Orange";
-                    } else if (value.startsWith(UNEXPECTED_PASS)) {
-                      color = "Lime";
-                    } else if (value.startsWith(UNEXPECTED_ERROR)) {
-                      color = "OrangeRed";
-                    }
-                    if (color != null) {
-                      setStyle("-fx-background-color: " + color + "; -fx-text-fill: black");
-                    } else {
-                      setStyle("");
-                    }
-                    setText(value);
-                  }
-                }
-              });
-        });
-
-    testFileTypesColumn.setCellValueFactory(
-        p -> {
-          return p.getValue().sourceTypes;
-        });
-
-    testFileTypesColumn.setCellFactory(
-        param -> {
-          return configureTableCell(
-              new TableCell<ValidationTestFileSet, ObservableSet<SourceType>>() {
-                @Override
-                protected void updateItem(ObservableSet<SourceType> value, boolean empty) {
-                  super.updateItem(value, empty);
-                  if (value == null) {
-                    setText(null);
-                  } else {
-                    setText(
-                        value.stream()
-                            .sorted()
-                            .map(SourceType::getDisplayName)
-                            .collect(Collectors.joining(", ")));
-                  }
-                }
-              });
-        });
-
-    manualEditsColumn.setCellValueFactory(
-        p -> {
-          ReadOnlyStringProperty valueSafe = p.getValue().remapFile;
-          if (valueSafe != null
-              && valueSafe.get() != null
-              && !valueSafe.get().isBlank()
-              && new File(valueSafe.get()).exists()) {
-            return new SimpleStringProperty(
-                p.getValue().remappedLoci.get().stream()
-                    .map(HLALocus::name)
-                    .collect(Collectors.joining(", ")));
+    lastRunResultColumn.setCellFactory(param -> {
+      return configureTableCell(new TableCell<ValidationTestFileSet, String>() {
+        @Override
+        protected void updateItem(String value, boolean empty) {
+          super.updateItem(value, empty);
+          if (value == null) {
+            setText(null);
+            setStyle("");
           } else {
-            return new SimpleStringProperty("");
+            String color = null;
+            if (value.startsWith(PASS) || value.startsWith(EXPECTED_FAILURE) || value.startsWith(EXPECTED_ERROR)) {
+              color = "LimeGreen";
+            } else if (value.startsWith(UNEXPECTED_FAILURE)) {
+              color = "Orange";
+            } else if (value.startsWith(UNEXPECTED_PASS)) {
+              color = "Lime";
+            } else if (value.startsWith(UNEXPECTED_ERROR)) {
+              color = "OrangeRed";
+            }
+            if (color != null) {
+              setStyle("-fx-background-color: " + color + "; -fx-text-fill: black");
+            } else {
+              setStyle("");
+            }
+            setText(value);
           }
-        });
+        }
+      });
+    });
+
+    testFileTypesColumn.setCellValueFactory(p -> {
+      return p.getValue().sourceTypes;
+    });
+
+    testFileTypesColumn.setCellFactory(param -> {
+      return configureTableCell(new TableCell<ValidationTestFileSet, ObservableSet<SourceType>>() {
+        @Override
+        protected void updateItem(ObservableSet<SourceType> value, boolean empty) {
+          super.updateItem(value, empty);
+          if (value == null) {
+            setText(null);
+          } else {
+            setText(value.stream().sorted().map(SourceType::getDisplayName).collect(Collectors.joining(", ")));
+          }
+        }
+      });
+    });
+
+    manualEditsColumn.setCellValueFactory(p -> {
+      ReadOnlyStringProperty valueSafe = p.getValue().remapFile;
+      if (valueSafe != null && valueSafe.get() != null && !valueSafe.get().isBlank() && new File(valueSafe.get()).exists()) {
+        return new SimpleStringProperty(p.getValue().remappedLoci.get().stream().map(HLALocus::name).collect(Collectors.joining(", ")));
+      } else {
+        return new SimpleStringProperty("");
+      }
+    });
 
     manualEditsColumn.setCellFactory(getDefaultTextTableCellFactory());
 
-    ciwdVersionColumn.setCellValueFactory(
-        p -> {
-          return p.getValue().cwdSource;
-        });
+    ciwdVersionColumn.setCellValueFactory(p -> {
+      return p.getValue().cwdSource;
+    });
 
-    ciwdVersionColumn.setCellFactory(
-        param ->
-            configureTableCell(
-                new TableCell<ValidationTestFileSet, SOURCE>() {
-                  @Override
-                  protected void updateItem(SOURCE value, boolean empty) {
-                    super.updateItem(value, empty);
-                    setText(value == null ? "" : value.getVersion());
-                  }
-                }));
+    ciwdVersionColumn.setCellFactory(param -> configureTableCell(new TableCell<ValidationTestFileSet, SOURCE>() {
+      @Override
+      protected void updateItem(SOURCE value, boolean empty) {
+        super.updateItem(value, empty);
+        setText(value == null ? "" : value.getVersion());
+      }
+    }));
 
-    relDnaSerVersion.setCellValueFactory(
-        p -> {
-          return p.getValue()
-              .relDnaSerFile
-              .map(
-                  os -> {
-                    String v = "Unknown";
-                    v = AntigenDictionary.getVersion(os);
-                    if (v == null) {
-                      v = "File Missing (" + os + ")";
-                    }
-                    return v;
-                  })
-              .orElse("");
-        });
+    relDnaSerVersion.setCellValueFactory(p -> {
+      return p.getValue().relDnaSerFile.map(os -> {
+        String v = "Unknown";
+        v = AntigenDictionary.getVersion(os);
+        if (v == null) {
+          v = "File missing (" + os + ")";
+        }
+        return v;
+      }).orElse("");
+    });
 
     relDnaSerVersion.setCellFactory(getDefaultTextTableCellFactory());
 
-    // Any selection enable/disable
-    removeSelectedButton
-        .disableProperty()
-        .bind(
-            Bindings.createBooleanBinding(
-                () -> {
-                  return testTable.getSelectionModel().getSelectedIndices().isEmpty();
-                },
-                testTable.getSelectionModel().selectedIndexProperty()));
+    removeSelectedButton.textProperty().bind(Bindings.createStringBinding(() -> {
+      int t = testTable.getSelectionModel().getSelectedIndices().size();
+      if (t == 0) {
+        return "Remove selected tests";
+      }
+      return "Remove " + t + " selected test" + (t > 1 ? "s" : "");
+    }, testTable.getSelectionModel().selectedIndexProperty()));
 
-    runSelectedButton
-        .disableProperty()
-        .bind(
-            Bindings.createBooleanBinding(
-                () -> {
-                  return testTable.getSelectionModel().getSelectedIndices().isEmpty();
-                },
-                testTable.getSelectionModel().selectedIndexProperty()));
+    // Any selection enable/disable
+    removeSelectedButton.disableProperty().bind(Bindings.createBooleanBinding(() -> {
+      return testTable.getSelectionModel().getSelectedIndices().isEmpty();
+    }, testTable.getSelectionModel().selectedIndexProperty()));
+
+    runSelectedButton.disableProperty().bind(Bindings.createBooleanBinding(() -> {
+      return testTable.getSelectionModel().getSelectedIndices().isEmpty();
+    }, testTable.getSelectionModel().selectedIndexProperty()));
+
+    runSelectedButton.textProperty().bind(Bindings.createStringBinding(() -> {
+      int t = testTable.getSelectionModel().getSelectedIndices().size();
+      if (t == 0) {
+        return "Run selected tests";
+      }
+      return "Run " + t + " selected test" + (t > 1 ? "s" : "");
+    }, testTable.getSelectionModel().selectedIndexProperty()));
 
     // Table not empty enable/disable
-    runAllButton
-        .disableProperty()
-        .bind(
-            Bindings.createBooleanBinding(
-                () -> {
-                  return testTable.getItems().isEmpty();
-                },
-                testTable.itemsProperty()));
+    runAllButton.disableProperty().bind(Bindings.createBooleanBinding(() -> {
+      return testTable.getItems().isEmpty();
+    }, testTable.itemsProperty()));
 
     // Single selection enable/disable
-    openDirectoryButton
-        .disableProperty()
-        .bind(
-            Bindings.createBooleanBinding(
-                () -> {
-                  return testTable.getSelectionModel().getSelectedIndices().size() != 1;
-                },
-                testTable.getSelectionModel().selectedIndexProperty()));
+    openDirectoryButton.disableProperty().bind(Bindings.createBooleanBinding(() -> {
+      return testTable.getSelectionModel().getSelectedIndices().size() != 1;
+    }, testTable.getSelectionModel().selectedIndexProperty()));
 
-    openTestButton
-        .disableProperty()
-        .bind(
-            Bindings.createBooleanBinding(
-                () -> {
-                  return testTable.getSelectionModel().getSelectedIndices().size() != 1;
-                },
-                testTable.getSelectionModel().selectedIndexProperty()));
+    openTestButton.disableProperty().bind(Bindings.createBooleanBinding(() -> {
+      return testTable.getSelectionModel().getSelectedIndices().size() != 1;
+    }, testTable.getSelectionModel().selectedIndexProperty()));
   }
 
-  public <T>
-      Callback<TableColumn<ValidationTestFileSet, T>, TableCell<ValidationTestFileSet, T>>
-          getDefaultTextTableCellFactory() {
-    return param ->
-        configureTableCell(
-            new TableCell<ValidationTestFileSet, T>() {
-              @Override
-              protected void updateItem(T value, boolean empty) {
-                super.updateItem(value, empty);
-                setText(Objects.toString(value).trim());
-              }
-            });
+  public <T> Callback<TableColumn<ValidationTestFileSet, T>, TableCell<ValidationTestFileSet, T>> getDefaultTextTableCellFactory() {
+    return param -> configureTableCell(new TableCell<ValidationTestFileSet, T>() {
+      @Override
+      protected void updateItem(T value, boolean empty) {
+        super.updateItem(value, empty);
+        setText(Objects.toString(value).trim());
+      }
+    });
   }
 
   private String convert(String s) {
@@ -488,69 +422,36 @@ public class BatchTestMgmtController {
 
   public void setTable(Table<SOURCE, String, List<ValidationTestFileSet>> testData) {
     ObservableList<ValidationTestFileSet> testList =
-        FXCollections.observableArrayList(
-            testData.values().stream().flatMap(List::stream).collect(Collectors.toList()));
+        FXCollections.observableArrayList(testData.values().stream().flatMap(List::stream).collect(Collectors.toList()));
     testTable.setItems(testList);
   }
 
   @FXML
   void removeSelected() {
-    List<ValidationTestFileSet> toRemove =
-        testTable.selectionModelProperty().get().getSelectedItems();
+    List<ValidationTestFileSet> toRemove = testTable.selectionModelProperty().get().getSelectedItems();
 
-    Alert alert =
-        new Alert(
-            AlertType.CONFIRMATION,
-            "Are you sure you'd like to remove "
-                + toRemove.size()
-                + " test"
-                + (toRemove.size() > 1 ? "s" : "")
-                + "?",
-            ButtonType.OK,
-            ButtonType.CANCEL);
+    Alert alert = new Alert(AlertType.CONFIRMATION,
+        "Are you sure you'd like to remove " + toRemove.size() + " test" + (toRemove.size() > 1 ? "s" : "") + "?", ButtonType.OK, ButtonType.CANCEL);
     alert.setTitle("Remove tests");
     alert.setHeaderText("");
     Optional<ButtonType> selVal = alert.showAndWait();
 
     if (selVal.isPresent() && selVal.get() == ButtonType.OK) {
       Map<ValidationTestFileSet, Boolean> results = ValidationTesting.deleteTests(toRemove);
-      Set<ValidationTestFileSet> removed =
-          results.entrySet().stream()
-              .filter(e -> e.getValue())
-              .map(Map.Entry::getKey)
-              .collect(Collectors.toSet());
+      Set<ValidationTestFileSet> removed = results.entrySet().stream().filter(e -> e.getValue()).map(Map.Entry::getKey).collect(Collectors.toSet());
       Set<ValidationTestFileSet> notRemoved =
-          results.entrySet().stream()
-              .filter(e -> !e.getValue())
-              .map(Map.Entry::getKey)
-              .collect(Collectors.toSet());
+          results.entrySet().stream().filter(e -> !e.getValue()).map(Map.Entry::getKey).collect(Collectors.toSet());
       testTable.getItems().removeAll(toRemove);
 
       if (removed.size() == toRemove.size()) {
-        Alert alert1 =
-            new Alert(
-                AlertType.INFORMATION,
-                "Successfully removed "
-                    + toRemove.size()
-                    + " test"
-                    + (toRemove.size() > 1 ? "s" : ""),
-                ButtonType.CLOSE);
+        Alert alert1 = new Alert(AlertType.INFORMATION, "Successfully removed " + toRemove.size() + " test" + (toRemove.size() > 1 ? "s" : ""),
+            ButtonType.CLOSE);
         alert1.setTitle("Successfully removed tests");
         alert1.setHeaderText("");
         alert1.showAndWait();
       } else {
-        Alert alert1 =
-            new Alert(
-                AlertType.WARNING,
-                "Failed to remove "
-                    + notRemoved.size()
-                    + " test"
-                    + (notRemoved.size() > 1 ? "s" : "")
-                    + "\n\nSuccessfully removed "
-                    + removed.size()
-                    + " test"
-                    + (removed.size() > 1 ? "s" : ""),
-                ButtonType.CLOSE);
+        Alert alert1 = new Alert(AlertType.WARNING, "Failed to remove " + notRemoved.size() + " test" + (notRemoved.size() > 1 ? "s" : "")
+            + "\n\nSuccessfully removed " + removed.size() + " test" + (removed.size() > 1 ? "s" : ""), ButtonType.CLOSE);
         alert1.setTitle("Failed to remove tests");
         alert1.setHeaderText("");
         alert1.showAndWait();
@@ -572,130 +473,103 @@ public class BatchTestMgmtController {
   void openSelectedTest() {
     final ValidationTestFileSet selectedItem = testTable.getSelectionModel().getSelectedItem();
 
-    Task<Void> runValidationTask =
-        JFXUtilHelper.createProgressTask(
-            () -> {
-              HaplotypeFrequencies.successfullyInitialized();
-            });
-    EventHandler<WorkerStateEvent> doValidation =
-        (w) -> {
+    Task<Void> runValidationTask = JFXUtilHelper.createProgressTask(() -> {
+      HaplotypeFrequencies.successfullyInitialized();
+    });
+    EventHandler<WorkerStateEvent> doValidation = (w) -> {
 
-          // Don't actually run this as an event, though - make it a runnable on the JFX App thread
-          Platform.runLater(
-              () -> {
-                if (!HaplotypeFrequencies.successfullyInitialized().get()) {
-                  Alert alert =
-                      new Alert(
-                          AlertType.INFORMATION,
-                          "Haplotype Frequency Tables are not found or are invalid, and thus frequency data will not be displayed.\n\n"
-                              + "Would you like to set these tables now?\n\n"
-                              + "Note: you can adjust these tables any time from the 'Haplotype' menu",
-                          ButtonType.YES,
-                          ButtonType.NO);
-                  alert.setTitle("No haplotype frequencies");
-                  alert.setHeaderText("");
-                  alert
-                      .showAndWait()
-                      .filter(response -> response == ButtonType.YES)
-                      .ifPresent(response -> TutorialHelper.chooseFreqTables(null));
-                } else if (!Strings.isNullOrEmpty(HaplotypeFrequencies.getMissingTableMessage())) {
-                  Alert alert =
-                      new Alert(
-                          AlertType.INFORMATION, HaplotypeFrequencies.getMissingTableMessage());
-                  alert.setTitle("Missing haplotype frequency table(s)");
-                  alert.setHeaderText("");
-                  alert.showAndWait();
-                }
+      // Don't actually run this as an event, though - make it a runnable on the JFX App thread
+      Platform.runLater(() -> {
+        if (!HaplotypeFrequencies.successfullyInitialized().get()) {
+          Alert alert = new Alert(AlertType.INFORMATION,
+              "Haplotype Frequency Tables are not found or are invalid, and thus frequency data will not be displayed.\n\n"
+                  + "Would you like to set these tables now?\n\n" + "Note: you can adjust these tables any time from the 'Haplotype' menu",
+              ButtonType.YES, ButtonType.NO);
+          alert.setTitle("No haplotype frequencies");
+          alert.setHeaderText("");
+          alert.showAndWait().filter(response -> response == ButtonType.YES).ifPresent(response -> TutorialHelper.chooseFreqTables(null));
+        } else if (!Strings.isNullOrEmpty(HaplotypeFrequencies.getMissingTableMessage())) {
+          Alert alert = new Alert(AlertType.INFORMATION, HaplotypeFrequencies.getMissingTableMessage());
+          alert.setTitle("Missing haplotype frequency table(s)");
+          alert.setHeaderText("");
+          alert.showAndWait();
+        }
 
-                SOURCE current = CommonWellDocumented.loadPropertyCWDSource();
-                String currentRel =
-                    DonorCheckProperties.get().getProperty(AntigenDictionary.REL_DNA_SER_PROP);
+        SOURCE current = CommonWellDocumented.loadPropertyCWDSource();
+        String currentRel = DonorCheckProperties.get().getProperty(AntigenDictionary.REL_DNA_SER_PROP);
 
-                SOURCE source = selectedItem.cwdSource.get();
-                String rel = selectedItem.relDnaSerFile.get();
-                boolean changedCWID = false;
-                boolean changedRel = false;
+        SOURCE source = selectedItem.cwdSource.get();
+        String rel = selectedItem.relDnaSerFile.get();
+        boolean changedCWID = false;
+        boolean changedRel = false;
 
-                if (current != source || !CommonWellDocumented.isLoaded()) {
-                  CommonWellDocumented.loadCIWDVersion(source);
-                  changedCWID = true;
-                }
-                if (!new File(currentRel).equals(new File(rel))) {
-                  DonorCheckProperties.get().setProperty(AntigenDictionary.REL_DNA_SER_PROP, rel);
-                  AntigenDictionary.clearCache();
-                  changedRel = true;
-                }
+        if (current != source || !CommonWellDocumented.isLoaded()) {
+          CommonWellDocumented.loadCIWDVersion(source);
+          changedCWID = true;
+        }
+        if (!new File(currentRel).equals(new File(rel))) {
+          DonorCheckProperties.get().setProperty(AntigenDictionary.REL_DNA_SER_PROP, rel);
+          AntigenDictionary.clearCache();
+          changedRel = true;
+        }
 
-                ValidationTable table = new ValidationTable();
+        ValidationTable table = new ValidationTable();
 
-                List<WizardPane> pages = new ArrayList<>();
+        List<WizardPane> pages = new ArrayList<>();
 
-                String f1 = selectedItem.filePaths.get().get(0);
-                String f2 = selectedItem.filePaths.get().get(1);
-                ValidationModelBuilder builder1 = new ValidationModelBuilder();
-                ValidationModelBuilder builder2 = new ValidationModelBuilder();
-                SourceType.parseFile(builder1, new File(f1));
-                SourceType.parseFile(builder2, new File(f2));
-                builder1.validate(false);
-                builder2.validate(false);
-                if (selectedItem.remapFile != null
-                    && selectedItem.remapFile.get() != null
-                    && new File(selectedItem.remapFile.get()).exists()) {
-                  XMLRemapProcessor processor = new XMLRemapProcessor(selectedItem.remapFile.get());
-                  if (builder1.hasCorrections()
-                      && processor.hasRemappings(builder1.getSourceType())) {
-                    builder1.processCorrections(processor);
-                  }
-                  if (builder2.hasCorrections()
-                      && processor.hasRemappings(builder2.getSourceType())) {
-                    builder2.processCorrections(processor);
-                  }
-                }
+        String f1 = selectedItem.filePaths.get().get(0);
+        String f2 = selectedItem.filePaths.get().get(1);
+        ValidationModelBuilder builder1 = new ValidationModelBuilder();
+        ValidationModelBuilder builder2 = new ValidationModelBuilder();
+        SourceType.parseFile(builder1, new File(f1));
+        SourceType.parseFile(builder2, new File(f2));
+        builder1.validate(false);
+        builder2.validate(false);
+        if (selectedItem.remapFile != null && selectedItem.remapFile.get() != null && new File(selectedItem.remapFile.get()).exists()) {
+          XMLRemapProcessor processor = new XMLRemapProcessor(selectedItem.remapFile.get());
+          if (builder1.hasCorrections() && processor.hasRemappings(builder1.getSourceType())) {
+            builder1.processCorrections(processor);
+          }
+          if (builder2.hasCorrections() && processor.hasRemappings(builder2.getSourceType())) {
+            builder2.processCorrections(processor);
+          }
+        }
 
-                try {
-                  LandingController.makePage(
-                      pages,
-                      table,
-                      LandingController.RESULTS_STEP,
-                      new ValidationResultsController());
-                  Wizard.Flow pageFlow = new LinearFlow(pages);
+        try {
+          LandingController.makePage(pages, table, LandingController.RESULTS_STEP, new ValidationResultsController());
+          Wizard.Flow pageFlow = new LinearFlow(pages);
 
-                  pages.get(0).getButtonTypes();
+          pages.get(0).getButtonTypes();
 
-                  Stage stage = new Stage();
-                  final Window window = stage.getOwner();
-                  Wizard validationWizard = new Wizard(window);
-                  final String string = Info.getVersion();
-                  validationWizard.setTitle("DonorCheck " + string);
-                  validationWizard.setFlow(pageFlow);
+          Stage stage = new Stage();
+          final Window window = stage.getOwner();
+          Wizard validationWizard = new Wizard(window);
+          final String string = Info.getVersion();
+          validationWizard.setTitle("DonorCheck " + string);
+          validationWizard.setFlow(pageFlow);
 
-                  table.setFirstModel(builder1.build());
-                  table.setSecondModel(builder2.build());
+          table.setFirstModel(builder1.build());
+          table.setSecondModel(builder2.build());
 
-                  // show wizard and wait for response
-                  validationWizard.showAndWait();
+          // show wizard and wait for response
+          validationWizard.showAndWait();
 
-                  if (changedCWID) {
-                    CommonWellDocumented.loadCIWDVersion(current);
-                  }
-                  if (changedRel) {
-                    DonorCheckProperties.get()
-                        .setProperty(AntigenDictionary.REL_DNA_SER_PROP, currentRel);
-                    AntigenDictionary.clearCache();
-                  }
-                } catch (IOException e) {
-                  e.printStackTrace();
-                  Alert alert1 =
-                      new Alert(
-                          AlertType.ERROR,
-                          "Error loading test data: " + e.getMessage(),
-                          ButtonType.CLOSE);
-                  alert1.setTitle("Error");
-                  alert1.setHeaderText("");
-                  alert1.showAndWait();
-                }
-              });
-        };
+          if (changedCWID) {
+            CommonWellDocumented.loadCIWDVersion(current);
+          }
+          if (changedRel) {
+            DonorCheckProperties.get().setProperty(AntigenDictionary.REL_DNA_SER_PROP, currentRel);
+            AntigenDictionary.clearCache();
+          }
+        } catch (IOException e) {
+          e.printStackTrace();
+          Alert alert1 = new Alert(AlertType.ERROR, "Error loading test data: " + e.getMessage(), ButtonType.CLOSE);
+          alert1.setTitle("Error");
+          alert1.setHeaderText("");
+          alert1.showAndWait();
+        }
+      });
+    };
     runValidationTask.addEventHandler(WorkerStateEvent.WORKER_STATE_SUCCEEDED, doValidation);
 
     new Thread(runValidationTask).start();
@@ -709,15 +583,12 @@ public class BatchTestMgmtController {
       Desktop.getDesktop().open(new File(dir));
     } catch (IOException e) {
       e.printStackTrace();
-      new Alert(
-              AlertType.ERROR,
-              "Error opening directory for test " + selectedItem.id.get() + ":\n" + e.getMessage(),
-              ButtonType.CLOSE)
+      new Alert(AlertType.ERROR, "Error opening directory for test " + selectedItem.id.get() + ":\n" + e.getMessage(), ButtonType.CLOSE)
           .showAndWait();
     }
   }
 
   private void runTasks(List<ValidationTestFileSet> tests) {
-    ValidationTesting.runTests(tests);
+    ValidationTesting.runTests(rootPane, tests);
   }
 }

--- a/src/main/java/org/pankratzlab/unet/jfx/BatchTestMgmtController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/BatchTestMgmtController.java
@@ -13,12 +13,13 @@ import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import org.controlsfx.dialog.Wizard;
 import org.controlsfx.dialog.Wizard.LinearFlow;
 import org.controlsfx.dialog.WizardPane;
 import org.pankratzlab.unet.deprecated.hla.AntigenDictionary;
-import org.pankratzlab.unet.deprecated.hla.HLALocus;
 import org.pankratzlab.unet.deprecated.hla.DonorCheckProperties;
+import org.pankratzlab.unet.deprecated.hla.HLALocus;
 import org.pankratzlab.unet.deprecated.hla.Info;
 import org.pankratzlab.unet.deprecated.hla.SourceType;
 import org.pankratzlab.unet.deprecated.jfx.JFXUtilHelper;
@@ -34,8 +35,10 @@ import org.pankratzlab.unet.validation.TEST_RESULT;
 import org.pankratzlab.unet.validation.ValidationTestFileSet;
 import org.pankratzlab.unet.validation.ValidationTesting;
 import org.pankratzlab.unet.validation.XMLRemapProcessor;
+
 import com.google.common.base.Strings;
 import com.google.common.collect.Table;
+
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.ReadOnlyStringProperty;
@@ -72,71 +75,61 @@ public class BatchTestMgmtController {
   private static final String UNEXPECTED_ERROR = "Unexpected error";
   private static final String EXPECTED_ERROR = "Expected error";
 
-  @FXML
-  private ResourceBundle resources;
+  @FXML private ResourceBundle resources;
 
-  @FXML
-  private URL location;
+  @FXML private URL location;
 
-  @FXML
-  TableView<ValidationTestFileSet> testTable;
+  @FXML TableView<ValidationTestFileSet> testTable;
 
-  @FXML
-  TableColumn<ValidationTestFileSet, String> testIDColumn;
+  @FXML TableColumn<ValidationTestFileSet, String> testIDColumn;
 
-  @FXML
-  TableColumn<ValidationTestFileSet, ObservableSet<SourceType>> testFileTypesColumn;
+  @FXML TableColumn<ValidationTestFileSet, ObservableSet<SourceType>> testFileTypesColumn;
 
-  @FXML
-  TableColumn<ValidationTestFileSet, String> manualEditsColumn;
+  @FXML TableColumn<ValidationTestFileSet, String> manualEditsColumn;
 
-  @FXML
-  TableColumn<ValidationTestFileSet, CommonWellDocumented.SOURCE> ciwdVersionColumn;
+  @FXML TableColumn<ValidationTestFileSet, CommonWellDocumented.SOURCE> ciwdVersionColumn;
 
-  @FXML
-  TableColumn<ValidationTestFileSet, String> relDnaSerVersion;
+  @FXML TableColumn<ValidationTestFileSet, String> relDnaSerVersion;
 
-  @FXML
-  TableColumn<ValidationTestFileSet, TEST_EXPECTATION> expectingPassFailColumn;
+  @FXML TableColumn<ValidationTestFileSet, TEST_EXPECTATION> expectingPassFailColumn;
 
-  @FXML
-  TableColumn<ValidationTestFileSet, String> lastRunResultColumn;
+  @FXML TableColumn<ValidationTestFileSet, String> lastRunResultColumn;
 
-  @FXML
-  TableColumn<ValidationTestFileSet, String> testCommentColumn;
+  @FXML TableColumn<ValidationTestFileSet, String> testCommentColumn;
 
   @FXML
   TableColumn<ValidationTestFileSet, String> lastRunDetailsColumn; // date and version of last run
 
-  @FXML
-  Button openDirectoryButton;
+  @FXML Button openDirectoryButton;
 
-  @FXML
-  Button openTestButton;
+  @FXML Button openTestButton;
 
-  @FXML
-  Button removeSelectedButton;
+  @FXML Button removeSelectedButton;
 
-  @FXML
-  Button runSelectedButton;
+  @FXML Button runSelectedButton;
 
-  @FXML
-  Button runAllButton;
+  @FXML Button runAllButton;
 
   private <K, V> TableCell<K, V> configureTableCell(TableCell<K, V> cell) {
     cell.setAlignment(Pos.CENTER);
     return cell;
   }
 
-  private <V> Callback<TableColumn<ValidationTestFileSet, String>, TableCell<ValidationTestFileSet, String>> getEditableCellFactory() {
-    Callback<TableColumn<ValidationTestFileSet, String>, TableCell<ValidationTestFileSet, String>> c1 =
-        list -> configureTableCell(
-            new TextFieldTableCell<ValidationTestFileSet, String>(new DefaultStringConverter()));
+  private <V>
+      Callback<TableColumn<ValidationTestFileSet, String>, TableCell<ValidationTestFileSet, String>>
+          getEditableCellFactory() {
+    Callback<TableColumn<ValidationTestFileSet, String>, TableCell<ValidationTestFileSet, String>>
+        c1 =
+            list ->
+                configureTableCell(
+                    new TextFieldTableCell<ValidationTestFileSet, String>(
+                        new DefaultStringConverter()));
     return c1;
   }
 
-  private <T> Callback<TableColumn<ValidationTestFileSet, T>, TableCell<ValidationTestFileSet, T>> getComboBoxCellFactory(
-      @SuppressWarnings("unchecked") T... values) {
+  private <T>
+      Callback<TableColumn<ValidationTestFileSet, T>, TableCell<ValidationTestFileSet, T>>
+          getComboBoxCellFactory(@SuppressWarnings("unchecked") T... values) {
     return list -> configureTableCell(new ComboBoxTableCell<>(values));
   }
 
@@ -144,252 +137,341 @@ public class BatchTestMgmtController {
 
   @FXML
   void initialize() {
-    assert ciwdVersionColumn != null : "fx:id=\"ciwdVersionColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert expectingPassFailColumn != null : "fx:id=\"expectingPassFailColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert lastRunDetailsColumn != null : "fx:id=\"lastRunDetailsColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert lastRunResultColumn != null : "fx:id=\"lastRunResultColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert manualEditsColumn != null : "fx:id=\"manualEditsColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert openDirectoryButton != null : "fx:id=\"openDirectoryButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert openTestButton != null : "fx:id=\"openTestButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert relDnaSerVersion != null : "fx:id=\"relDnaSerVersion\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert removeSelectedButton != null : "fx:id=\"removeSelectedButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert runAllButton != null : "fx:id=\"runAllButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert runSelectedButton != null : "fx:id=\"runSelectedButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert testCommentColumn != null : "fx:id=\"testCommentColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert testFileTypesColumn != null : "fx:id=\"testFileTypesColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert testIDColumn != null : "fx:id=\"testIDColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
-    assert testTable != null : "fx:id=\"testTable\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert ciwdVersionColumn != null
+        : "fx:id=\"ciwdVersionColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert expectingPassFailColumn != null
+        : "fx:id=\"expectingPassFailColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert lastRunDetailsColumn != null
+        : "fx:id=\"lastRunDetailsColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert lastRunResultColumn != null
+        : "fx:id=\"lastRunResultColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert manualEditsColumn != null
+        : "fx:id=\"manualEditsColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert openDirectoryButton != null
+        : "fx:id=\"openDirectoryButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert openTestButton != null
+        : "fx:id=\"openTestButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert relDnaSerVersion != null
+        : "fx:id=\"relDnaSerVersion\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert removeSelectedButton != null
+        : "fx:id=\"removeSelectedButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert runAllButton != null
+        : "fx:id=\"runAllButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert runSelectedButton != null
+        : "fx:id=\"runSelectedButton\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert testCommentColumn != null
+        : "fx:id=\"testCommentColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert testFileTypesColumn != null
+        : "fx:id=\"testFileTypesColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert testIDColumn != null
+        : "fx:id=\"testIDColumn\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
+    assert testTable != null
+        : "fx:id=\"testTable\" was not injected: check your FXML file 'ValidationTestMgmt.fxml'.";
 
     testTable.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
     testTable.setEditable(true);
 
-    testIDColumn.setCellValueFactory(p -> {
-      return p.getValue().id;
-    });
+    testIDColumn.setCellValueFactory(
+        p -> {
+          return p.getValue().id;
+        });
 
-    testIDColumn.setOnEditCommit(ev -> {
-      String oldId = ev.getOldValue();
-      ValidationTestFileSet oldTest = ev.getRowValue();
-      ValidationTestFileSet newTest;
-      try {
-        oldTest.id.set(ev.getNewValue());
-        newTest = ValidationTesting.updateTestID(oldId, oldTest);
-        testTable.itemsProperty().get().set(testTable.itemsProperty().get().indexOf(oldTest),
-            newTest);
-        testTable.refresh();
-      } catch (IllegalStateException e) {
-        AlertHelper.showMessage_ErrorUpdatingTestID(ev.getNewValue(), oldId, e.getCause());
-        testTable.refresh();
-      }
-    });
+    testIDColumn.setOnEditCommit(
+        ev -> {
+          String oldId = ev.getOldValue();
+          ValidationTestFileSet oldTest = ev.getRowValue();
+          ValidationTestFileSet newTest;
+          try {
+            oldTest.id.set(ev.getNewValue());
+            newTest = ValidationTesting.updateTestID(oldId, oldTest);
+            testTable
+                .itemsProperty()
+                .get()
+                .set(testTable.itemsProperty().get().indexOf(oldTest), newTest);
+            testTable.refresh();
+          } catch (IllegalStateException e) {
+            AlertHelper.showMessage_ErrorUpdatingTestID(ev.getNewValue(), oldId, e.getCause());
+            testTable.refresh();
+          }
+        });
 
     testIDColumn.setCellFactory(getEditableCellFactory());
 
-    testCommentColumn.setCellValueFactory(cdf -> {
-      return cdf.getValue().comment;
-    });
+    testCommentColumn.setCellValueFactory(
+        cdf -> {
+          return cdf.getValue().comment;
+        });
 
-    testCommentColumn.setOnEditCommit(ev -> {
-      try {
-        ev.getRowValue().comment.set(ev.getNewValue());
-        ValidationTesting.updateTestProperties(ev.getRowValue());
-        testTable.refresh();
-      } catch (IllegalStateException e) {
-        AlertHelper.showMessage_ErrorUpdatingTestProperties(ev.getRowValue(), e.getCause());
-        testTable.refresh();
-      }
-    });
+    testCommentColumn.setOnEditCommit(
+        ev -> {
+          try {
+            ev.getRowValue().comment.set(ev.getNewValue());
+            ValidationTesting.updateTestProperties(ev.getRowValue());
+            testTable.refresh();
+          } catch (IllegalStateException e) {
+            AlertHelper.showMessage_ErrorUpdatingTestProperties(ev.getRowValue(), e.getCause());
+            testTable.refresh();
+          }
+        });
 
     testCommentColumn.setCellFactory(getEditableCellFactory());
 
     expectingPassFailColumn.setCellFactory(getComboBoxCellFactory(TEST_EXPECTATION.values()));
 
-    expectingPassFailColumn.setCellValueFactory(p -> {
-      return p.getValue().expectedResult;
-    });
+    expectingPassFailColumn.setCellValueFactory(
+        p -> {
+          return p.getValue().expectedResult;
+        });
 
-    expectingPassFailColumn.setOnEditCommit(ev -> {
-      try {
-        ev.getRowValue().expectedResult.set(ev.getNewValue());
-        ValidationTesting.updateTestProperties(ev.getRowValue());
-        testTable.refresh();
-      } catch (Throwable e) {
-        AlertHelper.showMessage_ErrorUpdatingTestProperties(ev.getRowValue(), e.getCause());
-        testTable.refresh();
-      }
-    });
+    expectingPassFailColumn.setOnEditCommit(
+        ev -> {
+          try {
+            ev.getRowValue().expectedResult.set(ev.getNewValue());
+            ValidationTesting.updateTestProperties(ev.getRowValue());
+            testTable.refresh();
+          } catch (Throwable e) {
+            AlertHelper.showMessage_ErrorUpdatingTestProperties(ev.getRowValue(), e.getCause());
+            testTable.refresh();
+          }
+        });
 
     lastRunDetailsColumn.setCellFactory(getDefaultTextTableCellFactory());
 
-    lastRunDetailsColumn.setCellValueFactory(p -> {
-      ValidationTestFileSet value = p.getValue();
-      return Bindings.createStringBinding(() -> {
-        String ver = value.donorCheckVersion.getValueSafe();
-        String date = format.format(value.lastRunDate.getValue());
-        return date + (ver.isBlank() ? "" : " (" + ver + ")");
-      }, value.donorCheckVersion, value.lastRunDate);
-    });
+    lastRunDetailsColumn.setCellValueFactory(
+        p -> {
+          ValidationTestFileSet value = p.getValue();
+          return Bindings.createStringBinding(
+              () -> {
+                String ver = value.donorCheckVersion.getValueSafe();
+                String date = format.format(value.lastRunDate.getValue());
+                return date + (ver.isBlank() ? "" : " (" + ver + ")");
+              },
+              value.donorCheckVersion,
+              value.lastRunDate);
+        });
 
-    lastRunResultColumn.setCellValueFactory(p -> {
-      return Bindings.createStringBinding(() -> {
-        TEST_RESULT testResult = p.getValue().lastTestResult.get();
+    lastRunResultColumn.setCellValueFactory(
+        p -> {
+          return Bindings.createStringBinding(
+              () -> {
+                TEST_RESULT testResult = p.getValue().lastTestResult.get();
 
-        String v = "";
-        switch (p.getValue().expectedResult.get()) {
-          case Error:
-            // expecting an error
-            if (testResult != TEST_RESULT.TEST_SUCCESS && testResult != TEST_RESULT.TEST_FAILURE) {
-              // got an error
-              v = EXPECTED_ERROR;
-            } else {
-              if (testResult == TEST_RESULT.TEST_SUCCESS) {
-                // didn't get an error
-                v = UNEXPECTED_PASS;
-              } else if (testResult == TEST_RESULT.TEST_FAILURE) {
-                // didn't get an error
-                v = UNEXPECTED_FAILURE;
-              }
-            }
-            break;
-          case Pass:
-            if (testResult == TEST_RESULT.TEST_SUCCESS) {
-              v = PASS;
-            } else if (testResult == TEST_RESULT.TEST_FAILURE) {
-              v = UNEXPECTED_FAILURE;
-            } else {
-              v = UNEXPECTED_ERROR + " (" + convert(testResult.name()) + ")";
-            }
-            break;
-          case Fail:
-            if (testResult == TEST_RESULT.TEST_SUCCESS) {
-              v = UNEXPECTED_PASS;
-            } else if (testResult == TEST_RESULT.TEST_FAILURE) {
-              v = EXPECTED_FAILURE;
-            } else {
-              v = UNEXPECTED_ERROR + " (" + convert(testResult.name()) + ")";
-            }
-            break;
-        };
-        return v;
-      }, p.getValue().expectedResult, p.getValue().lastTestResult);
-    });
+                String v = "";
+                switch (p.getValue().expectedResult.get()) {
+                  case Error:
+                    // expecting an error
+                    if (testResult != TEST_RESULT.TEST_SUCCESS
+                        && testResult != TEST_RESULT.TEST_FAILURE) {
+                      // got an error
+                      v = EXPECTED_ERROR;
+                    } else {
+                      if (testResult == TEST_RESULT.TEST_SUCCESS) {
+                        // didn't get an error
+                        v = UNEXPECTED_PASS;
+                      } else if (testResult == TEST_RESULT.TEST_FAILURE) {
+                        // didn't get an error
+                        v = UNEXPECTED_FAILURE;
+                      }
+                    }
+                    break;
+                  case Pass:
+                    if (testResult == TEST_RESULT.TEST_SUCCESS) {
+                      v = PASS;
+                    } else if (testResult == TEST_RESULT.TEST_FAILURE) {
+                      v = UNEXPECTED_FAILURE;
+                    } else {
+                      v = UNEXPECTED_ERROR + " (" + convert(testResult.name()) + ")";
+                    }
+                    break;
+                  case Fail:
+                    if (testResult == TEST_RESULT.TEST_SUCCESS) {
+                      v = UNEXPECTED_PASS;
+                    } else if (testResult == TEST_RESULT.TEST_FAILURE) {
+                      v = EXPECTED_FAILURE;
+                    } else {
+                      v = UNEXPECTED_ERROR + " (" + convert(testResult.name()) + ")";
+                    }
+                    break;
+                }
+                ;
+                return v;
+              },
+              p.getValue().expectedResult,
+              p.getValue().lastTestResult);
+        });
 
-    lastRunResultColumn.setCellFactory(param -> {
-      return configureTableCell(new TableCell<ValidationTestFileSet, String>() {
-        @Override
-        protected void updateItem(String value, boolean empty) {
-          super.updateItem(value, empty);
-          if (value == null) {
-            setText(null);
-            setStyle("");
+    lastRunResultColumn.setCellFactory(
+        param -> {
+          return configureTableCell(
+              new TableCell<ValidationTestFileSet, String>() {
+                @Override
+                protected void updateItem(String value, boolean empty) {
+                  super.updateItem(value, empty);
+                  if (value == null) {
+                    setText(null);
+                    setStyle("");
+                  } else {
+                    String color = null;
+                    if (value.startsWith(PASS)
+                        || value.startsWith(EXPECTED_FAILURE)
+                        || value.startsWith(EXPECTED_ERROR)) {
+                      color = "LimeGreen";
+                    } else if (value.startsWith(UNEXPECTED_FAILURE)) {
+                      color = "Orange";
+                    } else if (value.startsWith(UNEXPECTED_PASS)) {
+                      color = "Lime";
+                    } else if (value.startsWith(UNEXPECTED_ERROR)) {
+                      color = "OrangeRed";
+                    }
+                    if (color != null) {
+                      setStyle("-fx-background-color: " + color + "; -fx-text-fill: black");
+                    } else {
+                      setStyle("");
+                    }
+                    setText(value);
+                  }
+                }
+              });
+        });
+
+    testFileTypesColumn.setCellValueFactory(
+        p -> {
+          return p.getValue().sourceTypes;
+        });
+
+    testFileTypesColumn.setCellFactory(
+        param -> {
+          return configureTableCell(
+              new TableCell<ValidationTestFileSet, ObservableSet<SourceType>>() {
+                @Override
+                protected void updateItem(ObservableSet<SourceType> value, boolean empty) {
+                  super.updateItem(value, empty);
+                  if (value == null) {
+                    setText(null);
+                  } else {
+                    setText(
+                        value.stream()
+                            .sorted()
+                            .map(SourceType::getDisplayName)
+                            .collect(Collectors.joining(", ")));
+                  }
+                }
+              });
+        });
+
+    manualEditsColumn.setCellValueFactory(
+        p -> {
+          ReadOnlyStringProperty valueSafe = p.getValue().remapFile;
+          if (valueSafe != null
+              && valueSafe.get() != null
+              && !valueSafe.get().isBlank()
+              && new File(valueSafe.get()).exists()) {
+            return new SimpleStringProperty(
+                p.getValue().remappedLoci.get().stream()
+                    .map(HLALocus::name)
+                    .collect(Collectors.joining(", ")));
           } else {
-            String color = null;
-            if (value.startsWith(PASS) || value.startsWith(EXPECTED_FAILURE)
-                || value.startsWith(EXPECTED_ERROR)) {
-              color = "LimeGreen";
-            } else if (value.startsWith(UNEXPECTED_FAILURE)) {
-              color = "Orange";
-            } else if (value.startsWith(UNEXPECTED_PASS)) {
-              color = "Lime";
-            } else if (value.startsWith(UNEXPECTED_ERROR)) {
-              color = "OrangeRed";
-            }
-            if (color != null) {
-              setStyle("-fx-background-color: " + color + "; -fx-text-fill: black");
-            } else {
-              setStyle("");
-            }
-            setText(value);
+            return new SimpleStringProperty("");
           }
-        }
-      });
-    });
-
-    testFileTypesColumn.setCellValueFactory(p -> {
-      return p.getValue().sourceTypes;
-    });
-
-    testFileTypesColumn.setCellFactory(param -> {
-      return configureTableCell(new TableCell<ValidationTestFileSet, ObservableSet<SourceType>>() {
-        @Override
-        protected void updateItem(ObservableSet<SourceType> value, boolean empty) {
-          super.updateItem(value, empty);
-          if (value == null) {
-            setText(null);
-          } else {
-
-            setText(value.stream().sorted().map(SourceType::getDisplayName)
-                .collect(Collectors.joining(", ")));
-          }
-        }
-      });
-    });
-
-    manualEditsColumn.setCellValueFactory(p -> {
-      ReadOnlyStringProperty valueSafe = p.getValue().remapFile;
-      if (valueSafe != null && valueSafe.get() != null && !valueSafe.get().isBlank()
-          && new File(valueSafe.get()).exists()) {
-        return new SimpleStringProperty(p.getValue().remappedLoci.get().stream().map(HLALocus::name)
-            .collect(Collectors.joining(", ")));
-      } else {
-        return new SimpleStringProperty("");
-      }
-    });
+        });
 
     manualEditsColumn.setCellFactory(getDefaultTextTableCellFactory());
 
-    ciwdVersionColumn.setCellValueFactory(p -> {
-      return p.getValue().cwdSource;
-    });
+    ciwdVersionColumn.setCellValueFactory(
+        p -> {
+          return p.getValue().cwdSource;
+        });
 
-    ciwdVersionColumn
-        .setCellFactory(param -> configureTableCell(new TableCell<ValidationTestFileSet, SOURCE>() {
-          @Override
-          protected void updateItem(SOURCE value, boolean empty) {
-            super.updateItem(value, empty);
-            setText(value == null ? "" : value.getVersion());
-          }
-        }));
+    ciwdVersionColumn.setCellFactory(
+        param ->
+            configureTableCell(
+                new TableCell<ValidationTestFileSet, SOURCE>() {
+                  @Override
+                  protected void updateItem(SOURCE value, boolean empty) {
+                    super.updateItem(value, empty);
+                    setText(value == null ? "" : value.getVersion());
+                  }
+                }));
 
-    relDnaSerVersion.setCellValueFactory(p -> {
-      return p.getValue().relDnaSerFile.map(AntigenDictionary::getVersion).orElse("");
-    });
+    relDnaSerVersion.setCellValueFactory(
+        p -> {
+          return p.getValue()
+              .relDnaSerFile
+              .map(
+                  os -> {
+                    String v = "Unknown";
+                    v = AntigenDictionary.getVersion(os);
+                    if (v == null) {
+                      v = "File Missing (" + os + ")";
+                    }
+                    return v;
+                  })
+              .orElse("");
+        });
 
     relDnaSerVersion.setCellFactory(getDefaultTextTableCellFactory());
 
     // Any selection enable/disable
-    removeSelectedButton.disableProperty().bind(Bindings.createBooleanBinding(() -> {
-      return testTable.getSelectionModel().getSelectedIndices().isEmpty();
-    }, testTable.getSelectionModel().selectedIndexProperty()));
+    removeSelectedButton
+        .disableProperty()
+        .bind(
+            Bindings.createBooleanBinding(
+                () -> {
+                  return testTable.getSelectionModel().getSelectedIndices().isEmpty();
+                },
+                testTable.getSelectionModel().selectedIndexProperty()));
 
-    runSelectedButton.disableProperty().bind(Bindings.createBooleanBinding(() -> {
-      return testTable.getSelectionModel().getSelectedIndices().isEmpty();
-    }, testTable.getSelectionModel().selectedIndexProperty()));
+    runSelectedButton
+        .disableProperty()
+        .bind(
+            Bindings.createBooleanBinding(
+                () -> {
+                  return testTable.getSelectionModel().getSelectedIndices().isEmpty();
+                },
+                testTable.getSelectionModel().selectedIndexProperty()));
 
     // Table not empty enable/disable
-    runAllButton.disableProperty().bind(Bindings.createBooleanBinding(() -> {
-      return testTable.getItems().isEmpty();
-    }, testTable.itemsProperty()));
+    runAllButton
+        .disableProperty()
+        .bind(
+            Bindings.createBooleanBinding(
+                () -> {
+                  return testTable.getItems().isEmpty();
+                },
+                testTable.itemsProperty()));
 
     // Single selection enable/disable
-    openDirectoryButton.disableProperty().bind(Bindings.createBooleanBinding(() -> {
-      return testTable.getSelectionModel().getSelectedIndices().size() != 1;
-    }, testTable.getSelectionModel().selectedIndexProperty()));
+    openDirectoryButton
+        .disableProperty()
+        .bind(
+            Bindings.createBooleanBinding(
+                () -> {
+                  return testTable.getSelectionModel().getSelectedIndices().size() != 1;
+                },
+                testTable.getSelectionModel().selectedIndexProperty()));
 
-    openTestButton.disableProperty().bind(Bindings.createBooleanBinding(() -> {
-      return testTable.getSelectionModel().getSelectedIndices().size() != 1;
-    }, testTable.getSelectionModel().selectedIndexProperty()));
-
+    openTestButton
+        .disableProperty()
+        .bind(
+            Bindings.createBooleanBinding(
+                () -> {
+                  return testTable.getSelectionModel().getSelectedIndices().size() != 1;
+                },
+                testTable.getSelectionModel().selectedIndexProperty()));
   }
 
-  public <T> Callback<TableColumn<ValidationTestFileSet, T>, TableCell<ValidationTestFileSet, T>> getDefaultTextTableCellFactory() {
-    return param -> configureTableCell(new TableCell<ValidationTestFileSet, T>() {
-      @Override
-      protected void updateItem(T value, boolean empty) {
-        super.updateItem(value, empty);
-        setText(Objects.toString(value).trim());
-      }
-    });
+  public <T>
+      Callback<TableColumn<ValidationTestFileSet, T>, TableCell<ValidationTestFileSet, T>>
+          getDefaultTextTableCellFactory() {
+    return param ->
+        configureTableCell(
+            new TableCell<ValidationTestFileSet, T>() {
+              @Override
+              protected void updateItem(T value, boolean empty) {
+                super.updateItem(value, empty);
+                setText(Objects.toString(value).trim());
+              }
+            });
   }
 
   private String convert(String s) {
@@ -399,8 +481,9 @@ public class BatchTestMgmtController {
   }
 
   public void setTable(Table<SOURCE, String, List<ValidationTestFileSet>> testData) {
-    ObservableList<ValidationTestFileSet> testList = FXCollections.observableArrayList(
-        testData.values().stream().flatMap(List::stream).collect(Collectors.toList()));
+    ObservableList<ValidationTestFileSet> testList =
+        FXCollections.observableArrayList(
+            testData.values().stream().flatMap(List::stream).collect(Collectors.toList()));
     testTable.setItems(testList);
   }
 
@@ -410,40 +493,63 @@ public class BatchTestMgmtController {
         testTable.selectionModelProperty().get().getSelectedItems();
 
     Alert alert =
-        new Alert(AlertType.CONFIRMATION, "Are you sure you'd like to remove " + toRemove.size()
-            + " test" + (toRemove.size() > 1 ? "s" : "") + "?", ButtonType.OK, ButtonType.CANCEL);
+        new Alert(
+            AlertType.CONFIRMATION,
+            "Are you sure you'd like to remove "
+                + toRemove.size()
+                + " test"
+                + (toRemove.size() > 1 ? "s" : "")
+                + "?",
+            ButtonType.OK,
+            ButtonType.CANCEL);
     alert.setTitle("Remove tests");
     alert.setHeaderText("");
     Optional<ButtonType> selVal = alert.showAndWait();
 
     if (selVal.isPresent() && selVal.get() == ButtonType.OK) {
       Map<ValidationTestFileSet, Boolean> results = ValidationTesting.deleteTests(toRemove);
-      Set<ValidationTestFileSet> removed = results.entrySet().stream().filter(e -> e.getValue())
-          .map(Map.Entry::getKey).collect(Collectors.toSet());
-      Set<ValidationTestFileSet> notRemoved = results.entrySet().stream().filter(e -> !e.getValue())
-          .map(Map.Entry::getKey).collect(Collectors.toSet());
+      Set<ValidationTestFileSet> removed =
+          results.entrySet().stream()
+              .filter(e -> e.getValue())
+              .map(Map.Entry::getKey)
+              .collect(Collectors.toSet());
+      Set<ValidationTestFileSet> notRemoved =
+          results.entrySet().stream()
+              .filter(e -> !e.getValue())
+              .map(Map.Entry::getKey)
+              .collect(Collectors.toSet());
       testTable.getItems().removeAll(toRemove);
 
       if (removed.size() == toRemove.size()) {
-        Alert alert1 = new Alert(AlertType.INFORMATION,
-            "Successfully removed " + toRemove.size() + " test" + (toRemove.size() > 1 ? "s" : ""),
-            ButtonType.CLOSE);
+        Alert alert1 =
+            new Alert(
+                AlertType.INFORMATION,
+                "Successfully removed "
+                    + toRemove.size()
+                    + " test"
+                    + (toRemove.size() > 1 ? "s" : ""),
+                ButtonType.CLOSE);
         alert1.setTitle("Successfully removed tests");
         alert1.setHeaderText("");
         alert1.showAndWait();
       } else {
-        Alert alert1 = new Alert(AlertType.WARNING,
-            "Failed to remove " + notRemoved.size() + " test" + (notRemoved.size() > 1 ? "s" : "")
-                + "\n\nSuccessfully removed " + removed.size() + " test"
-                + (removed.size() > 1 ? "s" : ""),
-            ButtonType.CLOSE);
+        Alert alert1 =
+            new Alert(
+                AlertType.WARNING,
+                "Failed to remove "
+                    + notRemoved.size()
+                    + " test"
+                    + (notRemoved.size() > 1 ? "s" : "")
+                    + "\n\nSuccessfully removed "
+                    + removed.size()
+                    + " test"
+                    + (removed.size() > 1 ? "s" : ""),
+                ButtonType.CLOSE);
         alert1.setTitle("Failed to remove tests");
         alert1.setHeaderText("");
         alert1.showAndWait();
       }
-
     }
-
   }
 
   @FXML
@@ -460,109 +566,130 @@ public class BatchTestMgmtController {
   void openSelectedTest() {
     final ValidationTestFileSet selectedItem = testTable.getSelectionModel().getSelectedItem();
 
-    Task<Void> runValidationTask = JFXUtilHelper.createProgressTask(() -> {
-      HaplotypeFrequencies.successfullyInitialized();
-    });
-    EventHandler<WorkerStateEvent> doValidation = (w) -> {
+    Task<Void> runValidationTask =
+        JFXUtilHelper.createProgressTask(
+            () -> {
+              HaplotypeFrequencies.successfullyInitialized();
+            });
+    EventHandler<WorkerStateEvent> doValidation =
+        (w) -> {
 
-      // Don't actually run this as an event, though - make it a runnable on the JFX App thread
-      Platform.runLater(() -> {
-        if (!HaplotypeFrequencies.successfullyInitialized()) {
-          Alert alert = new Alert(AlertType.INFORMATION,
-              "Haplotype Frequency Tables are not found or are invalid, and thus frequency data will not be displayed.\n\n"
-                  + "Would you like to set these tables now?\n\n"
-                  + "Note: you can adjust these tables any time from the 'Haplotype' menu",
-              ButtonType.YES, ButtonType.NO);
-          alert.setTitle("No haplotype frequencies");
-          alert.setHeaderText("");
-          alert.showAndWait().filter(response -> response == ButtonType.YES)
-              .ifPresent(response -> TutorialHelper.chooseFreqTables(null));
-        } else if (!Strings.isNullOrEmpty(HaplotypeFrequencies.getMissingTableMessage())) {
-          Alert alert =
-              new Alert(AlertType.INFORMATION, HaplotypeFrequencies.getMissingTableMessage());
-          alert.setTitle("Missing haplotype frequency table(s)");
-          alert.setHeaderText("");
-          alert.showAndWait();
-        }
+          // Don't actually run this as an event, though - make it a runnable on the JFX App thread
+          Platform.runLater(
+              () -> {
+                if (!HaplotypeFrequencies.successfullyInitialized()) {
+                  Alert alert =
+                      new Alert(
+                          AlertType.INFORMATION,
+                          "Haplotype Frequency Tables are not found or are invalid, and thus frequency data will not be displayed.\n\n"
+                              + "Would you like to set these tables now?\n\n"
+                              + "Note: you can adjust these tables any time from the 'Haplotype' menu",
+                          ButtonType.YES,
+                          ButtonType.NO);
+                  alert.setTitle("No haplotype frequencies");
+                  alert.setHeaderText("");
+                  alert
+                      .showAndWait()
+                      .filter(response -> response == ButtonType.YES)
+                      .ifPresent(response -> TutorialHelper.chooseFreqTables(null));
+                } else if (!Strings.isNullOrEmpty(HaplotypeFrequencies.getMissingTableMessage())) {
+                  Alert alert =
+                      new Alert(
+                          AlertType.INFORMATION, HaplotypeFrequencies.getMissingTableMessage());
+                  alert.setTitle("Missing haplotype frequency table(s)");
+                  alert.setHeaderText("");
+                  alert.showAndWait();
+                }
 
-        SOURCE current = CommonWellDocumented.loadPropertyCWDSource();
-        String currentRel = DonorCheckProperties.get().getProperty(AntigenDictionary.REL_DNA_SER_PROP);
+                SOURCE current = CommonWellDocumented.loadPropertyCWDSource();
+                String currentRel =
+                    DonorCheckProperties.get().getProperty(AntigenDictionary.REL_DNA_SER_PROP);
 
-        SOURCE source = selectedItem.cwdSource.get();
-        String rel = selectedItem.relDnaSerFile.get();
-        boolean changedCWID = false;
-        boolean changedRel = false;
+                SOURCE source = selectedItem.cwdSource.get();
+                String rel = selectedItem.relDnaSerFile.get();
+                boolean changedCWID = false;
+                boolean changedRel = false;
 
-        if (current != source || !CommonWellDocumented.isLoaded()) {
-          CommonWellDocumented.loadCIWDVersion(source);
-          changedCWID = true;
-        }
-        if (!new File(currentRel).equals(new File(rel))) {
-          DonorCheckProperties.get().setProperty(AntigenDictionary.REL_DNA_SER_PROP, rel);
-          AntigenDictionary.clearCache();
-          changedRel = true;
-        }
+                if (current != source || !CommonWellDocumented.isLoaded()) {
+                  CommonWellDocumented.loadCIWDVersion(source);
+                  changedCWID = true;
+                }
+                if (!new File(currentRel).equals(new File(rel))) {
+                  DonorCheckProperties.get().setProperty(AntigenDictionary.REL_DNA_SER_PROP, rel);
+                  AntigenDictionary.clearCache();
+                  changedRel = true;
+                }
 
-        ValidationTable table = new ValidationTable();
+                ValidationTable table = new ValidationTable();
 
-        List<WizardPane> pages = new ArrayList<>();
+                List<WizardPane> pages = new ArrayList<>();
 
-        String f1 = selectedItem.filePaths.get().get(0);
-        String f2 = selectedItem.filePaths.get().get(1);
-        ValidationModelBuilder builder1 = new ValidationModelBuilder();
-        ValidationModelBuilder builder2 = new ValidationModelBuilder();
-        SourceType.parseFile(builder1, new File(f1));
-        SourceType.parseFile(builder2, new File(f2));
-        builder1.validate(false);
-        builder2.validate(false);
-        if (selectedItem.remapFile != null && selectedItem.remapFile.get() != null
-            && new File(selectedItem.remapFile.get()).exists()) {
-          XMLRemapProcessor processor = new XMLRemapProcessor(selectedItem.remapFile.get());
-          if (builder1.hasCorrections() && processor.hasRemappings(builder1.getSourceType())) {
-            builder1.processCorrections(processor);
-          }
-          if (builder2.hasCorrections() && processor.hasRemappings(builder2.getSourceType())) {
-            builder2.processCorrections(processor);
-          }
-        }
+                String f1 = selectedItem.filePaths.get().get(0);
+                String f2 = selectedItem.filePaths.get().get(1);
+                ValidationModelBuilder builder1 = new ValidationModelBuilder();
+                ValidationModelBuilder builder2 = new ValidationModelBuilder();
+                SourceType.parseFile(builder1, new File(f1));
+                SourceType.parseFile(builder2, new File(f2));
+                builder1.validate(false);
+                builder2.validate(false);
+                if (selectedItem.remapFile != null
+                    && selectedItem.remapFile.get() != null
+                    && new File(selectedItem.remapFile.get()).exists()) {
+                  XMLRemapProcessor processor = new XMLRemapProcessor(selectedItem.remapFile.get());
+                  if (builder1.hasCorrections()
+                      && processor.hasRemappings(builder1.getSourceType())) {
+                    builder1.processCorrections(processor);
+                  }
+                  if (builder2.hasCorrections()
+                      && processor.hasRemappings(builder2.getSourceType())) {
+                    builder2.processCorrections(processor);
+                  }
+                }
 
-        try {
-          LandingController.makePage(pages, table, LandingController.RESULTS_STEP,
-              new ValidationResultsController());
-          Wizard.Flow pageFlow = new LinearFlow(pages);
+                try {
+                  LandingController.makePage(
+                      pages,
+                      table,
+                      LandingController.RESULTS_STEP,
+                      new ValidationResultsController());
+                  Wizard.Flow pageFlow = new LinearFlow(pages);
 
-          pages.get(0).getButtonTypes();
+                  pages.get(0).getButtonTypes();
 
-          Stage stage = new Stage();
-          final Window window = stage.getOwner();
-          Wizard validationWizard = new Wizard(window);
-          final String string = Info.getVersion();
-          validationWizard.setTitle("DonorCheck " + string);
-          validationWizard.setFlow(pageFlow);
+                  Stage stage = new Stage();
+                  final Window window = stage.getOwner();
+                  Wizard validationWizard = new Wizard(window);
+                  final String string = Info.getVersion();
+                  validationWizard.setTitle("DonorCheck " + string);
+                  validationWizard.setFlow(pageFlow);
 
-          table.setFirstModel(builder1.build());
-          table.setSecondModel(builder2.build());
+                  table.setFirstModel(builder1.build());
+                  table.setSecondModel(builder2.build());
 
-          // show wizard and wait for response
-          validationWizard.showAndWait();
+                  // show wizard and wait for response
+                  validationWizard.showAndWait();
 
-          if (changedCWID) {
-            CommonWellDocumented.loadCIWDVersion(current);
-          }
-          if (changedRel) {
-            DonorCheckProperties.get().setProperty(AntigenDictionary.REL_DNA_SER_PROP, currentRel);
-            AntigenDictionary.clearCache();
-          }
-        } catch (IOException e) {
-          e.printStackTrace();
-          Alert alert1 = new Alert(AlertType.ERROR, "Error loading test data: " + e.getMessage(),
-              ButtonType.CLOSE);
-          alert1.setTitle("Error");
-          alert1.setHeaderText("");
-          alert1.showAndWait();
-        }
-      });
-    };
+                  if (changedCWID) {
+                    CommonWellDocumented.loadCIWDVersion(current);
+                  }
+                  if (changedRel) {
+                    DonorCheckProperties.get()
+                        .setProperty(AntigenDictionary.REL_DNA_SER_PROP, currentRel);
+                    AntigenDictionary.clearCache();
+                  }
+                } catch (IOException e) {
+                  e.printStackTrace();
+                  Alert alert1 =
+                      new Alert(
+                          AlertType.ERROR,
+                          "Error loading test data: " + e.getMessage(),
+                          ButtonType.CLOSE);
+                  alert1.setTitle("Error");
+                  alert1.setHeaderText("");
+                  alert1.showAndWait();
+                }
+              });
+        };
     runValidationTask.addEventHandler(WorkerStateEvent.WORKER_STATE_SUCCEEDED, doValidation);
 
     new Thread(runValidationTask).start();
@@ -576,15 +703,15 @@ public class BatchTestMgmtController {
       Desktop.getDesktop().open(new File(dir));
     } catch (IOException e) {
       e.printStackTrace();
-      new Alert(AlertType.ERROR,
-          "Error opening directory for test " + selectedItem.id.get() + ":\n" + e.getMessage(),
-          ButtonType.CLOSE).showAndWait();
+      new Alert(
+              AlertType.ERROR,
+              "Error opening directory for test " + selectedItem.id.get() + ":\n" + e.getMessage(),
+              ButtonType.CLOSE)
+          .showAndWait();
     }
   }
 
   private void runTasks(List<ValidationTestFileSet> tests) {
     ValidationTesting.runTests(tests);
   }
-
-
 }

--- a/src/main/java/org/pankratzlab/unet/jfx/BatchTestMgmtController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/BatchTestMgmtController.java
@@ -18,7 +18,7 @@ import org.controlsfx.dialog.Wizard.LinearFlow;
 import org.controlsfx.dialog.WizardPane;
 import org.pankratzlab.unet.deprecated.hla.AntigenDictionary;
 import org.pankratzlab.unet.deprecated.hla.HLALocus;
-import org.pankratzlab.unet.deprecated.hla.HLAProperties;
+import org.pankratzlab.unet.deprecated.hla.DonorCheckProperties;
 import org.pankratzlab.unet.deprecated.hla.Info;
 import org.pankratzlab.unet.deprecated.hla.SourceType;
 import org.pankratzlab.unet.deprecated.jfx.JFXUtilHelper;
@@ -317,6 +317,7 @@ public class BatchTestMgmtController {
           if (value == null) {
             setText(null);
           } else {
+
             setText(value.stream().sorted().map(SourceType::getDisplayName)
                 .collect(Collectors.joining(", ")));
           }
@@ -485,7 +486,7 @@ public class BatchTestMgmtController {
         }
 
         SOURCE current = CommonWellDocumented.loadPropertyCWDSource();
-        String currentRel = HLAProperties.get().getProperty(AntigenDictionary.REL_DNA_SER_PROP);
+        String currentRel = DonorCheckProperties.get().getProperty(AntigenDictionary.REL_DNA_SER_PROP);
 
         SOURCE source = selectedItem.cwdSource.get();
         String rel = selectedItem.relDnaSerFile.get();
@@ -497,7 +498,7 @@ public class BatchTestMgmtController {
           changedCWID = true;
         }
         if (!new File(currentRel).equals(new File(rel))) {
-          HLAProperties.get().setProperty(AntigenDictionary.REL_DNA_SER_PROP, rel);
+          DonorCheckProperties.get().setProperty(AntigenDictionary.REL_DNA_SER_PROP, rel);
           AntigenDictionary.clearCache();
           changedRel = true;
         }
@@ -549,7 +550,7 @@ public class BatchTestMgmtController {
             CommonWellDocumented.loadCIWDVersion(current);
           }
           if (changedRel) {
-            HLAProperties.get().setProperty(AntigenDictionary.REL_DNA_SER_PROP, currentRel);
+            DonorCheckProperties.get().setProperty(AntigenDictionary.REL_DNA_SER_PROP, currentRel);
             AntigenDictionary.clearCache();
           }
         } catch (IOException e) {

--- a/src/main/java/org/pankratzlab/unet/jfx/BatchTestMgmtController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/BatchTestMgmtController.java
@@ -577,7 +577,7 @@ public class BatchTestMgmtController {
           // Don't actually run this as an event, though - make it a runnable on the JFX App thread
           Platform.runLater(
               () -> {
-                if (!HaplotypeFrequencies.successfullyInitialized()) {
+                if (!HaplotypeFrequencies.successfullyInitialized().get()) {
                   Alert alert =
                       new Alert(
                           AlertType.INFORMATION,

--- a/src/main/java/org/pankratzlab/unet/jfx/BatchTestMgmtController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/BatchTestMgmtController.java
@@ -174,7 +174,11 @@ public class BatchTestMgmtController {
         testTable.itemsProperty().get().set(testTable.itemsProperty().get().indexOf(oldTest), newTest);
         testTable.refresh();
       } catch (IllegalStateException e) {
-        AlertHelper.showMessage_ErrorUpdatingTestID(ev.getNewValue(), oldId, e.getCause());
+        Throwable cause = e;
+        while (cause.getCause() != null) {
+          cause = cause.getCause();
+        }
+        AlertHelper.showMessage_ErrorUpdatingTestID(ev.getNewValue(), oldId, cause);
         testTable.refresh();
       }
     });
@@ -191,7 +195,11 @@ public class BatchTestMgmtController {
         ValidationTesting.updateTestProperties(ev.getRowValue());
         testTable.refresh();
       } catch (IllegalStateException e) {
-        AlertHelper.showMessage_ErrorUpdatingTestProperties(ev.getRowValue(), e.getCause());
+        Throwable cause = e;
+        while (cause.getCause() != null) {
+          cause = cause.getCause();
+        }
+        AlertHelper.showMessage_ErrorUpdatingTestProperties(ev.getRowValue(), cause);
         testTable.refresh();
       }
     });
@@ -210,7 +218,11 @@ public class BatchTestMgmtController {
         ValidationTesting.updateTestProperties(ev.getRowValue());
         testTable.refresh();
       } catch (Throwable e) {
-        AlertHelper.showMessage_ErrorUpdatingTestProperties(ev.getRowValue(), e.getCause());
+        Throwable cause = e;
+        while (cause.getCause() != null) {
+          cause = cause.getCause();
+        }
+        AlertHelper.showMessage_ErrorUpdatingTestProperties(ev.getRowValue(), cause);
         testTable.refresh();
       }
     });

--- a/src/main/java/org/pankratzlab/unet/jfx/DownloadNMDPController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/DownloadNMDPController.java
@@ -28,7 +28,7 @@ import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.ResourceBundle;
 import org.pankratzlab.unet.deprecated.hla.CurrentDirectoryProvider;
-import org.pankratzlab.unet.deprecated.hla.HLAProperties;
+import org.pankratzlab.unet.deprecated.hla.DonorCheckProperties;
 import org.pankratzlab.unet.deprecated.jfx.JFXUtilHelper;
 import org.pankratzlab.unet.hapstats.HaplotypeFrequencies;
 import com.google.common.base.Strings;
@@ -130,7 +130,7 @@ public class DownloadNMDPController {
   /** Link together a local property, text display and global property */
   private void init(StringProperty localProp, TextField tableField, String propertyName) {
     tableField.textProperty().bind(localProp);
-    String nmdpProp = HLAProperties.get().getProperty(propertyName);
+    String nmdpProp = DonorCheckProperties.get().getProperty(propertyName);
 
     if (!Strings.isNullOrEmpty(nmdpProp)) {
       if (!new File(nmdpProp).exists()) {
@@ -142,7 +142,7 @@ public class DownloadNMDPController {
 
     localProp.addListener((obs, o, n) -> {
       if (!Strings.isNullOrEmpty(n) && Files.exists(Paths.get(n))) {
-        HLAProperties.get().setProperty(propertyName, n);
+        DonorCheckProperties.get().setProperty(propertyName, n);
         dirty = true;
       }
     });

--- a/src/main/java/org/pankratzlab/unet/jfx/LandingController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/LandingController.java
@@ -138,12 +138,14 @@ public class LandingController {
         TestLoadingResults validationDirectory = ValidationTesting.loadValidationDirectory();
 
         return validationDirectory;
-      } catch (Exception e1) {
+      } catch (Throwable e1) {
         e1.printStackTrace();
-        Alert alert1 = new Alert(AlertType.ERROR, "Error loading test data: " + e1.getMessage(), ButtonType.CLOSE);
-        alert1.setTitle("Error");
-        alert1.setHeaderText("");
-        alert1.showAndWait();
+        Platform.runLater(() -> {
+          Alert alert1 = new Alert(AlertType.ERROR, "Error loading test data: " + e1.getMessage(), ButtonType.CLOSE);
+          alert1.setTitle("Error");
+          alert1.setHeaderText("");
+          alert1.showAndWait();
+        });
         throw new IllegalStateException("Error loading test data: " + e1.getMessage());
       }
     });
@@ -153,12 +155,14 @@ public class LandingController {
         TestLoadingResults testLoad;
         try {
           testLoad = manageValidationTask.get();
-        } catch (Exception e1) {
+        } catch (Throwable e1) {
           e1.printStackTrace();
-          Alert alert1 = new Alert(AlertType.ERROR, "Error loading test data: " + e1.getMessage(), ButtonType.CLOSE);
-          alert1.setTitle("Error");
-          alert1.setHeaderText("");
-          alert1.showAndWait();
+          Platform.runLater(() -> {
+            Alert alert1 = new Alert(AlertType.ERROR, "Error loading test data: " + e1.getMessage(), ButtonType.CLOSE);
+            alert1.setTitle("Error");
+            alert1.setHeaderText("");
+            alert1.showAndWait();
+          });
           return;
         }
 
@@ -181,15 +185,15 @@ public class LandingController {
           alert1.showAndWait();
         }
 
-        Table<SOURCE, String, List<ValidationTestFileSet>> testData = testLoad.testSets;
-
-        BatchTestMgmtController controller = new BatchTestMgmtController();
-
-        FXMLLoader loader = new FXMLLoader(LandingController.class.getResource(TESTING_MGMT));
-        loader.setController(controller);
-
-        Scene newScene;
         try {
+          Table<SOURCE, String, List<ValidationTestFileSet>> testData = testLoad.testSets;
+
+          BatchTestMgmtController controller = new BatchTestMgmtController();
+
+          FXMLLoader loader = new FXMLLoader(LandingController.class.getResource(TESTING_MGMT));
+          loader.setController(controller);
+
+          Scene newScene;
           newScene = new Scene(loader.load());
           Stage inputStage = new Stage();
           inputStage.initOwner(rootPane.getScene().getWindow());
@@ -199,12 +203,14 @@ public class LandingController {
           inputStage.setScene(newScene);
           controller.setTable(testData);
           inputStage.showAndWait();
-        } catch (IOException e1) {
+        } catch (Throwable e1) {
           e1.printStackTrace();
-          Alert alert1 = new Alert(AlertType.ERROR, "Error loading test data: " + e1.getMessage(), ButtonType.CLOSE);
-          alert1.setTitle("Error");
-          alert1.setHeaderText("");
-          alert1.showAndWait();
+          Platform.runLater(() -> {
+            Alert alert1 = new Alert(AlertType.ERROR, "Error loading test data: " + e1.getMessage(), ButtonType.CLOSE);
+            alert1.setTitle("Error");
+            alert1.setHeaderText("");
+            alert1.showAndWait();
+          });
         }
       });
     };

--- a/src/main/java/org/pankratzlab/unet/jfx/LandingController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/LandingController.java
@@ -308,7 +308,7 @@ public class LandingController {
       Platform.runLater(() -> {
         if (!HaplotypeFrequencies.successfullyInitialized()) {
           Alert alert = new Alert(AlertType.INFORMATION,
-              "Haplotype Frequency Tables are not found or are invalid, and thus frequency data will not be displayed.\n\n"
+              "Haplotype frequency tables are not found or are invalid, and thus frequency data will not be displayed.\n\n"
                   + "Would you like to set these tables now?\n\n"
                   + "Note: you can adjust these tables any time from the 'Haplotype' menu",
               ButtonType.YES, ButtonType.NO);

--- a/src/main/java/org/pankratzlab/unet/jfx/LandingController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/LandingController.java
@@ -40,6 +40,7 @@ import org.pankratzlab.unet.hapstats.CommonWellDocumented;
 import org.pankratzlab.unet.hapstats.CommonWellDocumented.SOURCE;
 import org.pankratzlab.unet.hapstats.HaplotypeFrequencies;
 import org.pankratzlab.unet.jfx.macui.MACUIController;
+import org.pankratzlab.unet.jfx.prop.DCProperty;
 import org.pankratzlab.unet.jfx.wizard.FileInputController;
 import org.pankratzlab.unet.jfx.wizard.ValidatingWizardController;
 import org.pankratzlab.unet.jfx.wizard.ValidationResultsController;
@@ -47,6 +48,7 @@ import org.pankratzlab.unet.model.ValidationTable;
 import org.pankratzlab.unet.validation.ValidationTestFileSet;
 import org.pankratzlab.unet.validation.ValidationTesting;
 import org.pankratzlab.unet.validation.ValidationTesting.TestLoadingResults;
+import com.dlsc.preferencesfx.PreferencesFx;
 import com.google.common.base.Strings;
 import com.google.common.collect.Table;
 import javafx.application.Platform;
@@ -98,6 +100,12 @@ public class LandingController {
   private Label menuVersionLabel;
 
   private String version;
+
+  @FXML
+  void editPreferences() {
+    PreferencesFx.of(new DCProperty.PropertiesStorageHandler(), DCProperty.getTopLevelCategories())
+        .show(true);
+  }
 
   @FXML
   void fileQuitAction(ActionEvent event) {

--- a/src/main/java/org/pankratzlab/unet/jfx/LandingController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/LandingController.java
@@ -29,9 +29,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.concurrent.ExecutionException;
-
 import javax.annotation.Nullable;
-
 import org.controlsfx.dialog.Wizard;
 import org.controlsfx.dialog.Wizard.LinearFlow;
 import org.controlsfx.dialog.WizardPane;
@@ -50,11 +48,9 @@ import org.pankratzlab.unet.model.ValidationTable;
 import org.pankratzlab.unet.validation.ValidationTestFileSet;
 import org.pankratzlab.unet.validation.ValidationTesting;
 import org.pankratzlab.unet.validation.ValidationTesting.TestLoadingResults;
-
 import com.dlsc.preferencesfx.PreferencesFx;
 import com.google.common.base.Strings;
 import com.google.common.collect.Table;
-
 import javafx.application.Platform;
 import javafx.concurrent.Task;
 import javafx.concurrent.WorkerStateEvent;
@@ -77,10 +73,8 @@ import javafx.stage.Window;
 /** Controller instance for the main user page. Validation wizards can be launched from here. */
 public class LandingController {
 
-  private static final String WEBSITE_DONORCHECK_GITHUB =
-      "https://github.com/PankratzLab/DonorCheck";
-  private static final String WEBSITE_COMP_PATH =
-      "https://med.umn.edu/pathology/research/computational-pathology";
+  private static final String WEBSITE_DONORCHECK_GITHUB = "https://github.com/PankratzLab/DonorCheck";
+  private static final String WEBSITE_COMP_PATH = "https://med.umn.edu/pathology/research/computational-pathology";
   private static final String UNET_BASE_DIR_PROP = "unet.base.dir";
   private static final String MACUI_ENTRY = "/MACUIConversionPanel.fxml";
 
@@ -88,22 +82,26 @@ public class LandingController {
   static final String RESULTS_STEP = "/ValidationResults.fxml";
   private static final String TESTING_MGMT = "/ValidationTestMgmt.fxml";
 
-  @FXML private ResourceBundle resources;
+  @FXML
+  private ResourceBundle resources;
 
-  @FXML private URL location;
+  @FXML
+  private URL location;
 
-  @FXML private BorderPane rootPane;
+  @FXML
+  private BorderPane rootPane;
 
-  @FXML private Label versionLabel;
+  @FXML
+  private Label versionLabel;
 
-  @FXML private Label menuVersionLabel;
+  @FXML
+  private Label menuVersionLabel;
 
   private String version;
 
   @FXML
   void editPreferences() {
-    PreferencesFx.of(new DCProperty.PropertiesStorageHandler(), DCProperty.getTopLevelCategories())
-        .show(true);
+    PreferencesFx.of(new DCProperty.PropertiesStorageHandler(), DCProperty.getTopLevelCategories()).show(true);
   }
 
   @FXML
@@ -134,104 +132,82 @@ public class LandingController {
 
   @FXML
   void manageTestingFiles(ActionEvent event) {
-    Task<TestLoadingResults> manageValidationTask =
-        JFXUtilHelper.createProgressTask(
-            () -> {
-              // first, load the test data
-              try {
-                TestLoadingResults validationDirectory =
-                    ValidationTesting.loadValidationDirectory();
+    Task<TestLoadingResults> manageValidationTask = JFXUtilHelper.createProgressTask(() -> {
+      // first, load the test data
+      try {
+        TestLoadingResults validationDirectory = ValidationTesting.loadValidationDirectory();
 
-                return validationDirectory;
-              } catch (Exception e1) {
-                e1.printStackTrace();
-                Alert alert1 =
-                    new Alert(
-                        AlertType.ERROR,
-                        "Error loading test data: " + e1.getMessage(),
-                        ButtonType.CLOSE);
-                alert1.setTitle("Error");
-                alert1.setHeaderText("");
-                alert1.showAndWait();
-                throw new IllegalStateException("Error loading test data: " + e1.getMessage());
-              }
-            });
+        return validationDirectory;
+      } catch (Exception e1) {
+        e1.printStackTrace();
+        Alert alert1 = new Alert(AlertType.ERROR, "Error loading test data: " + e1.getMessage(), ButtonType.CLOSE);
+        alert1.setTitle("Error");
+        alert1.setHeaderText("");
+        alert1.showAndWait();
+        throw new IllegalStateException("Error loading test data: " + e1.getMessage());
+      }
+    });
 
-    EventHandler<WorkerStateEvent> doValidation =
-        e -> {
-          Platform.runLater(
-              () -> {
-                TestLoadingResults testLoad;
-                try {
-                  testLoad = manageValidationTask.get();
-                } catch (Exception e1) {
-                  e1.printStackTrace();
-                  Alert alert1 =
-                      new Alert(
-                          AlertType.ERROR,
-                          "Error loading test data: " + e1.getMessage(),
-                          ButtonType.CLOSE);
-                  alert1.setTitle("Error");
-                  alert1.setHeaderText("");
-                  alert1.showAndWait();
-                  return;
-                }
+    EventHandler<WorkerStateEvent> doValidation = e -> {
+      Platform.runLater(() -> {
+        TestLoadingResults testLoad;
+        try {
+          testLoad = manageValidationTask.get();
+        } catch (Exception e1) {
+          e1.printStackTrace();
+          Alert alert1 = new Alert(AlertType.ERROR, "Error loading test data: " + e1.getMessage(), ButtonType.CLOSE);
+          alert1.setTitle("Error");
+          alert1.setHeaderText("");
+          alert1.showAndWait();
+          return;
+        }
 
-                if (testLoad.invalidTests.size() > 0) {
-                  Alert alert1 = new Alert(AlertType.ERROR);
-                  alert1.getButtonTypes().add(ButtonType.CLOSE);
+        if (testLoad.invalidTests.size() > 0) {
+          Alert alert1 = new Alert(AlertType.ERROR);
+          alert1.getButtonTypes().add(ButtonType.CLOSE);
 
-                  String content =
-                      "Please remove the listed tests manually from this directory: \n\n"
-                          + ValidationTesting.VALIDATION_DIRECTORY
-                          + "\n";
-                  for (String invalidTest : testLoad.invalidTests) {
-                    content += "\n" + invalidTest;
-                  }
-                  TextArea textArea = new TextArea(content);
-                  textArea.setEditable(false);
-                  textArea.setWrapText(true);
+          String content = "Please remove the listed tests manually from this directory: \n\n" + ValidationTesting.VALIDATION_DIRECTORY + "\n";
+          for (String invalidTest : testLoad.invalidTests) {
+            content += "\n" + invalidTest;
+          }
+          TextArea textArea = new TextArea(content);
+          textArea.setEditable(false);
+          textArea.setWrapText(true);
 
-                  alert1.setTitle("Error loading tests");
-                  alert1.setHeaderText("Failed to Load " + testLoad.invalidTests.size() + " Tests");
-                  alert1.getDialogPane().setContent(textArea);
-                  alert1.setResizable(true);
-                  alert1.showAndWait();
-                }
+          alert1.setTitle("Error loading tests");
+          alert1.setHeaderText("Failed to Load " + testLoad.invalidTests.size() + " Tests");
+          alert1.getDialogPane().setContent(textArea);
+          alert1.setResizable(true);
+          alert1.showAndWait();
+        }
 
-                Table<SOURCE, String, List<ValidationTestFileSet>> testData = testLoad.testSets;
+        Table<SOURCE, String, List<ValidationTestFileSet>> testData = testLoad.testSets;
 
-                BatchTestMgmtController controller = new BatchTestMgmtController();
+        BatchTestMgmtController controller = new BatchTestMgmtController();
 
-                FXMLLoader loader =
-                    new FXMLLoader(LandingController.class.getResource(TESTING_MGMT));
-                loader.setController(controller);
+        FXMLLoader loader = new FXMLLoader(LandingController.class.getResource(TESTING_MGMT));
+        loader.setController(controller);
 
-                Scene newScene;
-                try {
-                  newScene = new Scene(loader.load());
-                  Stage inputStage = new Stage();
-                  inputStage.initOwner(rootPane.getScene().getWindow());
-                  inputStage.initModality(Modality.APPLICATION_MODAL);
-                  inputStage.setTitle(
-                      "DonorCheck " + (version.isEmpty() ? "" : version) + ": batch validation");
-                  inputStage.setResizable(true);
-                  inputStage.setScene(newScene);
-                  controller.setTable(testData);
-                  inputStage.showAndWait();
-                } catch (IOException e1) {
-                  e1.printStackTrace();
-                  Alert alert1 =
-                      new Alert(
-                          AlertType.ERROR,
-                          "Error loading test data: " + e1.getMessage(),
-                          ButtonType.CLOSE);
-                  alert1.setTitle("Error");
-                  alert1.setHeaderText("");
-                  alert1.showAndWait();
-                }
-              });
-        };
+        Scene newScene;
+        try {
+          newScene = new Scene(loader.load());
+          Stage inputStage = new Stage();
+          inputStage.initOwner(rootPane.getScene().getWindow());
+          inputStage.initModality(Modality.APPLICATION_MODAL);
+          inputStage.setTitle("DonorCheck " + (version.isEmpty() ? "" : version) + ": batch validation");
+          inputStage.setResizable(true);
+          inputStage.setScene(newScene);
+          controller.setTable(testData);
+          inputStage.showAndWait();
+        } catch (IOException e1) {
+          e1.printStackTrace();
+          Alert alert1 = new Alert(AlertType.ERROR, "Error loading test data: " + e1.getMessage(), ButtonType.CLOSE);
+          alert1.setTitle("Error");
+          alert1.setHeaderText("");
+          alert1.showAndWait();
+        }
+      });
+    };
 
     manageValidationTask.addEventHandler(WorkerStateEvent.WORKER_STATE_SUCCEEDED, doValidation);
 
@@ -240,43 +216,36 @@ public class LandingController {
 
   @FXML
   void runTesting(ActionEvent event) {
-    Task<List<ValidationTestFileSet>> loadTestsTask =
-        JFXUtilHelper.createProgressTask(
-            () -> {
-              TestLoadingResults tests = ValidationTesting.loadValidationDirectory();
+    Task<List<ValidationTestFileSet>> loadTestsTask = JFXUtilHelper.createProgressTask(() -> {
+      TestLoadingResults tests = ValidationTesting.loadValidationDirectory();
 
-              List<ValidationTestFileSet> allTests = new ArrayList<>();
-              for (String relFile : tests.testSets.columnKeySet()) {
-                for (SOURCE cwd : tests.testSets.column(relFile).keySet()) {
-                  allTests.addAll(tests.testSets.get(cwd, relFile));
-                }
-              }
+      List<ValidationTestFileSet> allTests = new ArrayList<>();
+      for (String relFile : tests.testSets.columnKeySet()) {
+        for (SOURCE cwd : tests.testSets.column(relFile).keySet()) {
+          allTests.addAll(tests.testSets.get(cwd, relFile));
+        }
+      }
 
-              allTests = ValidationTesting.sortTests(allTests);
+      allTests = ValidationTesting.sortTests(allTests);
 
-              return allTests;
-            });
+      return allTests;
+    });
 
-    EventHandler<WorkerStateEvent> doValidation =
-        e -> {
-          List<ValidationTestFileSet> allTests;
-          try {
-            allTests = loadTestsTask.get();
-          } catch (InterruptedException | ExecutionException e1) {
-            e1.printStackTrace();
-            Alert alert1 =
-                new Alert(
-                    AlertType.ERROR,
-                    "Error loading test data: " + e1.getMessage(),
-                    ButtonType.CLOSE);
-            alert1.setTitle("Error");
-            alert1.setHeaderText("");
-            alert1.showAndWait();
-            return;
-          }
+    EventHandler<WorkerStateEvent> doValidation = e -> {
+      List<ValidationTestFileSet> allTests;
+      try {
+        allTests = loadTestsTask.get();
+      } catch (InterruptedException | ExecutionException e1) {
+        e1.printStackTrace();
+        Alert alert1 = new Alert(AlertType.ERROR, "Error loading test data: " + e1.getMessage(), ButtonType.CLOSE);
+        alert1.setTitle("Error");
+        alert1.setHeaderText("");
+        alert1.showAndWait();
+        return;
+      }
 
-          ValidationTesting.runTests(allTests);
-        };
+      ValidationTesting.runTests(rootPane, allTests);
+    };
 
     loadTestsTask.addEventHandler(WorkerStateEvent.WORKER_STATE_SUCCEEDED, doValidation);
 
@@ -325,72 +294,59 @@ public class LandingController {
     // The way DonorCheck is set up, "validation" is run in two parts
 
     // The first is the actual task we're running, which is to check/initialize the haplotype freqs
-    Task<Void> runValidationTask =
-        JFXUtilHelper.createProgressTask(
-            () -> {
-              HaplotypeFrequencies.successfullyInitialized();
-            });
+    Task<Void> runValidationTask = JFXUtilHelper.createProgressTask(() -> {
+      HaplotypeFrequencies.successfullyInitialized();
+    });
 
     // Then we set up the actual file validation as an event that triggers
     // in response to the success of the haplotypes initialization task above
-    EventHandler<WorkerStateEvent> doValidation =
-        (w) -> {
+    EventHandler<WorkerStateEvent> doValidation = (w) -> {
 
-          // Don't actually run this as an event, though - make it a runnable on the JFX App thread
-          Platform.runLater(
-              () -> {
-                if (!HaplotypeFrequencies.successfullyInitialized().get()) {
-                  Alert alert =
-                      new Alert(
-                          AlertType.INFORMATION,
-                          "Haplotype frequency tables are not found or are invalid, and thus frequency data will not be displayed.\n\n"
-                              + "Would you like to set these tables now?\n\n"
-                              + "Note: you can adjust these tables any time from the 'Haplotype' menu",
-                          ButtonType.YES,
-                          ButtonType.NO);
-                  alert.setTitle("No haplotype frequencies");
-                  alert.setHeaderText("");
-                  alert
-                      .showAndWait()
-                      .filter(response -> response == ButtonType.YES)
-                      .ifPresent(response -> chooseFreqTables(event));
-                } else if (!Strings.isNullOrEmpty(HaplotypeFrequencies.getMissingTableMessage())) {
-                  Alert alert =
-                      new Alert(
-                          AlertType.INFORMATION, HaplotypeFrequencies.getMissingTableMessage());
-                  alert.setTitle("Missing haplotype table(s)");
-                  alert.setHeaderText("");
-                  alert.showAndWait();
-                }
+      // Don't actually run this as an event, though - make it a runnable on the JFX App thread
+      Platform.runLater(() -> {
+        if (!HaplotypeFrequencies.successfullyInitialized().get()) {
+          Alert alert = new Alert(AlertType.INFORMATION,
+              "Haplotype frequency tables are not found or are invalid, and thus frequency data will not be displayed.\n\n"
+                  + "Would you like to set these tables now?\n\n" + "Note: you can adjust these tables any time from the 'Haplotype' menu",
+              ButtonType.YES, ButtonType.NO);
+          alert.setTitle("No haplotype frequencies");
+          alert.setHeaderText("");
+          alert.showAndWait().filter(response -> response == ButtonType.YES).ifPresent(response -> chooseFreqTables(event));
+        } else if (!Strings.isNullOrEmpty(HaplotypeFrequencies.getMissingTableMessage())) {
+          Alert alert = new Alert(AlertType.INFORMATION, HaplotypeFrequencies.getMissingTableMessage());
+          alert.setTitle("Missing haplotype table(s)");
+          alert.setHeaderText("");
+          alert.showAndWait();
+        }
 
-                CommonWellDocumented.initFromProperty();
+        CommonWellDocumented.initFromProperty();
 
-                ValidationTable table = new ValidationTable();
-                final Scene scene = ((Node) event.getSource()).getScene();
+        ValidationTable table = new ValidationTable();
+        final Scene scene = ((Node) event.getSource()).getScene();
 
-                final Window window = scene.getWindow();
-                Wizard validationWizard = new Wizard(window);
-                validationWizard.setTitle("DonorCheck " + (version.isEmpty() ? "" : version));
+        final Window window = scene.getWindow();
+        Wizard validationWizard = new Wizard(window);
+        validationWizard.setTitle("DonorCheck " + (version.isEmpty() ? "" : version));
 
-                List<WizardPane> pages = new ArrayList<>();
-                try {
-                  makePage(pages, table, INPUT_STEP, new FileInputController());
-                  makePage(pages, table, RESULTS_STEP, new ValidationResultsController());
-                } catch (IOException e) {
-                  e.printStackTrace();
-                  throw new IllegalStateException(e);
-                }
+        List<WizardPane> pages = new ArrayList<>();
+        try {
+          makePage(pages, table, INPUT_STEP, new FileInputController());
+          makePage(pages, table, RESULTS_STEP, new ValidationResultsController());
+        } catch (IOException e) {
+          e.printStackTrace();
+          throw new IllegalStateException(e);
+        }
 
-                pages.get(0).getButtonTypes();
+        pages.get(0).getButtonTypes();
 
-                Wizard.Flow pageFlow = new LinearFlow(pages);
+        Wizard.Flow pageFlow = new LinearFlow(pages);
 
-                validationWizard.setFlow(pageFlow);
+        validationWizard.setFlow(pageFlow);
 
-                // show wizard and wait for response
-                validationWizard.showAndWait();
-              });
-        };
+        // show wizard and wait for response
+        validationWizard.showAndWait();
+      });
+    };
 
     runValidationTask.addEventHandler(WorkerStateEvent.WORKER_STATE_SUCCEEDED, doValidation);
 
@@ -404,9 +360,7 @@ public class LandingController {
    * @param controller Controller instance to attach to this page
    * @throws IOException If errors during FXML reading
    */
-  public static void makePage(
-      List<WizardPane> pages, @Nullable ValidationTable table, String pageFXML, Object controller)
-      throws IOException {
+  public static void makePage(List<WizardPane> pages, @Nullable ValidationTable table, String pageFXML, Object controller) throws IOException {
     try (InputStream is = TypeValidationApp.class.getResourceAsStream(pageFXML)) {
       FXMLLoader loader = new FXMLLoader();
       // NB: reading the controller from FMXL can cause problems
@@ -426,8 +380,7 @@ public class LandingController {
 
   @FXML
   void initialize() {
-    assert rootPane != null
-        : "fx:id=\"rootPane\" was not injected: check your FXML file 'TypeValidationLanding.fxml'.";
+    assert rootPane != null : "fx:id=\"rootPane\" was not injected: check your FXML file 'TypeValidationLanding.fxml'.";
 
     version = Info.getVersion();
     versionLabel.setText("Version: " + version + " ");

--- a/src/main/java/org/pankratzlab/unet/jfx/LandingController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/LandingController.java
@@ -29,7 +29,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.concurrent.ExecutionException;
+
 import javax.annotation.Nullable;
+
 import org.controlsfx.dialog.Wizard;
 import org.controlsfx.dialog.Wizard.LinearFlow;
 import org.controlsfx.dialog.WizardPane;
@@ -48,9 +50,11 @@ import org.pankratzlab.unet.model.ValidationTable;
 import org.pankratzlab.unet.validation.ValidationTestFileSet;
 import org.pankratzlab.unet.validation.ValidationTesting;
 import org.pankratzlab.unet.validation.ValidationTesting.TestLoadingResults;
+
 import com.dlsc.preferencesfx.PreferencesFx;
 import com.google.common.base.Strings;
 import com.google.common.collect.Table;
+
 import javafx.application.Platform;
 import javafx.concurrent.Task;
 import javafx.concurrent.WorkerStateEvent;
@@ -84,20 +88,15 @@ public class LandingController {
   static final String RESULTS_STEP = "/ValidationResults.fxml";
   private static final String TESTING_MGMT = "/ValidationTestMgmt.fxml";
 
-  @FXML
-  private ResourceBundle resources;
+  @FXML private ResourceBundle resources;
 
-  @FXML
-  private URL location;
+  @FXML private URL location;
 
-  @FXML
-  private BorderPane rootPane;
+  @FXML private BorderPane rootPane;
 
-  @FXML
-  private Label versionLabel;
+  @FXML private Label versionLabel;
 
-  @FXML
-  private Label menuVersionLabel;
+  @FXML private Label menuVersionLabel;
 
   private String version;
 
@@ -135,127 +134,149 @@ public class LandingController {
 
   @FXML
   void manageTestingFiles(ActionEvent event) {
-    Task<TestLoadingResults> manageValidationTask = JFXUtilHelper.createProgressTask(() -> {
-      // first, load the test data
-      try {
-        TestLoadingResults validationDirectory = ValidationTesting.loadValidationDirectory();
+    Task<TestLoadingResults> manageValidationTask =
+        JFXUtilHelper.createProgressTask(
+            () -> {
+              // first, load the test data
+              try {
+                TestLoadingResults validationDirectory =
+                    ValidationTesting.loadValidationDirectory();
 
-        return validationDirectory;
-      } catch (Exception e1) {
-        e1.printStackTrace();
-        Alert alert1 = new Alert(AlertType.ERROR, "Error loading test data: " + e1.getMessage(),
-            ButtonType.CLOSE);
-        alert1.setTitle("Error");
-        alert1.setHeaderText("");
-        alert1.showAndWait();
-        throw new IllegalStateException("Error loading test data: " + e1.getMessage());
-      }
-    });
+                return validationDirectory;
+              } catch (Exception e1) {
+                e1.printStackTrace();
+                Alert alert1 =
+                    new Alert(
+                        AlertType.ERROR,
+                        "Error loading test data: " + e1.getMessage(),
+                        ButtonType.CLOSE);
+                alert1.setTitle("Error");
+                alert1.setHeaderText("");
+                alert1.showAndWait();
+                throw new IllegalStateException("Error loading test data: " + e1.getMessage());
+              }
+            });
 
-    EventHandler<WorkerStateEvent> doValidation = e -> {
-      Platform.runLater(() -> {
-        TestLoadingResults testLoad;
-        try {
-          testLoad = manageValidationTask.get();
-        } catch (Exception e1) {
-          e1.printStackTrace();
-          Alert alert1 = new Alert(AlertType.ERROR, "Error loading test data: " + e1.getMessage(),
-              ButtonType.CLOSE);
-          alert1.setTitle("Error");
-          alert1.setHeaderText("");
-          alert1.showAndWait();
-          return;
-        }
+    EventHandler<WorkerStateEvent> doValidation =
+        e -> {
+          Platform.runLater(
+              () -> {
+                TestLoadingResults testLoad;
+                try {
+                  testLoad = manageValidationTask.get();
+                } catch (Exception e1) {
+                  e1.printStackTrace();
+                  Alert alert1 =
+                      new Alert(
+                          AlertType.ERROR,
+                          "Error loading test data: " + e1.getMessage(),
+                          ButtonType.CLOSE);
+                  alert1.setTitle("Error");
+                  alert1.setHeaderText("");
+                  alert1.showAndWait();
+                  return;
+                }
 
-        if (testLoad.invalidTests.size() > 0) {
-          Alert alert1 = new Alert(AlertType.ERROR);
-          alert1.getButtonTypes().add(ButtonType.CLOSE);
+                if (testLoad.invalidTests.size() > 0) {
+                  Alert alert1 = new Alert(AlertType.ERROR);
+                  alert1.getButtonTypes().add(ButtonType.CLOSE);
 
-          String content = "Please remove the listed tests manually from this directory: \n\n"
-              + ValidationTesting.VALIDATION_DIRECTORY + "\n";
-          for (String invalidTest : testLoad.invalidTests) {
-            content += "\n" + invalidTest;
-          }
-          TextArea textArea = new TextArea(content);
-          textArea.setEditable(false);
-          textArea.setWrapText(true);
+                  String content =
+                      "Please remove the listed tests manually from this directory: \n\n"
+                          + ValidationTesting.VALIDATION_DIRECTORY
+                          + "\n";
+                  for (String invalidTest : testLoad.invalidTests) {
+                    content += "\n" + invalidTest;
+                  }
+                  TextArea textArea = new TextArea(content);
+                  textArea.setEditable(false);
+                  textArea.setWrapText(true);
 
-          alert1.setTitle("Error loading tests");
-          alert1.setHeaderText("Failed to Load " + testLoad.invalidTests.size() + " Tests");
-          alert1.getDialogPane().setContent(textArea);
-          alert1.setResizable(true);
-          alert1.showAndWait();
-        }
+                  alert1.setTitle("Error loading tests");
+                  alert1.setHeaderText("Failed to Load " + testLoad.invalidTests.size() + " Tests");
+                  alert1.getDialogPane().setContent(textArea);
+                  alert1.setResizable(true);
+                  alert1.showAndWait();
+                }
 
-        Table<SOURCE, String, List<ValidationTestFileSet>> testData = testLoad.testSets;
+                Table<SOURCE, String, List<ValidationTestFileSet>> testData = testLoad.testSets;
 
-        BatchTestMgmtController controller = new BatchTestMgmtController();
+                BatchTestMgmtController controller = new BatchTestMgmtController();
 
-        FXMLLoader loader = new FXMLLoader(LandingController.class.getResource(TESTING_MGMT));
-        loader.setController(controller);
+                FXMLLoader loader =
+                    new FXMLLoader(LandingController.class.getResource(TESTING_MGMT));
+                loader.setController(controller);
 
-        Scene newScene;
-        try {
-          newScene = new Scene(loader.load());
-          Stage inputStage = new Stage();
-          inputStage.initOwner(rootPane.getScene().getWindow());
-          inputStage.initModality(Modality.APPLICATION_MODAL);
-          inputStage
-              .setTitle("DonorCheck " + (version.isEmpty() ? "" : version) + ": batch validation");
-          inputStage.setResizable(true);
-          inputStage.setScene(newScene);
-          controller.setTable(testData);
-          inputStage.showAndWait();
-        } catch (IOException e1) {
-          e1.printStackTrace();
-          Alert alert1 = new Alert(AlertType.ERROR, "Error loading test data: " + e1.getMessage(),
-              ButtonType.CLOSE);
-          alert1.setTitle("Error");
-          alert1.setHeaderText("");
-          alert1.showAndWait();
-        }
-      });
-    };
+                Scene newScene;
+                try {
+                  newScene = new Scene(loader.load());
+                  Stage inputStage = new Stage();
+                  inputStage.initOwner(rootPane.getScene().getWindow());
+                  inputStage.initModality(Modality.APPLICATION_MODAL);
+                  inputStage.setTitle(
+                      "DonorCheck " + (version.isEmpty() ? "" : version) + ": batch validation");
+                  inputStage.setResizable(true);
+                  inputStage.setScene(newScene);
+                  controller.setTable(testData);
+                  inputStage.showAndWait();
+                } catch (IOException e1) {
+                  e1.printStackTrace();
+                  Alert alert1 =
+                      new Alert(
+                          AlertType.ERROR,
+                          "Error loading test data: " + e1.getMessage(),
+                          ButtonType.CLOSE);
+                  alert1.setTitle("Error");
+                  alert1.setHeaderText("");
+                  alert1.showAndWait();
+                }
+              });
+        };
 
     manageValidationTask.addEventHandler(WorkerStateEvent.WORKER_STATE_SUCCEEDED, doValidation);
-
 
     new Thread(manageValidationTask).start();
   }
 
   @FXML
   void runTesting(ActionEvent event) {
-    Task<List<ValidationTestFileSet>> loadTestsTask = JFXUtilHelper.createProgressTask(() -> {
-      TestLoadingResults tests = ValidationTesting.loadValidationDirectory();
+    Task<List<ValidationTestFileSet>> loadTestsTask =
+        JFXUtilHelper.createProgressTask(
+            () -> {
+              TestLoadingResults tests = ValidationTesting.loadValidationDirectory();
 
-      List<ValidationTestFileSet> allTests = new ArrayList<>();
-      for (String relFile : tests.testSets.columnKeySet()) {
-        for (SOURCE cwd : tests.testSets.column(relFile).keySet()) {
-          allTests.addAll(tests.testSets.get(cwd, relFile));
-        }
-      }
+              List<ValidationTestFileSet> allTests = new ArrayList<>();
+              for (String relFile : tests.testSets.columnKeySet()) {
+                for (SOURCE cwd : tests.testSets.column(relFile).keySet()) {
+                  allTests.addAll(tests.testSets.get(cwd, relFile));
+                }
+              }
 
-      allTests = ValidationTesting.sortTests(allTests);
+              allTests = ValidationTesting.sortTests(allTests);
 
-      return allTests;
-    });
+              return allTests;
+            });
 
-    EventHandler<WorkerStateEvent> doValidation = e -> {
-      List<ValidationTestFileSet> allTests;
-      try {
-        allTests = loadTestsTask.get();
-      } catch (InterruptedException | ExecutionException e1) {
-        e1.printStackTrace();
-        Alert alert1 = new Alert(AlertType.ERROR, "Error loading test data: " + e1.getMessage(),
-            ButtonType.CLOSE);
-        alert1.setTitle("Error");
-        alert1.setHeaderText("");
-        alert1.showAndWait();
-        return;
-      }
+    EventHandler<WorkerStateEvent> doValidation =
+        e -> {
+          List<ValidationTestFileSet> allTests;
+          try {
+            allTests = loadTestsTask.get();
+          } catch (InterruptedException | ExecutionException e1) {
+            e1.printStackTrace();
+            Alert alert1 =
+                new Alert(
+                    AlertType.ERROR,
+                    "Error loading test data: " + e1.getMessage(),
+                    ButtonType.CLOSE);
+            alert1.setTitle("Error");
+            alert1.setHeaderText("");
+            alert1.showAndWait();
+            return;
+          }
 
-      ValidationTesting.runTests(allTests);
-    };
+          ValidationTesting.runTests(allTests);
+        };
 
     loadTestsTask.addEventHandler(WorkerStateEvent.WORKER_STATE_SUCCEEDED, doValidation);
 
@@ -304,62 +325,72 @@ public class LandingController {
     // The way DonorCheck is set up, "validation" is run in two parts
 
     // The first is the actual task we're running, which is to check/initialize the haplotype freqs
-    Task<Void> runValidationTask = JFXUtilHelper.createProgressTask(() -> {
-      HaplotypeFrequencies.successfullyInitialized();
-    });
+    Task<Void> runValidationTask =
+        JFXUtilHelper.createProgressTask(
+            () -> {
+              HaplotypeFrequencies.successfullyInitialized();
+            });
 
     // Then we set up the actual file validation as an event that triggers
     // in response to the success of the haplotypes initialization task above
-    EventHandler<WorkerStateEvent> doValidation = (w) -> {
+    EventHandler<WorkerStateEvent> doValidation =
+        (w) -> {
 
-      // Don't actually run this as an event, though - make it a runnable on the JFX App thread
-      Platform.runLater(() -> {
-        if (!HaplotypeFrequencies.successfullyInitialized()) {
-          Alert alert = new Alert(AlertType.INFORMATION,
-              "Haplotype frequency tables are not found or are invalid, and thus frequency data will not be displayed.\n\n"
-                  + "Would you like to set these tables now?\n\n"
-                  + "Note: you can adjust these tables any time from the 'Haplotype' menu",
-              ButtonType.YES, ButtonType.NO);
-          alert.setTitle("No haplotype frequencies");
-          alert.setHeaderText("");
-          alert.showAndWait().filter(response -> response == ButtonType.YES)
-              .ifPresent(response -> chooseFreqTables(event));
-        } else if (!Strings.isNullOrEmpty(HaplotypeFrequencies.getMissingTableMessage())) {
-          Alert alert =
-              new Alert(AlertType.INFORMATION, HaplotypeFrequencies.getMissingTableMessage());
-          alert.setTitle("Missing haplotype table(s)");
-          alert.setHeaderText("");
-          alert.showAndWait();
-        }
+          // Don't actually run this as an event, though - make it a runnable on the JFX App thread
+          Platform.runLater(
+              () -> {
+                if (!HaplotypeFrequencies.successfullyInitialized().get()) {
+                  Alert alert =
+                      new Alert(
+                          AlertType.INFORMATION,
+                          "Haplotype frequency tables are not found or are invalid, and thus frequency data will not be displayed.\n\n"
+                              + "Would you like to set these tables now?\n\n"
+                              + "Note: you can adjust these tables any time from the 'Haplotype' menu",
+                          ButtonType.YES,
+                          ButtonType.NO);
+                  alert.setTitle("No haplotype frequencies");
+                  alert.setHeaderText("");
+                  alert
+                      .showAndWait()
+                      .filter(response -> response == ButtonType.YES)
+                      .ifPresent(response -> chooseFreqTables(event));
+                } else if (!Strings.isNullOrEmpty(HaplotypeFrequencies.getMissingTableMessage())) {
+                  Alert alert =
+                      new Alert(
+                          AlertType.INFORMATION, HaplotypeFrequencies.getMissingTableMessage());
+                  alert.setTitle("Missing haplotype table(s)");
+                  alert.setHeaderText("");
+                  alert.showAndWait();
+                }
 
-        CommonWellDocumented.initFromProperty();
+                CommonWellDocumented.initFromProperty();
 
-        ValidationTable table = new ValidationTable();
-        final Scene scene = ((Node) event.getSource()).getScene();
+                ValidationTable table = new ValidationTable();
+                final Scene scene = ((Node) event.getSource()).getScene();
 
-        final Window window = scene.getWindow();
-        Wizard validationWizard = new Wizard(window);
-        validationWizard.setTitle("DonorCheck " + (version.isEmpty() ? "" : version));
+                final Window window = scene.getWindow();
+                Wizard validationWizard = new Wizard(window);
+                validationWizard.setTitle("DonorCheck " + (version.isEmpty() ? "" : version));
 
-        List<WizardPane> pages = new ArrayList<>();
-        try {
-          makePage(pages, table, INPUT_STEP, new FileInputController());
-          makePage(pages, table, RESULTS_STEP, new ValidationResultsController());
-        } catch (IOException e) {
-          e.printStackTrace();
-          throw new IllegalStateException(e);
-        }
+                List<WizardPane> pages = new ArrayList<>();
+                try {
+                  makePage(pages, table, INPUT_STEP, new FileInputController());
+                  makePage(pages, table, RESULTS_STEP, new ValidationResultsController());
+                } catch (IOException e) {
+                  e.printStackTrace();
+                  throw new IllegalStateException(e);
+                }
 
-        pages.get(0).getButtonTypes();
+                pages.get(0).getButtonTypes();
 
-        Wizard.Flow pageFlow = new LinearFlow(pages);
+                Wizard.Flow pageFlow = new LinearFlow(pages);
 
-        validationWizard.setFlow(pageFlow);
+                validationWizard.setFlow(pageFlow);
 
-        // show wizard and wait for response
-        validationWizard.showAndWait();
-      });
-    };
+                // show wizard and wait for response
+                validationWizard.showAndWait();
+              });
+        };
 
     runValidationTask.addEventHandler(WorkerStateEvent.WORKER_STATE_SUCCEEDED, doValidation);
 
@@ -373,8 +404,9 @@ public class LandingController {
    * @param controller Controller instance to attach to this page
    * @throws IOException If errors during FXML reading
    */
-  public static void makePage(List<WizardPane> pages, @Nullable ValidationTable table,
-      String pageFXML, Object controller) throws IOException {
+  public static void makePage(
+      List<WizardPane> pages, @Nullable ValidationTable table, String pageFXML, Object controller)
+      throws IOException {
     try (InputStream is = TypeValidationApp.class.getResourceAsStream(pageFXML)) {
       FXMLLoader loader = new FXMLLoader();
       // NB: reading the controller from FMXL can cause problems
@@ -394,7 +426,8 @@ public class LandingController {
 
   @FXML
   void initialize() {
-    assert rootPane != null : "fx:id=\"rootPane\" was not injected: check your FXML file 'TypeValidationLanding.fxml'.";
+    assert rootPane != null
+        : "fx:id=\"rootPane\" was not injected: check your FXML file 'TypeValidationLanding.fxml'.";
 
     version = Info.getVersion();
     versionLabel.setText("Version: " + version + " ");

--- a/src/main/java/org/pankratzlab/unet/jfx/SerotypeLookupFileController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/SerotypeLookupFileController.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 import java.util.ResourceBundle;
 import org.pankratzlab.unet.deprecated.hla.AntigenDictionary;
 import org.pankratzlab.unet.deprecated.hla.CurrentDirectoryProvider;
-import org.pankratzlab.unet.deprecated.hla.HLAProperties;
+import org.pankratzlab.unet.deprecated.hla.DonorCheckProperties;
 import org.pankratzlab.unet.deprecated.jfx.JFXUtilHelper;
 import com.google.common.base.Strings;
 import javafx.beans.property.SimpleStringProperty;
@@ -96,7 +96,7 @@ public class SerotypeLookupFileController {
   /** Link together a local property, text display and global property */
   private void init(StringProperty localProp, TextField tableField, String propertyName) {
     tableField.textProperty().bind(localProp);
-    String fileProp = HLAProperties.get().getProperty(propertyName);
+    String fileProp = DonorCheckProperties.get().getProperty(propertyName);
 
     if (!Strings.isNullOrEmpty(fileProp)) {
       if (!new File(fileProp).exists()) {
@@ -108,7 +108,7 @@ public class SerotypeLookupFileController {
 
     localProp.addListener((obs, o, n) -> {
       if (!Strings.isNullOrEmpty(n) && Files.exists(Paths.get(n))) {
-        HLAProperties.get().setProperty(propertyName, n);
+        DonorCheckProperties.get().setProperty(propertyName, n);
         dirty = true;
       }
     });

--- a/src/main/java/org/pankratzlab/unet/jfx/prop/DCProperty.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/prop/DCProperty.java
@@ -1,0 +1,440 @@
+package org.pankratzlab.unet.jfx.prop;
+
+import static com.dlsc.preferencesfx.util.Constants.DEFAULT_DIVIDER_POSITION;
+import static com.dlsc.preferencesfx.util.Constants.DEFAULT_PREFERENCES_HEIGHT;
+import static com.dlsc.preferencesfx.util.Constants.DEFAULT_PREFERENCES_POS_X;
+import static com.dlsc.preferencesfx.util.Constants.DEFAULT_PREFERENCES_POS_Y;
+import static com.dlsc.preferencesfx.util.Constants.DEFAULT_PREFERENCES_WIDTH;
+import static com.dlsc.preferencesfx.util.Constants.DIVIDER_POSITION;
+import static com.dlsc.preferencesfx.util.Constants.SELECTED_CATEGORY;
+import static com.dlsc.preferencesfx.util.Constants.WINDOW_HEIGHT;
+import static com.dlsc.preferencesfx.util.Constants.WINDOW_POS_X;
+import static com.dlsc.preferencesfx.util.Constants.WINDOW_POS_Y;
+import static com.dlsc.preferencesfx.util.Constants.WINDOW_WIDTH;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.pankratzlab.unet.deprecated.hla.DonorCheckProperties;
+import org.pankratzlab.unet.parser.HtmlDonorParser;
+import org.pankratzlab.unet.parser.PdfDonorParser;
+import org.pankratzlab.unet.parser.XmlDonorParser;
+import com.dlsc.preferencesfx.model.Category;
+import com.dlsc.preferencesfx.model.Setting;
+import com.dlsc.preferencesfx.util.StorageHandler;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+public abstract class DCProperty<T> {
+
+  public enum DCCATEGORY {
+    INPUT_OPTIONS("Input Options"), DATA_SOURCE_OPTIONS("Data Sources");
+
+    private final String categoryName;
+
+    private DCCATEGORY(String categoryName) {
+      this.categoryName = categoryName;
+    }
+
+    public String getCategoryName() {
+      return categoryName;
+    }
+
+  }
+
+  public enum DCSUBCATEGORY {
+
+    SCORE6("SCORE 6");
+
+    private final String groupName;
+
+    private DCSUBCATEGORY(String groupName) {
+      this.groupName = groupName;
+    }
+
+    public String getGroupName() {
+      return groupName;
+    }
+
+  }
+
+  private final String key;
+  private final String name;
+  private final DCCATEGORY category;
+  private final DCSUBCATEGORY group;
+  private final Function<String, Object> fromConverter;
+  private final Function<Object, String> toConverter;
+
+  DCProperty(String key, String name, DCCATEGORY category, DCSUBCATEGORY group,
+      Function<String, Object> fromConverter, Function<Object, String> toConverter) {
+    this.key = key;
+    this.name = name;
+    this.category = category;
+    this.group = group;
+    this.fromConverter = fromConverter;
+    this.toConverter = toConverter;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public DCCATEGORY getCategory() {
+    return category;
+  }
+
+  public DCSUBCATEGORY getGroup() {
+    return group;
+  }
+
+  public Setting getSetting() {
+    Setting s = buildSetting();
+    register(s, this);
+    return s;
+  }
+
+  // abstract methods
+
+  @SuppressWarnings("rawtypes")
+  protected abstract Setting buildSetting();
+
+  public void setStringValue(String value) {
+    setValue((T) fromConverter.apply(value));
+  }
+
+  public abstract void setValue(T value);
+
+
+  public static class DCListProperty<T> extends DCProperty<T> {
+
+    T defaultSelection;
+    T[] possibleValues;
+
+    @SafeVarargs
+    public DCListProperty(String key, String name, DCCATEGORY category, DCSUBCATEGORY group,
+        Function<String, Object> fromConverter, Function<Object, String> toConverter, T value,
+        T... values) {
+      super(key, name, category, group, fromConverter, toConverter);
+      this.defaultSelection = value;
+      this.possibleValues = values;
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    protected Setting buildSetting() {
+      ObservableList<T> list = FXCollections.observableArrayList(possibleValues);
+      SimpleObjectProperty<T> prop = new SimpleObjectProperty<>(defaultSelection);
+      return Setting.of(this.getName(), list, prop).customKey(this.getKey());
+    }
+
+    @Override
+    public void setValue(T value) {
+      this.defaultSelection = value;
+    }
+
+  }
+
+  public final static class DCStringListProperty extends DCListProperty<String> {
+
+    public DCStringListProperty(String key, String name, DCCATEGORY category, DCSUBCATEGORY group,
+        String value, String... values) {
+      super(key, name, category, group, s -> s, s -> s.toString(), value, values);
+    }
+
+  }
+
+  public final static class DCBooleanProperty extends DCProperty<Boolean> {
+
+    boolean defaultValue;
+
+    public DCBooleanProperty(String key, String name, DCCATEGORY category, DCSUBCATEGORY group,
+        boolean value) {
+      super(key, name, category, group, Boolean::parseBoolean, b -> b.toString());
+      this.defaultValue = value;
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    protected Setting buildSetting() {
+      BooleanProperty p = new SimpleBooleanProperty(defaultValue);
+      Setting s = Setting.of(this.getName(), p);
+      s = s.customKey(this.getKey());
+      return s;
+    }
+
+    @Override
+    public void setValue(Boolean value) {
+      this.defaultValue = value;
+    }
+
+  }
+
+  public static final DCStringListProperty FIRST_TYPE =
+      new DCStringListProperty(DonorCheckProperties.FIRST_TYPE,
+          "First source type dropdown default", DCCATEGORY.INPUT_OPTIONS, null,
+          PdfDonorParser.getTypeString(), PdfDonorParser.getTypeString(),
+          XmlDonorParser.getTypeString(), HtmlDonorParser.getTypeString());
+
+  public static final DCStringListProperty SECOND_TYPE =
+      new DCStringListProperty(DonorCheckProperties.SECOND_TYPE,
+          "Second source type dropdown default", DCCATEGORY.INPUT_OPTIONS, null,
+          XmlDonorParser.getTypeString(), PdfDonorParser.getTypeString(),
+          XmlDonorParser.getTypeString(), HtmlDonorParser.getTypeString());
+
+  public static final DCBooleanProperty USE_ALLELE_CALL = new DCBooleanProperty(
+      DonorCheckProperties.USE_ALLELE_CALL, "Use <alleleCall> value if present",
+      DCCATEGORY.DATA_SOURCE_OPTIONS, DCSUBCATEGORY.SCORE6, true);
+
+  private static final List<DCProperty<?>> ALL_PROPS = new ArrayList<>() {
+    {
+      add(FIRST_TYPE);
+      add(SECOND_TYPE);
+      add(USE_ALLELE_CALL);
+    }
+  };
+
+  private static final Map<String, DCProperty<?>> KEY_MAP = new HashMap<>();
+
+  private static Setting register(Setting s, DCProperty p) {
+    s.breadcrumbProperty().addListener((observable, oldValue, newValue) -> {
+      if (oldValue != null && !oldValue.isBlank()) {
+        KEY_MAP.remove(oldValue);
+      }
+      KEY_MAP.put(newValue, p);
+    });
+    KEY_MAP.put(p.getKey(), p);
+    return s;
+  }
+
+  @SuppressWarnings("rawtypes")
+  public static Category[] getTopLevelCategories() {
+    List<Category> all = new ArrayList<>();
+
+    for (DCCATEGORY c : DCCATEGORY.values()) {
+      // find all properties with this category
+      List<DCProperty<?>> catProps =
+          ALL_PROPS.stream().filter(dcp -> dcp.getCategory() == c).collect(Collectors.toList());
+
+      // find all "top-level" properties for this category
+      List<DCProperty<?>> noSubProps =
+          catProps.stream().filter(dcp -> dcp.getGroup() == null).collect(Collectors.toList());
+
+      // final all sub-category properties and group together in-order
+      Multimap<DCSUBCATEGORY, DCProperty<?>> subMap = ArrayListMultimap.create();
+      catProps.stream().filter(dcp -> dcp.getGroup() != null)
+          .forEach(dcp -> subMap.put(dcp.getGroup(), dcp));
+
+      Setting[] topLevel = noSubProps.stream().map(DCProperty::getSetting).toArray(Setting[]::new);
+
+      Category[] subCats = subMap.keySet().stream().sorted().map(subCat -> {
+        Setting[] catLevel =
+            subMap.get(subCat).stream().map(DCProperty::getSetting).toArray(Setting[]::new);
+        return Category.of(subCat.getGroupName(), catLevel);
+      }).toArray(Category[]::new);
+
+      all.add(Category.of(c.getCategoryName(), topLevel).subCategories(subCats));
+    }
+
+    return all.toArray(Category[]::new);
+  }
+
+  public static final class PropertiesStorageHandler implements StorageHandler {
+
+    private static final String DCP = "DCP_";
+
+    Properties preferences;
+
+    public PropertiesStorageHandler() {
+      preferences = DonorCheckProperties.get();
+
+      for (DCProperty<?> dcp : ALL_PROPS) {
+        if (preferences.containsKey(dcp.getKey())) {
+          dcp.setStringValue(preferences.getProperty(dcp.getKey()));
+        }
+      }
+    }
+
+    public void saveSelectedCategory(String breadcrumb) {
+      preferences.setProperty(DCP + SELECTED_CATEGORY, breadcrumb);
+    }
+
+    /**
+     * Gets the last selected category in TreeSearchView.
+     *
+     * @return the breadcrumb string of the selected category. null if none is found
+     */
+    public String loadSelectedCategory() {
+      return preferences.getProperty(DCP + SELECTED_CATEGORY, null);
+    }
+
+    /**
+     * Stores the given divider position of the MasterDetailPane.
+     *
+     * @param dividerPosition the divider position to be stored
+     */
+    public void saveDividerPosition(double dividerPosition) {
+      putDouble(DCP + DIVIDER_POSITION, dividerPosition);
+    }
+
+    /**
+     * Gets the stored divider position of the MasterDetailPane.
+     *
+     * @return the double value of the divider position. 0.2 if none is found
+     */
+    public double loadDividerPosition() {
+      return getDouble(DCP + DIVIDER_POSITION, DEFAULT_DIVIDER_POSITION);
+    }
+
+    /**
+     * Stores the window width of the PreferencesFxDialog.
+     *
+     * @param windowWidth the width of the window to be stored
+     */
+    public void saveWindowWidth(double windowWidth) {
+      putDouble(DCP + WINDOW_WIDTH, windowWidth);
+    }
+
+    /**
+     * Searches for the window width of the PreferencesFxDialog.
+     *
+     * @return the double value of the window width. 1000 if none is found
+     */
+    public double loadWindowWidth() {
+      return getDouble(DCP + WINDOW_WIDTH, DEFAULT_PREFERENCES_WIDTH);
+    }
+
+    /**
+     * Stores the window height of the PreferencesFxDialog.
+     *
+     * @param windowHeight the height of the window to be stored
+     */
+    public void saveWindowHeight(double windowHeight) {
+      putDouble(DCP + WINDOW_HEIGHT, windowHeight);
+    }
+
+    /**
+     * Searches for the window height of the PreferencesFxDialog.
+     *
+     * @return the double value of the window height. 700 if none is found
+     */
+    public double loadWindowHeight() {
+      return getDouble(DCP + WINDOW_HEIGHT, DEFAULT_PREFERENCES_HEIGHT);
+    }
+
+    /**
+     * Stores the position of the PreferencesFxDialog in horizontal orientation.
+     *
+     * @param windowPosX the double value of the window position in horizontal orientation
+     */
+    public void saveWindowPosX(double windowPosX) {
+      putDouble(DCP + WINDOW_POS_X, windowPosX);
+    }
+
+    /**
+     * Searches for the horizontal window position.
+     *
+     * @return the double value of the horizontal window position
+     */
+    public double loadWindowPosX() {
+      return getDouble(DCP + WINDOW_POS_X, DEFAULT_PREFERENCES_POS_X);
+    }
+
+    /**
+     * Stores the position of the PreferencesFxDialog in vertical orientation.
+     *
+     * @param windowPosY the double value of the window position in vertical orientation
+     */
+    public void saveWindowPosY(double windowPosY) {
+      putDouble(DCP + WINDOW_POS_Y, windowPosY);
+    }
+
+    /**
+     * Searches for the vertical window position.
+     *
+     * @return the double value of the vertical window position
+     */
+    public double loadWindowPosY() {
+      return getDouble(DCP + WINDOW_POS_Y, DEFAULT_PREFERENCES_POS_Y);
+    }
+
+    private void putDouble(String key, double value) {
+      preferences.setProperty(key, Double.toString(value));
+    }
+
+    private double getDouble(String key, double defaultValue) {
+      return Double.parseDouble(preferences.getProperty(key, Double.toString(defaultValue)));
+    }
+
+    @Override
+    public void saveObject(String breadcrumb, Object object) {
+      DCProperty dcp = KEY_MAP.get(breadcrumb);
+      Function<Object, String> toF = dcp.toConverter;
+      preferences.setProperty(dcp.getKey(), toF.apply(object));
+    }
+
+    @Override
+    public Object loadObject(String breadcrumb, Object defaultObject) {
+      DCProperty dcp = KEY_MAP.get(breadcrumb);
+      Function<String, Object> fromF = dcp.fromConverter;
+      String p = preferences.getProperty(dcp.getKey());
+      if (p == null)
+        return defaultObject;
+      return fromF.apply(p);
+    }
+
+    @Override
+    public <T> T loadObject(String breadcrumb, Class<T> type, T defaultObject) {
+      DCProperty dcp = KEY_MAP.get(breadcrumb);
+      Function<String, Object> fromF = dcp.fromConverter;
+      String p = preferences.getProperty(dcp.getKey());
+      if (p == null)
+        return defaultObject;
+      return (T) fromF.apply(p);
+    }
+
+    private static final String listSeparator = ";";
+
+    @Override
+    public ObservableList loadObservableList(String breadcrumb,
+        ObservableList defaultObservableList) {
+      DCProperty dcp = KEY_MAP.get(breadcrumb);
+      String p = preferences.getProperty(dcp.getKey());
+      String[] pts = p.split(listSeparator);
+      return FXCollections.observableArrayList(
+          Arrays.stream(pts).map(dcp.fromConverter).collect(Collectors.toList()));
+    }
+
+    @Override
+    public <T> ObservableList<T> loadObservableList(String breadcrumb, Class<T> type,
+        ObservableList<T> defaultObservableList) {
+      DCProperty dcp = KEY_MAP.get(breadcrumb);
+      String p = preferences.getProperty(dcp.getKey());
+      String[] pts = p.split(listSeparator);
+      List<T> cL = Arrays.stream(pts).map(pt -> dcp.fromConverter.apply(pt)).map(o -> type.cast(o))
+          .collect(Collectors.toList());
+      return FXCollections.observableArrayList(cL);
+    }
+
+    @Override
+    public boolean clearPreferences() {
+      preferences.clear();
+      return true;
+    }
+
+  }
+
+
+}

--- a/src/main/java/org/pankratzlab/unet/jfx/wizard/FileInputController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/wizard/FileInputController.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import org.pankratzlab.BackgroundDataProcessor;
 import org.pankratzlab.unet.deprecated.hla.CurrentDirectoryProvider;
+import org.pankratzlab.unet.deprecated.hla.DonorCheckProperties;
 import org.pankratzlab.unet.deprecated.hla.HLALocus;
 import org.pankratzlab.unet.deprecated.hla.LoggingPlaceholder;
 import org.pankratzlab.unet.deprecated.jfx.JFXPropertyHelper;
@@ -89,12 +90,26 @@ public class FileInputController extends AbstractValidatingWizardController {
     invalidBinding = Bindings.createBooleanBinding(() -> selectedFileProperties.isEmpty(),
         selectedFileProperties);
 
-    inputFiles_VBox.getChildren()
-        .add(createFileBox(PdfDonorParser.class, ValidationTable::setFirstModel));
-    inputFiles_VBox.getChildren()
-        .add(createFileBox(XmlDonorParser.class, ValidationTable::setSecondModel));
+    DonorFileParser f = getParser(DonorCheckProperties.get()
+        .getProperty(DonorCheckProperties.FIRST_TYPE, PdfDonorParser.getTypeString()));
+    DonorFileParser s = getParser(DonorCheckProperties.get()
+        .getProperty(DonorCheckProperties.SECOND_TYPE, XmlDonorParser.getTypeString()));
+
+    inputFiles_VBox.getChildren().add(createFileBox(f.getClass(), ValidationTable::setFirstModel));
+    inputFiles_VBox.getChildren().add(createFileBox(s.getClass(), ValidationTable::setSecondModel));
 
     rootPane().setInvalidBinding(invalidBinding);
+  }
+
+  private DonorFileParser getParser(String type) {
+    if (Objects.equals(type, PdfDonorParser.getTypeString())) {
+      return new PdfDonorParser();
+    } else if (Objects.equals(type, XmlDonorParser.getTypeString())) {
+      return new XmlDonorParser();
+    } else if (Objects.equals(type, HtmlDonorParser.getTypeString())) {
+      return new HtmlDonorParser();
+    }
+    return null;
   }
 
   @FXML

--- a/src/main/java/org/pankratzlab/unet/jfx/wizard/OutputCSVConfig.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/wizard/OutputCSVConfig.java
@@ -1,0 +1,72 @@
+package org.pankratzlab.unet.jfx.wizard;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ResourceBundle;
+import org.pankratzlab.unet.validation.ValidationTesting.OutputConfig;
+import javafx.beans.binding.Bindings;
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.TextField;
+import javafx.stage.FileChooser;
+import javafx.stage.FileChooser.ExtensionFilter;
+
+public class OutputCSVConfig {
+
+  @FXML
+  private ResourceBundle resources;
+
+  @FXML
+  private URL location;
+
+  @FXML
+  private CheckBox includeIDs;
+
+  @FXML
+  private CheckBox maskIDs;
+
+  @FXML
+  private TextField outputFileField;
+
+  @FXML
+  private Button selectFileBtn;
+
+  @FXML
+  void initialize() {
+    assert includeIDs != null : "fx:id=\"includeIDs\" was not injected: check your FXML file 'Untitled'.";
+    assert maskIDs != null : "fx:id=\"maskIDs\" was not injected: check your FXML file 'Untitled'.";
+    assert outputFileField != null : "fx:id=\"outputFileField\" was not injected: check your FXML file 'Untitled'.";
+    assert selectFileBtn != null : "fx:id=\"selectFileBtn\" was not injected: check your FXML file 'Untitled'.";
+
+    maskIDs.disableProperty().bind(Bindings.createBooleanBinding(() -> !includeIDs.isSelected(), includeIDs.selectedProperty()));
+
+    selectFileBtn.setOnAction((e) -> {
+      FileChooser fc = new FileChooser();
+      fc.setTitle("Select output file");
+      ExtensionFilter filter = new ExtensionFilter("Excel XLSX file", "*.xlsx");
+      fc.getExtensionFilters().clear();
+      fc.getExtensionFilters().add(filter);
+      fc.setSelectedExtensionFilter(filter);
+      File file = fc.showSaveDialog(outputFileField.getScene().getWindow());
+      if (file != null) {
+        outputFileField.setText(file.getAbsolutePath());
+      }
+    });
+  }
+
+
+
+  public OutputConfig getConfig() {
+    return new OutputConfig(outputFileField.getText(), includeIDs.isSelected(), maskIDs.isSelected());
+  }
+
+
+
+  public void setOKButton(Button okBtn) {
+    ((Button) okBtn).disableProperty().bind(Bindings.createBooleanBinding(() -> {
+      return outputFileField.getText().isEmpty();
+    }, outputFileField.textProperty()));
+  }
+
+}

--- a/src/main/java/org/pankratzlab/unet/jfx/wizard/ValidationResultsController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/wizard/ValidationResultsController.java
@@ -29,7 +29,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.Set;
+
 import javax.imageio.ImageIO;
+
 import org.pankratzlab.unet.deprecated.hla.HLAType;
 import org.pankratzlab.unet.deprecated.hla.NullType;
 import org.pankratzlab.unet.hapstats.CommonWellDocumented;
@@ -42,7 +44,9 @@ import org.pankratzlab.unet.model.ValidationRow;
 import org.pankratzlab.unet.model.ValidationTable;
 import org.pankratzlab.unet.validation.TestInfo;
 import org.pankratzlab.unet.validation.ValidationTesting;
+
 import com.google.common.collect.ImmutableSet;
+
 import javafx.beans.binding.Bindings;
 import javafx.collections.ObservableList;
 import javafx.embed.swing.SwingFXUtils;
@@ -75,99 +79,83 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
   private static final Set<String> HAPLOTYPE_CLASSES =
       ImmutableSet.of(WD_ALLELE_CLASS, UK_ALLELE_CLASS, UNKNOWN_HAPLOTYPE_CLASS);
   private final Label noHapPatientLabel1 = new Label("No haplotype data found for patient.");
-  private final Label noHapDataLabel1 = new Label(
-      " In order to review haplotype frequencies and flag rare haplotypes,\n download data from NMDP or another source.");
+  private final Label noHapDataLabel1 =
+      new Label(
+          " In order to review haplotype frequencies and flag rare haplotypes,\n download data from NMDP or another source.");
   private final Label noHapPatientLabel2 = new Label("No haplotype data found for patient.");
-  private final Label noHapDataLabel2 = new Label(
-      " In order to review haplotype frequencies and flag rare haplotypes,\n download data from NMDP or another source.");
+  private final Label noHapDataLabel2 =
+      new Label(
+          " In order to review haplotype frequencies and flag rare haplotypes,\n download data from NMDP or another source.");
 
-  @FXML
-  private ResourceBundle resources;
+  @FXML private ResourceBundle resources;
 
-  @FXML
-  private URL location;
+  @FXML private URL location;
 
-  @FXML
-  private ValidatingWizardPane rootPane;
+  @FXML private ValidatingWizardPane rootPane;
 
-  @FXML
-  private MenuItem saveOption;
+  @FXML private MenuItem saveOption;
 
-  @FXML
-  private MenuItem saveCSVOption;
+  @FXML private MenuItem saveCSVOption;
 
-  @FXML
-  private MenuItem printOption;
+  @FXML private MenuItem printOption;
 
-  @FXML
-  MenuItem addToValidationOption;
+  @FXML MenuItem addToValidationOption;
 
-  @FXML
-  private TableView<ValidationRow<?>> resultsTable;
+  @FXML private TableView<ValidationRow<?>> resultsTable;
 
-  @FXML
-  private TableColumn<ValidationRow<?>, String> rowLabelCol;
+  @FXML private TableColumn<ValidationRow<?>, String> rowLabelCol;
 
-  @FXML
-  private TableColumn<ValidationRow<?>, String> firstSourceCol;
+  @FXML private TableColumn<ValidationRow<?>, String> firstSourceCol;
 
-  @FXML
-  private TableColumn<ValidationRow<?>, Boolean> isEqualCol;
+  @FXML private TableColumn<ValidationRow<?>, Boolean> isEqualCol;
 
-  @FXML
-  private TableColumn<ValidationRow<?>, String> secondSourceCol;
+  @FXML private TableColumn<ValidationRow<?>, String> secondSourceCol;
 
-  @FXML
-  private Label resultDisplayText;
+  @FXML private Label resultDisplayText;
 
-  @FXML
-  private Label auditLog;
+  @FXML private Label auditLog;
 
-  @FXML
-  private TableView<BCHaplotypeRow> bcHaplotypeTable;
+  @FXML private TableView<BCHaplotypeRow> bcHaplotypeTable;
 
-  @FXML
-  private TableColumn<BCHaplotypeRow, String> bcEthnicityColumn;
+  @FXML private TableColumn<BCHaplotypeRow, String> bcEthnicityColumn;
 
-  @FXML
-  private TableColumn<BCHaplotypeRow, HLAType> haplotypeCAlleleColumn;
+  @FXML private TableColumn<BCHaplotypeRow, HLAType> haplotypeCAlleleColumn;
 
-  @FXML
-  private TableColumn<BCHaplotypeRow, HLAType> haplotypeBAlleleColumn;
+  @FXML private TableColumn<BCHaplotypeRow, HLAType> haplotypeBAlleleColumn;
 
-  @FXML
-  private TableColumn<BCHaplotypeRow, String> haplotypeBwColumn;
+  @FXML private TableColumn<BCHaplotypeRow, String> haplotypeBwColumn;
 
-  @FXML
-  private TableColumn<BCHaplotypeRow, Double> bcFrequencyColumn;
+  @FXML private TableColumn<BCHaplotypeRow, Double> bcFrequencyColumn;
 
-  @FXML
-  private TableView<DRDQHaplotypeRow> drdqHaplotypeTable;
+  @FXML private TableView<DRDQHaplotypeRow> drdqHaplotypeTable;
 
-  @FXML
-  private TableColumn<DRDQHaplotypeRow, String> drdqEthnicityColumn;
+  @FXML private TableColumn<DRDQHaplotypeRow, String> drdqEthnicityColumn;
 
-  @FXML
-  private TableColumn<DRDQHaplotypeRow, HLAType> haplotypeDRB345AlleleColumn;
+  @FXML private TableColumn<DRDQHaplotypeRow, HLAType> haplotypeDRB345AlleleColumn;
 
-  @FXML
-  private TableColumn<DRDQHaplotypeRow, HLAType> haplotypeDRB1AlleleColumn;
+  @FXML private TableColumn<DRDQHaplotypeRow, HLAType> haplotypeDRB1AlleleColumn;
 
-  @FXML
-  private TableColumn<DRDQHaplotypeRow, HLAType> haplotypeDQB1AlleleColumn;
+  @FXML private TableColumn<DRDQHaplotypeRow, HLAType> haplotypeDQB1AlleleColumn;
 
-  @FXML
-  private TableColumn<DRDQHaplotypeRow, Double> drdqFrequencyColumn;
+  @FXML private TableColumn<DRDQHaplotypeRow, Double> drdqFrequencyColumn;
 
   /** Write the given {@link ValidationTable#getValidationImage()} to disk */
   @FXML
   void savePNGResults(ActionEvent event) {
-    Optional<File> destination = DonorNetUtils.getFile(rootPane, "Save validation results",
-        getTable().getId() + "_donor_valid", "PNG", ".png", false);
+    Optional<File> destination =
+        DonorNetUtils.getFile(
+            rootPane,
+            "Save validation results",
+            getTable().getId() + "_donor_valid",
+            "PNG",
+            ".png",
+            false);
 
     if (destination.isPresent()) {
       try {
-        ImageIO.write(SwingFXUtils.fromFXImage(rootPane.snapshot(null, null), null), "png",
+        ImageIO.write(
+            SwingFXUtils.fromFXImage(rootPane.snapshot(null, null), null),
+            "png",
             destination.get());
         Alert alert = new Alert(AlertType.INFORMATION);
         alert.setHeaderText("Saved validation image to: " + destination.get().getName());
@@ -184,8 +172,9 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
   @FXML
   private void saveCSVResults(ActionEvent event) {
     ValidationTable vt = getTable();
-    Optional<File> destination = DonorNetUtils.getFile(rootPane, "Save validation results",
-        vt.getId() + "_results", "CSV", ".csv", false);
+    Optional<File> destination =
+        DonorNetUtils.getFile(
+            rootPane, "Save validation results", vt.getId() + "_results", "CSV", ".csv", false);
 
     if (destination.isPresent()) {
       try {
@@ -229,16 +218,26 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
 
   @FXML
   void addInputsToValidationSet() {
-    TestInfo file1 = new TestInfo(getTable().getId(), getTable().firstColFile().get(),
-        getTable().getFirstRemappings(), getTable().firstColSourceType().get());
-    TestInfo file2 = new TestInfo(getTable().getId(), getTable().secondColFile().get(),
-        getTable().getSecondRemappings(), getTable().secondColSourceType().get());
+    TestInfo file1 =
+        new TestInfo(
+            getTable().getId(),
+            getTable().firstColFile().get(),
+            getTable().getFirstRemappings(),
+            getTable().firstColSourceType().get());
+    TestInfo file2 =
+        new TestInfo(
+            getTable().getId(),
+            getTable().secondColFile().get(),
+            getTable().getSecondRemappings(),
+            getTable().secondColSourceType().get());
     boolean added = ValidationTesting.addToValidationSet(file1, file2);
 
     if (added) {
-      Alert alert1 = new Alert(AlertType.INFORMATION,
-          "Successfully added " + getTable().getId() + " to validation testing set.",
-          ButtonType.CLOSE);
+      Alert alert1 =
+          new Alert(
+              AlertType.INFORMATION,
+              "Successfully added " + getTable().getId() + " to validation testing set.",
+              ButtonType.CLOSE);
       alert1.setTitle("Successfully added.");
       alert1.setHeaderText("");
       alert1.showAndWait();
@@ -247,26 +246,46 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
 
   @FXML
   void initialize() {
-    assert rootPane != null : "fx:id=\"rootPane\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert saveOption != null : "fx:id=\"saveOption\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert printOption != null : "fx:id=\"printOption\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert resultsTable != null : "fx:id=\"resultsTable\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert rowLabelCol != null : "fx:id=\"rowLabelCol\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert firstSourceCol != null : "fx:id=\"firstSourceCol\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert isEqualCol != null : "fx:id=\"isEqualCol\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert secondSourceCol != null : "fx:id=\"secondSourceCol\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert resultDisplayText != null : "fx:id=\"resultDisplayText\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert auditLog != null : "fx:id=\"auditLog\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert bcHaplotypeTable != null : "fx:id=\"haplotypeTable\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert bcEthnicityColumn != null : "fx:id=\"ethnicityColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert haplotypeCAlleleColumn != null : "fx:id=\"haplotypeCAlleleColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert haplotypeBAlleleColumn != null : "fx:id=\"haplotypeBAlleleColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert haplotypeBwColumn != null : "fx:id=\"haplotypeBwColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert drdqHaplotypeTable != null : "fx:id=\"drdqHaplotypeTable\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert drdqEthnicityColumn != null : "fx:id=\"drdqEthnicityColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert haplotypeDRB345AlleleColumn != null : "fx:id=\"haplotypeDRB345AlleleColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert haplotypeDRB1AlleleColumn != null : "fx:id=\"haplotypeDRB1AlleleColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert haplotypeDQB1AlleleColumn != null : "fx:id=\"haplotypeDQB1Column\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert rootPane != null
+        : "fx:id=\"rootPane\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert saveOption != null
+        : "fx:id=\"saveOption\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert printOption != null
+        : "fx:id=\"printOption\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert resultsTable != null
+        : "fx:id=\"resultsTable\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert rowLabelCol != null
+        : "fx:id=\"rowLabelCol\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert firstSourceCol != null
+        : "fx:id=\"firstSourceCol\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert isEqualCol != null
+        : "fx:id=\"isEqualCol\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert secondSourceCol != null
+        : "fx:id=\"secondSourceCol\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert resultDisplayText != null
+        : "fx:id=\"resultDisplayText\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert auditLog != null
+        : "fx:id=\"auditLog\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert bcHaplotypeTable != null
+        : "fx:id=\"haplotypeTable\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert bcEthnicityColumn != null
+        : "fx:id=\"ethnicityColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert haplotypeCAlleleColumn != null
+        : "fx:id=\"haplotypeCAlleleColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert haplotypeBAlleleColumn != null
+        : "fx:id=\"haplotypeBAlleleColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert haplotypeBwColumn != null
+        : "fx:id=\"haplotypeBwColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert drdqHaplotypeTable != null
+        : "fx:id=\"drdqHaplotypeTable\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert drdqEthnicityColumn != null
+        : "fx:id=\"drdqEthnicityColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert haplotypeDRB345AlleleColumn != null
+        : "fx:id=\"haplotypeDRB345AlleleColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert haplotypeDRB1AlleleColumn != null
+        : "fx:id=\"haplotypeDRB1AlleleColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert haplotypeDQB1AlleleColumn != null
+        : "fx:id=\"haplotypeDQB1Column\" was not injected: check your FXML file 'ValidationResults.fxml'.";
 
     rootPane.setAutosize(Bindings.createBooleanBinding(() -> true));
 
@@ -282,26 +301,26 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
 
     // Configure haplotype table columns
     bcEthnicityColumn.setCellValueFactory(new PropertyValueFactory<>(HaplotypeRow.ETHNICITY_PROP));
-    haplotypeCAlleleColumn
-        .setCellValueFactory(new PropertyValueFactory<>(BCHaplotypeRow.C_ALLELE_PROP));
-    haplotypeBAlleleColumn
-        .setCellValueFactory(new PropertyValueFactory<>(BCHaplotypeRow.B_ALLELE_PROP));
+    haplotypeCAlleleColumn.setCellValueFactory(
+        new PropertyValueFactory<>(BCHaplotypeRow.C_ALLELE_PROP));
+    haplotypeBAlleleColumn.setCellValueFactory(
+        new PropertyValueFactory<>(BCHaplotypeRow.B_ALLELE_PROP));
     haplotypeBwColumn.setCellValueFactory(new PropertyValueFactory<>(BCHaplotypeRow.BW_GROUP_PROP));
     bcFrequencyColumn.setCellValueFactory(new PropertyValueFactory<>(HaplotypeRow.FREQUENCY_PROP));
 
     haplotypeCAlleleColumn.setCellFactory(new HaplotypeCellFactory<>());
     haplotypeBAlleleColumn.setCellFactory(new HaplotypeCellFactory<>());
 
-    drdqEthnicityColumn
-        .setCellValueFactory(new PropertyValueFactory<>(HaplotypeRow.ETHNICITY_PROP));
-    haplotypeDRB345AlleleColumn
-        .setCellValueFactory(new PropertyValueFactory<>(DRDQHaplotypeRow.DRB345_PROP));
-    haplotypeDRB1AlleleColumn
-        .setCellValueFactory(new PropertyValueFactory<>(DRDQHaplotypeRow.DRB1_ALLELE_PROP));
-    haplotypeDQB1AlleleColumn
-        .setCellValueFactory(new PropertyValueFactory<>(DRDQHaplotypeRow.DQB1_ALLELE_PROP));
-    drdqFrequencyColumn
-        .setCellValueFactory(new PropertyValueFactory<>(HaplotypeRow.FREQUENCY_PROP));
+    drdqEthnicityColumn.setCellValueFactory(
+        new PropertyValueFactory<>(HaplotypeRow.ETHNICITY_PROP));
+    haplotypeDRB345AlleleColumn.setCellValueFactory(
+        new PropertyValueFactory<>(DRDQHaplotypeRow.DRB345_PROP));
+    haplotypeDRB1AlleleColumn.setCellValueFactory(
+        new PropertyValueFactory<>(DRDQHaplotypeRow.DRB1_ALLELE_PROP));
+    haplotypeDQB1AlleleColumn.setCellValueFactory(
+        new PropertyValueFactory<>(DRDQHaplotypeRow.DQB1_ALLELE_PROP));
+    drdqFrequencyColumn.setCellValueFactory(
+        new PropertyValueFactory<>(HaplotypeRow.FREQUENCY_PROP));
 
     haplotypeDRB345AlleleColumn.setCellFactory(new HaplotypeCellFactory<>());
     haplotypeDRB1AlleleColumn.setCellFactory(new HaplotypeCellFactory<>());
@@ -325,15 +344,19 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
     bcHaplotypeTable.getItems().clear();
     drdqHaplotypeTable.getItems().clear();
 
-    if (HaplotypeFrequencies.successfullyInitialized()) {
-      bcHaplotypeTable.setPlaceholder(noHapPatientLabel1);
-      drdqHaplotypeTable.setPlaceholder(noHapPatientLabel2);
-      bcHaplotypeTable.setItems(table.getBCHaplotypeRows());
-      drdqHaplotypeTable.setItems(table.getDRDQHaplotypeRows());
-    } else {
-      bcHaplotypeTable.setPlaceholder(noHapDataLabel1);
-      drdqHaplotypeTable.setPlaceholder(noHapDataLabel2);
-    }
+    HaplotypeFrequencies.addListener(
+        (observable, oldValue, newValue) -> {
+          if (newValue) {
+            bcHaplotypeTable.setPlaceholder(noHapPatientLabel1);
+            drdqHaplotypeTable.setPlaceholder(noHapPatientLabel2);
+            bcHaplotypeTable.setItems(table.getBCHaplotypeRows());
+            drdqHaplotypeTable.setItems(table.getDRDQHaplotypeRows());
+          } else {
+            bcHaplotypeTable.setPlaceholder(noHapDataLabel1);
+            drdqHaplotypeTable.setPlaceholder(noHapDataLabel2);
+          }
+        });
+    HaplotypeFrequencies.successfullyInitialized();
   }
 
   /** Perform required actions when the page is being displayed */
@@ -372,8 +395,12 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
                   }
                   setText("");
                 } else {
-                  boolean val = resultsTable.getItems().get(getTableRow().getIndex())
-                      .wasRemappedFirstProperty().get();
+                  boolean val =
+                      resultsTable
+                          .getItems()
+                          .get(getTableRow().getIndex())
+                          .wasRemappedFirstProperty()
+                          .get();
                   setText(item.toString());
                   if (val) {
                     style = getStyle();
@@ -408,8 +435,12 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
                 if (item == null) {
                   setText("");
                 } else {
-                  boolean val = resultsTable.getItems().get(getTableRow().getIndex())
-                      .wasRemappedSecondProperty().get();
+                  boolean val =
+                      resultsTable
+                          .getItems()
+                          .get(getTableRow().getIndex())
+                          .wasRemappedSecondProperty()
+                          .get();
                   if (val) {
                     setText(ValidationTable.REMAP_SYMBOL + " " + item.toString());
                   } else {
@@ -434,7 +465,6 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
     }
     resultDisplayText.setText(displayText);
     resultDisplayText.setStyle(displayStyle);
-
   }
 
   /**
@@ -443,8 +473,9 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
    *
    * @see https://stackoverflow.com/a/44807681/1027800
    */
-  private static class PassFailCellFactory implements
-      Callback<TableColumn<ValidationRow<?>, Boolean>, TableCell<ValidationRow<?>, Boolean>> {
+  private static class PassFailCellFactory
+      implements Callback<
+          TableColumn<ValidationRow<?>, Boolean>, TableCell<ValidationRow<?>, Boolean>> {
 
     private final Image imageTrue = new Image(getClass().getResourceAsStream("/pass.png"));
     private final Image imageFalse = new Image(getClass().getResourceAsStream("/fail.png"));
@@ -478,8 +509,9 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
   }
 
   /** Helper class to color cells when the row is invalid */
-  private static class InvalidColorCellFactory implements
-      Callback<TableColumn<ValidationRow<?>, String>, TableCell<ValidationRow<?>, String>> {
+  private static class InvalidColorCellFactory
+      implements Callback<
+          TableColumn<ValidationRow<?>, String>, TableCell<ValidationRow<?>, String>> {
     @Override
     public TableCell<ValidationRow<?>, String> call(TableColumn<ValidationRow<?>, String> param) {
       return new TableCell<ValidationRow<?>, String>() {
@@ -487,7 +519,8 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
         protected void updateItem(String item, boolean empty) {
           setText(item);
           ValidationRow<?> row = (ValidationRow<?>) getTableRow().getItem();
-          if (Objects.nonNull(row) && Objects.nonNull(row.isValidProperty())
+          if (Objects.nonNull(row)
+              && Objects.nonNull(row.isValidProperty())
               && !(row.isValidProperty().get())) {
             getStyleClass().add(0, INVALID_STYLE_CLASS);
           } else {
@@ -555,8 +588,9 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
           TableRow<?> tableRow = getTableRow();
           if (Objects.nonNull(tableRow)) {
             HaplotypeRow row = (HaplotypeRow) tableRow.getItem();
-            if (Objects.nonNull(row) && HaplotypeFrequencies.UNKNOWN_HAP_CUTOFF
-                .compareTo(row.frequencyProperty().get()) > 0) {
+            if (Objects.nonNull(row)
+                && HaplotypeFrequencies.UNKNOWN_HAP_CUTOFF.compareTo(row.frequencyProperty().get())
+                    > 0) {
               getStyleClass().add(0, UNKNOWN_HAPLOTYPE_CLASS);
             }
           }

--- a/src/main/java/org/pankratzlab/unet/jfx/wizard/ValidationResultsController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/wizard/ValidationResultsController.java
@@ -185,7 +185,7 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
   private void saveCSVResults(ActionEvent event) {
     ValidationTable vt = getTable();
     Optional<File> destination = DonorNetUtils.getFile(rootPane, "Save validation results",
-        vt.getId() + "_results_csv", "CSV", ".csv", false);
+        vt.getId() + "_results", "CSV", ".csv", false);
 
     if (destination.isPresent()) {
       try {

--- a/src/main/java/org/pankratzlab/unet/jfx/wizard/ValidationResultsController.java
+++ b/src/main/java/org/pankratzlab/unet/jfx/wizard/ValidationResultsController.java
@@ -29,9 +29,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.Set;
-
 import javax.imageio.ImageIO;
-
 import org.pankratzlab.unet.deprecated.hla.HLAType;
 import org.pankratzlab.unet.deprecated.hla.NullType;
 import org.pankratzlab.unet.hapstats.CommonWellDocumented;
@@ -44,9 +42,7 @@ import org.pankratzlab.unet.model.ValidationRow;
 import org.pankratzlab.unet.model.ValidationTable;
 import org.pankratzlab.unet.validation.TestInfo;
 import org.pankratzlab.unet.validation.ValidationTesting;
-
 import com.google.common.collect.ImmutableSet;
-
 import javafx.beans.binding.Bindings;
 import javafx.collections.ObservableList;
 import javafx.embed.swing.SwingFXUtils;
@@ -68,6 +64,7 @@ import javafx.scene.control.TableView;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.text.Text;
 import javafx.util.Callback;
 
 /** Controller for viewing the final results status. */
@@ -76,87 +73,101 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
   private static final String WD_ALLELE_CLASS = "well-documented-allele";
   private static final String UK_ALLELE_CLASS = "unknown-allele";
   private static final String UNKNOWN_HAPLOTYPE_CLASS = "unknown-haplotype";
-  private static final Set<String> HAPLOTYPE_CLASSES =
-      ImmutableSet.of(WD_ALLELE_CLASS, UK_ALLELE_CLASS, UNKNOWN_HAPLOTYPE_CLASS);
+  private static final Set<String> HAPLOTYPE_CLASSES = ImmutableSet.of(WD_ALLELE_CLASS, UK_ALLELE_CLASS, UNKNOWN_HAPLOTYPE_CLASS);
   private final Label noHapPatientLabel1 = new Label("No haplotype data found for patient.");
   private final Label noHapDataLabel1 =
-      new Label(
-          " In order to review haplotype frequencies and flag rare haplotypes,\n download data from NMDP or another source.");
+      new Label(" In order to review haplotype frequencies and flag rare haplotypes,\n download data from NMDP or another source.");
   private final Label noHapPatientLabel2 = new Label("No haplotype data found for patient.");
   private final Label noHapDataLabel2 =
-      new Label(
-          " In order to review haplotype frequencies and flag rare haplotypes,\n download data from NMDP or another source.");
+      new Label(" In order to review haplotype frequencies and flag rare haplotypes,\n download data from NMDP or another source.");
 
-  @FXML private ResourceBundle resources;
+  @FXML
+  private ResourceBundle resources;
 
-  @FXML private URL location;
+  @FXML
+  private URL location;
 
-  @FXML private ValidatingWizardPane rootPane;
+  @FXML
+  private ValidatingWizardPane rootPane;
 
-  @FXML private MenuItem saveOption;
+  @FXML
+  private MenuItem saveOption;
 
-  @FXML private MenuItem saveCSVOption;
+  @FXML
+  private MenuItem saveCSVOption;
 
-  @FXML private MenuItem printOption;
+  @FXML
+  private MenuItem printOption;
 
-  @FXML MenuItem addToValidationOption;
+  @FXML
+  MenuItem addToValidationOption;
 
-  @FXML private TableView<ValidationRow<?>> resultsTable;
+  @FXML
+  private TableView<ValidationRow<?>> resultsTable;
 
-  @FXML private TableColumn<ValidationRow<?>, String> rowLabelCol;
+  @FXML
+  private TableColumn<ValidationRow<?>, String> rowLabelCol;
 
-  @FXML private TableColumn<ValidationRow<?>, String> firstSourceCol;
+  @FXML
+  private TableColumn<ValidationRow<?>, String> firstSourceCol;
 
-  @FXML private TableColumn<ValidationRow<?>, Boolean> isEqualCol;
+  @FXML
+  private TableColumn<ValidationRow<?>, Boolean> isEqualCol;
 
-  @FXML private TableColumn<ValidationRow<?>, String> secondSourceCol;
+  @FXML
+  private TableColumn<ValidationRow<?>, String> secondSourceCol;
 
-  @FXML private Label resultDisplayText;
+  @FXML
+  private Label resultDisplayText;
 
-  @FXML private Label auditLog;
+  @FXML
+  private Text auditLog;
 
-  @FXML private TableView<BCHaplotypeRow> bcHaplotypeTable;
+  @FXML
+  private TableView<BCHaplotypeRow> bcHaplotypeTable;
 
-  @FXML private TableColumn<BCHaplotypeRow, String> bcEthnicityColumn;
+  @FXML
+  private TableColumn<BCHaplotypeRow, String> bcEthnicityColumn;
 
-  @FXML private TableColumn<BCHaplotypeRow, HLAType> haplotypeCAlleleColumn;
+  @FXML
+  private TableColumn<BCHaplotypeRow, HLAType> haplotypeCAlleleColumn;
 
-  @FXML private TableColumn<BCHaplotypeRow, HLAType> haplotypeBAlleleColumn;
+  @FXML
+  private TableColumn<BCHaplotypeRow, HLAType> haplotypeBAlleleColumn;
 
-  @FXML private TableColumn<BCHaplotypeRow, String> haplotypeBwColumn;
+  @FXML
+  private TableColumn<BCHaplotypeRow, String> haplotypeBwColumn;
 
-  @FXML private TableColumn<BCHaplotypeRow, Double> bcFrequencyColumn;
+  @FXML
+  private TableColumn<BCHaplotypeRow, Double> bcFrequencyColumn;
 
-  @FXML private TableView<DRDQHaplotypeRow> drdqHaplotypeTable;
+  @FXML
+  private TableView<DRDQHaplotypeRow> drdqHaplotypeTable;
 
-  @FXML private TableColumn<DRDQHaplotypeRow, String> drdqEthnicityColumn;
+  @FXML
+  private TableColumn<DRDQHaplotypeRow, String> drdqEthnicityColumn;
 
-  @FXML private TableColumn<DRDQHaplotypeRow, HLAType> haplotypeDRB345AlleleColumn;
+  @FXML
+  private TableColumn<DRDQHaplotypeRow, HLAType> haplotypeDRB345AlleleColumn;
 
-  @FXML private TableColumn<DRDQHaplotypeRow, HLAType> haplotypeDRB1AlleleColumn;
+  @FXML
+  private TableColumn<DRDQHaplotypeRow, HLAType> haplotypeDRB1AlleleColumn;
 
-  @FXML private TableColumn<DRDQHaplotypeRow, HLAType> haplotypeDQB1AlleleColumn;
+  @FXML
+  private TableColumn<DRDQHaplotypeRow, HLAType> haplotypeDQB1AlleleColumn;
 
-  @FXML private TableColumn<DRDQHaplotypeRow, Double> drdqFrequencyColumn;
+  @FXML
+  private TableColumn<DRDQHaplotypeRow, Double> drdqFrequencyColumn;
 
   /** Write the given {@link ValidationTable#getValidationImage()} to disk */
   @FXML
   void savePNGResults(ActionEvent event) {
     Optional<File> destination =
-        DonorNetUtils.getFile(
-            rootPane,
-            "Save validation results",
-            getTable().getId() + "_donor_valid",
-            "PNG",
-            ".png",
-            false);
+        DonorNetUtils.getFile(rootPane, "Save validation results", getTable().getId() + "_donor_valid", "PNG", ".png", false);
 
     if (destination.isPresent()) {
       try {
-        ImageIO.write(
-            SwingFXUtils.fromFXImage(rootPane.snapshot(null, null), null),
-            "png",
-            destination.get());
+        ImageIO.write(SwingFXUtils.fromFXImage(rootPane.snapshot(null, null), null), "png", destination.get());
         Alert alert = new Alert(AlertType.INFORMATION);
         alert.setHeaderText("Saved validation image to: " + destination.get().getName());
         alert.showAndWait();
@@ -172,9 +183,7 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
   @FXML
   private void saveCSVResults(ActionEvent event) {
     ValidationTable vt = getTable();
-    Optional<File> destination =
-        DonorNetUtils.getFile(
-            rootPane, "Save validation results", vt.getId() + "_results", "CSV", ".csv", false);
+    Optional<File> destination = DonorNetUtils.getFile(rootPane, "Save validation results", vt.getId() + "_results", "CSV", ".csv", false);
 
     if (destination.isPresent()) {
       try {
@@ -194,8 +203,7 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
 
   @FXML
   void printResults(ActionEvent event) {
-    ChoiceDialog<Printer> dialog =
-        new ChoiceDialog<>(Printer.getDefaultPrinter(), Printer.getAllPrinters());
+    ChoiceDialog<Printer> dialog = new ChoiceDialog<>(Printer.getDefaultPrinter(), Printer.getAllPrinters());
     dialog.setHeaderText("Select a printer");
     dialog.setContentText("Choose a printer from available printers");
     dialog.setTitle("Printer choice");
@@ -219,25 +227,13 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
   @FXML
   void addInputsToValidationSet() {
     TestInfo file1 =
-        new TestInfo(
-            getTable().getId(),
-            getTable().firstColFile().get(),
-            getTable().getFirstRemappings(),
-            getTable().firstColSourceType().get());
+        new TestInfo(getTable().getId(), getTable().firstColFile().get(), getTable().getFirstRemappings(), getTable().firstColSourceType().get());
     TestInfo file2 =
-        new TestInfo(
-            getTable().getId(),
-            getTable().secondColFile().get(),
-            getTable().getSecondRemappings(),
-            getTable().secondColSourceType().get());
+        new TestInfo(getTable().getId(), getTable().secondColFile().get(), getTable().getSecondRemappings(), getTable().secondColSourceType().get());
     boolean added = ValidationTesting.addToValidationSet(file1, file2);
 
     if (added) {
-      Alert alert1 =
-          new Alert(
-              AlertType.INFORMATION,
-              "Successfully added " + getTable().getId() + " to validation testing set.",
-              ButtonType.CLOSE);
+      Alert alert1 = new Alert(AlertType.INFORMATION, "Successfully added " + getTable().getId() + " to validation testing set.", ButtonType.CLOSE);
       alert1.setTitle("Successfully added.");
       alert1.setHeaderText("");
       alert1.showAndWait();
@@ -246,46 +242,26 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
 
   @FXML
   void initialize() {
-    assert rootPane != null
-        : "fx:id=\"rootPane\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert saveOption != null
-        : "fx:id=\"saveOption\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert printOption != null
-        : "fx:id=\"printOption\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert resultsTable != null
-        : "fx:id=\"resultsTable\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert rowLabelCol != null
-        : "fx:id=\"rowLabelCol\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert firstSourceCol != null
-        : "fx:id=\"firstSourceCol\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert isEqualCol != null
-        : "fx:id=\"isEqualCol\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert secondSourceCol != null
-        : "fx:id=\"secondSourceCol\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert resultDisplayText != null
-        : "fx:id=\"resultDisplayText\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert auditLog != null
-        : "fx:id=\"auditLog\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert bcHaplotypeTable != null
-        : "fx:id=\"haplotypeTable\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert bcEthnicityColumn != null
-        : "fx:id=\"ethnicityColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert haplotypeCAlleleColumn != null
-        : "fx:id=\"haplotypeCAlleleColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert haplotypeBAlleleColumn != null
-        : "fx:id=\"haplotypeBAlleleColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert haplotypeBwColumn != null
-        : "fx:id=\"haplotypeBwColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert drdqHaplotypeTable != null
-        : "fx:id=\"drdqHaplotypeTable\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert drdqEthnicityColumn != null
-        : "fx:id=\"drdqEthnicityColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert haplotypeDRB345AlleleColumn != null
-        : "fx:id=\"haplotypeDRB345AlleleColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert haplotypeDRB1AlleleColumn != null
-        : "fx:id=\"haplotypeDRB1AlleleColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
-    assert haplotypeDQB1AlleleColumn != null
-        : "fx:id=\"haplotypeDQB1Column\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert rootPane != null : "fx:id=\"rootPane\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert saveOption != null : "fx:id=\"saveOption\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert printOption != null : "fx:id=\"printOption\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert resultsTable != null : "fx:id=\"resultsTable\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert rowLabelCol != null : "fx:id=\"rowLabelCol\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert firstSourceCol != null : "fx:id=\"firstSourceCol\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert isEqualCol != null : "fx:id=\"isEqualCol\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert secondSourceCol != null : "fx:id=\"secondSourceCol\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert resultDisplayText != null : "fx:id=\"resultDisplayText\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert auditLog != null : "fx:id=\"auditLog\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert bcHaplotypeTable != null : "fx:id=\"haplotypeTable\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert bcEthnicityColumn != null : "fx:id=\"ethnicityColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert haplotypeCAlleleColumn != null : "fx:id=\"haplotypeCAlleleColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert haplotypeBAlleleColumn != null : "fx:id=\"haplotypeBAlleleColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert haplotypeBwColumn != null : "fx:id=\"haplotypeBwColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert drdqHaplotypeTable != null : "fx:id=\"drdqHaplotypeTable\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert drdqEthnicityColumn != null : "fx:id=\"drdqEthnicityColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert haplotypeDRB345AlleleColumn != null : "fx:id=\"haplotypeDRB345AlleleColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert haplotypeDRB1AlleleColumn != null : "fx:id=\"haplotypeDRB1AlleleColumn\" was not injected: check your FXML file 'ValidationResults.fxml'.";
+    assert haplotypeDQB1AlleleColumn != null : "fx:id=\"haplotypeDQB1Column\" was not injected: check your FXML file 'ValidationResults.fxml'.";
 
     rootPane.setAutosize(Bindings.createBooleanBinding(() -> true));
 
@@ -301,26 +277,19 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
 
     // Configure haplotype table columns
     bcEthnicityColumn.setCellValueFactory(new PropertyValueFactory<>(HaplotypeRow.ETHNICITY_PROP));
-    haplotypeCAlleleColumn.setCellValueFactory(
-        new PropertyValueFactory<>(BCHaplotypeRow.C_ALLELE_PROP));
-    haplotypeBAlleleColumn.setCellValueFactory(
-        new PropertyValueFactory<>(BCHaplotypeRow.B_ALLELE_PROP));
+    haplotypeCAlleleColumn.setCellValueFactory(new PropertyValueFactory<>(BCHaplotypeRow.C_ALLELE_PROP));
+    haplotypeBAlleleColumn.setCellValueFactory(new PropertyValueFactory<>(BCHaplotypeRow.B_ALLELE_PROP));
     haplotypeBwColumn.setCellValueFactory(new PropertyValueFactory<>(BCHaplotypeRow.BW_GROUP_PROP));
     bcFrequencyColumn.setCellValueFactory(new PropertyValueFactory<>(HaplotypeRow.FREQUENCY_PROP));
 
     haplotypeCAlleleColumn.setCellFactory(new HaplotypeCellFactory<>());
     haplotypeBAlleleColumn.setCellFactory(new HaplotypeCellFactory<>());
 
-    drdqEthnicityColumn.setCellValueFactory(
-        new PropertyValueFactory<>(HaplotypeRow.ETHNICITY_PROP));
-    haplotypeDRB345AlleleColumn.setCellValueFactory(
-        new PropertyValueFactory<>(DRDQHaplotypeRow.DRB345_PROP));
-    haplotypeDRB1AlleleColumn.setCellValueFactory(
-        new PropertyValueFactory<>(DRDQHaplotypeRow.DRB1_ALLELE_PROP));
-    haplotypeDQB1AlleleColumn.setCellValueFactory(
-        new PropertyValueFactory<>(DRDQHaplotypeRow.DQB1_ALLELE_PROP));
-    drdqFrequencyColumn.setCellValueFactory(
-        new PropertyValueFactory<>(HaplotypeRow.FREQUENCY_PROP));
+    drdqEthnicityColumn.setCellValueFactory(new PropertyValueFactory<>(HaplotypeRow.ETHNICITY_PROP));
+    haplotypeDRB345AlleleColumn.setCellValueFactory(new PropertyValueFactory<>(DRDQHaplotypeRow.DRB345_PROP));
+    haplotypeDRB1AlleleColumn.setCellValueFactory(new PropertyValueFactory<>(DRDQHaplotypeRow.DRB1_ALLELE_PROP));
+    haplotypeDQB1AlleleColumn.setCellValueFactory(new PropertyValueFactory<>(DRDQHaplotypeRow.DQB1_ALLELE_PROP));
+    drdqFrequencyColumn.setCellValueFactory(new PropertyValueFactory<>(HaplotypeRow.FREQUENCY_PROP));
 
     haplotypeDRB345AlleleColumn.setCellFactory(new HaplotypeCellFactory<>());
     haplotypeDRB1AlleleColumn.setCellFactory(new HaplotypeCellFactory<>());
@@ -344,19 +313,27 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
     bcHaplotypeTable.getItems().clear();
     drdqHaplotypeTable.getItems().clear();
 
-    HaplotypeFrequencies.addListener(
-        (observable, oldValue, newValue) -> {
-          if (newValue) {
-            bcHaplotypeTable.setPlaceholder(noHapPatientLabel1);
-            drdqHaplotypeTable.setPlaceholder(noHapPatientLabel2);
-            bcHaplotypeTable.setItems(table.getBCHaplotypeRows());
-            drdqHaplotypeTable.setItems(table.getDRDQHaplotypeRows());
-          } else {
-            bcHaplotypeTable.setPlaceholder(noHapDataLabel1);
-            drdqHaplotypeTable.setPlaceholder(noHapDataLabel2);
-          }
-        });
-    HaplotypeFrequencies.successfullyInitialized();
+    HaplotypeFrequencies.addListener((observable, oldValue, newValue) -> {
+      if (newValue) {
+        bcHaplotypeTable.setPlaceholder(noHapPatientLabel1);
+        drdqHaplotypeTable.setPlaceholder(noHapPatientLabel2);
+        bcHaplotypeTable.setItems(table.getBCHaplotypeRows());
+        drdqHaplotypeTable.setItems(table.getDRDQHaplotypeRows());
+      } else {
+        bcHaplotypeTable.setPlaceholder(noHapDataLabel1);
+        drdqHaplotypeTable.setPlaceholder(noHapDataLabel2);
+      }
+    });
+    boolean hapAvailable = HaplotypeFrequencies.successfullyInitialized().get();
+    if (hapAvailable) {
+      bcHaplotypeTable.setPlaceholder(noHapPatientLabel1);
+      drdqHaplotypeTable.setPlaceholder(noHapPatientLabel2);
+      bcHaplotypeTable.setItems(table.getBCHaplotypeRows());
+      drdqHaplotypeTable.setItems(table.getDRDQHaplotypeRows());
+    } else {
+      bcHaplotypeTable.setPlaceholder(noHapDataLabel1);
+      drdqHaplotypeTable.setPlaceholder(noHapDataLabel2);
+    }
   }
 
   /** Perform required actions when the page is being displayed */
@@ -379,8 +356,7 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
         new Callback<TableColumn<ValidationRow<?>, String>, TableCell<ValidationRow<?>, String>>() {
 
           @Override
-          public TableCell<ValidationRow<?>, String> call(
-              TableColumn<ValidationRow<?>, String> param) {
+          public TableCell<ValidationRow<?>, String> call(TableColumn<ValidationRow<?>, String> param) {
             return new TableCell() {
 
               private String style;
@@ -395,17 +371,11 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
                   }
                   setText("");
                 } else {
-                  boolean val =
-                      resultsTable
-                          .getItems()
-                          .get(getTableRow().getIndex())
-                          .wasRemappedFirstProperty()
-                          .get();
+                  boolean val = resultsTable.getItems().get(getTableRow().getIndex()).wasRemappedFirstProperty().get();
                   setText(item.toString());
                   if (val) {
                     style = getStyle();
-                    setStyle(
-                        "-fx-font-style:" + (val ? "italic" + "; -fx-font-weight:bold" : "normal"));
+                    setStyle("-fx-font-style:" + (val ? "italic" + "; -fx-font-weight:bold" : "normal"));
                   } else {
                     if (style != null) {
                       setStyle(style);
@@ -423,8 +393,7 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
         new Callback<TableColumn<ValidationRow<?>, String>, TableCell<ValidationRow<?>, String>>() {
 
           @Override
-          public TableCell<ValidationRow<?>, String> call(
-              TableColumn<ValidationRow<?>, String> param) {
+          public TableCell<ValidationRow<?>, String> call(TableColumn<ValidationRow<?>, String> param) {
             return new TableCell() {
 
               // private String style;
@@ -435,12 +404,7 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
                 if (item == null) {
                   setText("");
                 } else {
-                  boolean val =
-                      resultsTable
-                          .getItems()
-                          .get(getTableRow().getIndex())
-                          .wasRemappedSecondProperty()
-                          .get();
+                  boolean val = resultsTable.getItems().get(getTableRow().getIndex()).wasRemappedSecondProperty().get();
                   if (val) {
                     setText(ValidationTable.REMAP_SYMBOL + " " + item.toString());
                   } else {
@@ -473,9 +437,7 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
    *
    * @see https://stackoverflow.com/a/44807681/1027800
    */
-  private static class PassFailCellFactory
-      implements Callback<
-          TableColumn<ValidationRow<?>, Boolean>, TableCell<ValidationRow<?>, Boolean>> {
+  private static class PassFailCellFactory implements Callback<TableColumn<ValidationRow<?>, Boolean>, TableCell<ValidationRow<?>, Boolean>> {
 
     private final Image imageTrue = new Image(getClass().getResourceAsStream("/pass.png"));
     private final Image imageFalse = new Image(getClass().getResourceAsStream("/fail.png"));
@@ -509,9 +471,7 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
   }
 
   /** Helper class to color cells when the row is invalid */
-  private static class InvalidColorCellFactory
-      implements Callback<
-          TableColumn<ValidationRow<?>, String>, TableCell<ValidationRow<?>, String>> {
+  private static class InvalidColorCellFactory implements Callback<TableColumn<ValidationRow<?>, String>, TableCell<ValidationRow<?>, String>> {
     @Override
     public TableCell<ValidationRow<?>, String> call(TableColumn<ValidationRow<?>, String> param) {
       return new TableCell<ValidationRow<?>, String>() {
@@ -519,9 +479,7 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
         protected void updateItem(String item, boolean empty) {
           setText(item);
           ValidationRow<?> row = (ValidationRow<?>) getTableRow().getItem();
-          if (Objects.nonNull(row)
-              && Objects.nonNull(row.isValidProperty())
-              && !(row.isValidProperty().get())) {
+          if (Objects.nonNull(row) && Objects.nonNull(row.isValidProperty()) && !(row.isValidProperty().get())) {
             getStyleClass().add(0, INVALID_STYLE_CLASS);
           } else {
             ObservableList<String> styleList = getStyleClass();
@@ -541,8 +499,7 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
    * Helper class to color cells when the row's haplotype is unknown or individual alleles are not
    * common
    */
-  private static class HaplotypeCellFactory<T extends HaplotypeRow>
-      implements Callback<TableColumn<T, HLAType>, TableCell<T, HLAType>> {
+  private static class HaplotypeCellFactory<T extends HaplotypeRow> implements Callback<TableColumn<T, HLAType>, TableCell<T, HLAType>> {
 
     @Override
     public TableCell<T, HLAType> call(TableColumn<T, HLAType> param) {
@@ -588,9 +545,7 @@ public class ValidationResultsController extends AbstractValidatingWizardControl
           TableRow<?> tableRow = getTableRow();
           if (Objects.nonNull(tableRow)) {
             HaplotypeRow row = (HaplotypeRow) tableRow.getItem();
-            if (Objects.nonNull(row)
-                && HaplotypeFrequencies.UNKNOWN_HAP_CUTOFF.compareTo(row.frequencyProperty().get())
-                    > 0) {
+            if (Objects.nonNull(row) && HaplotypeFrequencies.UNKNOWN_HAP_CUTOFF.compareTo(row.frequencyProperty().get()) > 0) {
               getStyleClass().add(0, UNKNOWN_HAPLOTYPE_CLASS);
             }
           }

--- a/src/main/java/org/pankratzlab/unet/model/BCHaplotypeRow.java
+++ b/src/main/java/org/pankratzlab/unet/model/BCHaplotypeRow.java
@@ -22,13 +22,11 @@
 package org.pankratzlab.unet.model;
 
 import java.util.Objects;
-
 import org.pankratzlab.unet.deprecated.hla.HLAType;
 import org.pankratzlab.unet.hapstats.Haplotype;
 import org.pankratzlab.unet.hapstats.RaceGroup;
 import org.pankratzlab.unet.parser.util.BwSerotypes;
 import org.pankratzlab.unet.parser.util.BwSerotypes.BwGroup;
-
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.property.ReadOnlyStringProperty;

--- a/src/main/java/org/pankratzlab/unet/model/ModelData.java
+++ b/src/main/java/org/pankratzlab/unet/model/ModelData.java
@@ -1,0 +1,45 @@
+package org.pankratzlab.unet.model;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
+import org.pankratzlab.unet.deprecated.hla.HLALocus;
+import org.pankratzlab.unet.deprecated.hla.HLAType;
+import org.pankratzlab.unet.model.ValidationModelBuilder.TypePair;
+import org.pankratzlab.unet.model.ValidationTable.ValidationKey;
+import com.google.common.collect.ImmutableMap;
+
+public class ModelData {
+  private final Map<ValidationKey, String> data = new HashMap<>();
+  private final List<String> audit;
+  private final ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> remaps;
+  private ImmutableMap<HLALocus, Set<HLAType>> manuals;
+
+  public ModelData(ValidationModel t) {
+    for (ValidationKey k : ValidationKey.values()) {
+      data.put(k, k.get(t));
+    }
+    this.remaps = t.getRemappings();
+    this.audit = t.getAuditMessages();
+    this.manuals = t.getManuallyAssignedLoci();
+  }
+
+  public String get(ValidationKey key) {
+    return data.getOrDefault(key, "");
+  }
+
+  public ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> getRemaps() {
+    return remaps;
+  }
+
+  public List<String> getAudit() {
+    return audit;
+  }
+
+  public ImmutableMap<HLALocus, Set<HLAType>> getManuallyAssignedLoci() {
+    return manuals;
+  }
+
+}

--- a/src/main/java/org/pankratzlab/unet/model/ValidationModel.java
+++ b/src/main/java/org/pankratzlab/unet/model/ValidationModel.java
@@ -70,13 +70,10 @@ public class ValidationModel {
   private final ImmutableMultimap<RaceGroup, Haplotype> drdqHaplotypes;
   private final ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> remapping;
 
-  public ValidationModel(String donorId, String filepath, String source, SourceType sourceType,
-      Collection<SeroType> a, Collection<SeroType> b, Collection<SeroType> c,
-      Collection<SeroType> drb, Collection<SeroType> dqb, Collection<SeroType> dqa,
-      Collection<SeroType> dpa, Collection<HLAType> dpb, boolean bw4, boolean bw6,
-      List<HLAType> dr51, List<HLAType> dr52, List<HLAType> dr53,
-      Multimap<RaceGroup, Haplotype> bcCwdHaplotypes,
-      Multimap<RaceGroup, Haplotype> drdqCwdHaplotypes,
+  public ValidationModel(String donorId, String filepath, String source, SourceType sourceType, Collection<SeroType> a, Collection<SeroType> b,
+      Collection<SeroType> c, Collection<SeroType> drb, Collection<SeroType> dqb, Collection<SeroType> dqa, Collection<SeroType> dpa,
+      Collection<HLAType> dpb, boolean bw4, boolean bw6, List<HLAType> dr51, List<HLAType> dr52, List<HLAType> dr53,
+      Multimap<RaceGroup, Haplotype> bcCwdHaplotypes, Multimap<RaceGroup, Haplotype> drdqCwdHaplotypes,
       Map<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> remapping) {
     this.donorId = donorId;
     this.filepath = filepath;
@@ -385,13 +382,11 @@ public class ValidationModel {
     return sj.toString();
   }
 
-  private void addHaplotypes(StringJoiner sj, ImmutableMultimap<RaceGroup, Haplotype> haplotypes,
-      String title) {
+  private void addHaplotypes(StringJoiner sj, ImmutableMultimap<RaceGroup, Haplotype> haplotypes, String title) {
     sj.add(title);
     for (RaceGroup e : RaceGroup.values()) {
       sj.add("\t" + e.toString());
-      List<String> hapStrings =
-          haplotypes.get(e).stream().map(Haplotype::toString).sorted().collect(Collectors.toList());
+      List<String> hapStrings = haplotypes.get(e).stream().map(Haplotype::toString).sorted().collect(Collectors.toList());
       hapStrings.forEach(s -> sj.add("\t" + s));
     }
   }

--- a/src/main/java/org/pankratzlab/unet/model/ValidationModel.java
+++ b/src/main/java/org/pankratzlab/unet/model/ValidationModel.java
@@ -69,12 +69,14 @@ public class ValidationModel {
   private final ImmutableMultimap<RaceGroup, Haplotype> bcHaplotypes;
   private final ImmutableMultimap<RaceGroup, Haplotype> drdqHaplotypes;
   private final ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> remapping;
+  private final ImmutableMap<HLALocus, Set<HLAType>> manualAssignments;
+  private final ImmutableList<String> auditMessages;
 
   public ValidationModel(String donorId, String filepath, String source, SourceType sourceType, Collection<SeroType> a, Collection<SeroType> b,
       Collection<SeroType> c, Collection<SeroType> drb, Collection<SeroType> dqb, Collection<SeroType> dqa, Collection<SeroType> dpa,
       Collection<HLAType> dpb, boolean bw4, boolean bw6, List<HLAType> dr51, List<HLAType> dr52, List<HLAType> dr53,
       Multimap<RaceGroup, Haplotype> bcCwdHaplotypes, Multimap<RaceGroup, Haplotype> drdqCwdHaplotypes,
-      Map<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> remapping) {
+      Map<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> remapping, Map<HLALocus, Set<HLAType>> manualAssignments, List<String> auditMessages) {
     this.donorId = donorId;
     this.filepath = filepath;
     this.source = source;
@@ -102,6 +104,8 @@ public class ValidationModel {
     drdqHaplotypes = ImmutableMultimap.copyOf(drdqCwdHaplotypes);
 
     this.remapping = ImmutableMap.copyOf(remapping);
+    this.manualAssignments = ImmutableMap.copyOf(manualAssignments);
+    this.auditMessages = ImmutableList.copyOf(auditMessages);
   }
 
   public String getDonorId() {
@@ -190,6 +194,14 @@ public class ValidationModel {
 
   public String isBw6() {
     return inGroupString(bw6);
+  }
+
+  public boolean getBw4() {
+    return bw4;
+  }
+
+  public boolean getBw6() {
+    return bw6;
   }
 
   public HLAType getDR51_1() {
@@ -423,4 +435,13 @@ public class ValidationModel {
   public ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> getRemappings() {
     return remapping;
   }
+
+  public ImmutableMap<HLALocus, Set<HLAType>> getManuallyAssignedLoci() {
+    return manualAssignments;
+  }
+
+  public ImmutableList<String> getAuditMessages() {
+    return auditMessages;
+  }
+
 }

--- a/src/main/java/org/pankratzlab/unet/model/ValidationModelBuilder.java
+++ b/src/main/java/org/pankratzlab/unet/model/ValidationModelBuilder.java
@@ -85,13 +85,11 @@ import com.google.common.collect.Table;
  */
 public class ValidationModelBuilder {
 
-  public static final Set<HLALocus> REPORT_SERO = Set.of(HLALocus.A, HLALocus.B, HLALocus.C,
-      HLALocus.DRB1, HLALocus.DQB1, HLALocus.DQA1, HLALocus.DPA1);
+  public static final Set<HLALocus> REPORT_SERO =
+      Set.of(HLALocus.A, HLALocus.B, HLALocus.C, HLALocus.DRB1, HLALocus.DQB1, HLALocus.DQA1, HLALocus.DPA1);
 
-  private static final Map<RaceGroup, EthnicityHaplotypeComp> comparators =
-      new EnumMap<>(RaceGroup.class);
-  private static final Table<Haplotype, RaceGroup, BigDecimal> frequencyTable =
-      HashBasedTable.create();
+  private static final Map<RaceGroup, EthnicityHaplotypeComp> comparators = new EnumMap<>(RaceGroup.class);
+  private static final Table<Haplotype, RaceGroup, BigDecimal> frequencyTable = HashBasedTable.create();
   private static final String NEGATIVE_ALLELE = "N-Negative";
   public static final String NOT_ON_CELL_SURFACE = ".+[0-9]+[LSCAQlscaq]$";
   public static final String NOT_EXPRESSED = ".+[0-9]+[Nn]$";
@@ -129,6 +127,8 @@ public class ValidationModelBuilder {
 
   private Set<HLALocus> nonCWDLoci = new TreeSet<>();
   private Map<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> remapping = new HashMap<>();
+  private Map<HLALocus, Set<HLAType>> manualAssignments = new HashMap<>();
+  private List<String> auditMessages = new ArrayList<>();
 
   private Set<SeroType> drbLocus;
   private Set<SeroType> drbLocusNonCWD;
@@ -192,6 +192,19 @@ public class ValidationModelBuilder {
   /** @param source Name for the source of this model */
   public SourceType getSourceType() {
     return sourceType;
+  }
+
+  public ValidationModelBuilder addAuditMessage(String message) {
+    this.auditMessages.add(message);
+    return this;
+  }
+
+  public ValidationModelBuilder setLocusAssigned(HLALocus locus, HLAType... types) {
+    Set<HLAType> manual = manualAssignments.computeIfAbsent(locus, k -> new HashSet<>());
+    for (HLAType t : types) {
+      manual.add(t);
+    }
+    return this;
   }
 
   public ValidationModelBuilder a(String aSeroType) {
@@ -303,8 +316,7 @@ public class ValidationModelBuilder {
     if (test2(drbType)) {
       return null;
     }
-    if (!Strings.isNullOrEmpty(drbType)
-        && Objects.equals(103, Integer.parseInt(drbType.replaceAll(":", "").trim()))) {
+    if (!Strings.isNullOrEmpty(drbType) && Objects.equals(103, Integer.parseInt(drbType.replaceAll(":", "").trim()))) {
       // UNOS explicitly requires DRB1*01:03 to be reported as DRB0103
       drbLocus.add(new SeroType(SeroLocus.DRB, "0103"));
     } else {
@@ -318,8 +330,7 @@ public class ValidationModelBuilder {
     if (test2(drbType)) {
       return null;
     }
-    if (!Strings.isNullOrEmpty(drbType)
-        && Objects.equals(103, Integer.parseInt(drbType.replaceAll(":", "").trim()))) {
+    if (!Strings.isNullOrEmpty(drbType) && Objects.equals(103, Integer.parseInt(drbType.replaceAll(":", "").trim()))) {
       // UNOS explicitly requires DRB1*01:03 to be reported as DRB0103
       drbLocusNonCWD.add(new SeroType(SeroLocus.DRB, "0103"));
     } else {
@@ -329,8 +340,8 @@ public class ValidationModelBuilder {
   }
 
   /**
-   * DR51 is a HLA-DR serotype that recognizes the antigens encoded by the minor DR locus HLA-DRB5
-   * (cc wikipedia)
+   * DR51 is a HLA-DR serotype that recognizes the antigens encoded by the minor DR locus HLA-DRB5 (cc
+   * wikipedia)
    * 
    * @param dr51
    * @return
@@ -654,8 +665,7 @@ public class ValidationModelBuilder {
     }
     returnTypes = new LinkedHashSet<>(returnTypes);
     if (remapping.containsKey(locus)) {
-      List<SeroType> types = remapping.get(locus).getRight().stream().map(TypePair::getSeroType)
-          .collect(Collectors.toList());
+      List<SeroType> types = remapping.get(locus).getRight().stream().map(TypePair::getSeroType).collect(Collectors.toList());
       returnTypes.clear();
       returnTypes.addAll(types);
     }
@@ -666,16 +676,14 @@ public class ValidationModelBuilder {
   public ValidationModel build() {
     Multimap<RaceGroup, Haplotype> bcCwdHaplotypes = buildBCHaplotypes(bHaplotypes, cHaplotypes);
 
-    Multimap<RaceGroup, Haplotype> drDqDR345Haplotypes =
-        buildHaplotypes(ImmutableList.of(drb1Haplotypes, dqb1Haplotypes, dr345Haplotypes));
+    Multimap<RaceGroup, Haplotype> drDqDR345Haplotypes = buildHaplotypes(ImmutableList.of(drb1Haplotypes, dqb1Haplotypes, dr345Haplotypes));
 
     frequencyTable.clear();
 
-    ValidationModel validationModel = new ValidationModel(donorId, filepath, source, sourceType,
-        getFinalTypes(HLALocus.A), getFinalTypes(HLALocus.B), getFinalTypes(HLALocus.C),
-        getFinalTypes(HLALocus.DRB1), getFinalTypes(HLALocus.DQB1), getFinalTypes(HLALocus.DQA1),
-        getFinalTypes(HLALocus.DPA1), getFinalDPBTypes(), bw4, bw6, dr51Locus, dr52Locus, dr53Locus,
-        bcCwdHaplotypes, drDqDR345Haplotypes, remapping);
+    ValidationModel validationModel = new ValidationModel(donorId, filepath, source, sourceType, getFinalTypes(HLALocus.A), getFinalTypes(HLALocus.B),
+        getFinalTypes(HLALocus.C), getFinalTypes(HLALocus.DRB1), getFinalTypes(HLALocus.DQB1), getFinalTypes(HLALocus.DQA1),
+        getFinalTypes(HLALocus.DPA1), getFinalDPBTypes(), bw4, bw6, dr51Locus, dr52Locus, dr53Locus, bcCwdHaplotypes, drDqDR345Haplotypes, remapping,
+        manualAssignments, auditMessages);
     return validationModel;
   }
 
@@ -687,8 +695,7 @@ public class ValidationModelBuilder {
 
     Set<HLAType> returnTypes = new LinkedHashSet<>();
     if (remapping.containsKey(HLALocus.DPB1)) {
-      List<HLAType> types = remapping.get(HLALocus.DPB1).getRight().stream()
-          .map(TypePair::getHlaType).collect(Collectors.toList());
+      List<HLAType> types = remapping.get(HLALocus.DPB1).getRight().stream().map(TypePair::getHlaType).collect(Collectors.toList());
       returnTypes.clear();
       returnTypes.addAll(types);
     }
@@ -698,8 +705,7 @@ public class ValidationModelBuilder {
       dpbSource = test1(dpbLocusAllelesNonCWD) ? dpbLocusAlleles : dpbLocusAllelesNonCWD;
       Set<SeroType> dpbBackup = test1(dpbLocusNonCWD) ? dpbLocus : trim(dpbLocusNonCWD);
       if (dpbSource == null || dpbSource.isEmpty()) {
-        dpbSource = dpbBackup.stream().map(s -> new HLAType(HLALocus.DPB1, s.spec()))
-            .collect(ImmutableSet.toImmutableSet());
+        dpbSource = dpbBackup.stream().map(s -> new HLAType(HLALocus.DPB1, s.spec())).collect(ImmutableSet.toImmutableSet());
       }
     }
     for (HLAType dpbType1 : dpbSource) {
@@ -707,8 +713,7 @@ public class ValidationModelBuilder {
       if (!Strings.isNullOrEmpty(dpbType) && dpbType.matches(".*\\d.*")) {
         HLAType tmpDPB1 = new HLAType(HLALocus.DPB1, dpbType);
         if (tmpDPB1.spec().size() > 2) {
-          tmpDPB1 =
-              new HLAType(HLALocus.DPB1, new int[] {tmpDPB1.spec().get(0), tmpDPB1.spec().get(1)});
+          tmpDPB1 = new HLAType(HLALocus.DPB1, new int[] {tmpDPB1.spec().get(0), tmpDPB1.spec().get(1)});
         }
         dpbTypes.add(tmpDPB1);
       }
@@ -719,16 +724,13 @@ public class ValidationModelBuilder {
   /**
    * Helper method to build the B/C haplotypes. Extra filtering is needed based on the Bw groups.
    */
-  private Multimap<RaceGroup, Haplotype> buildBCHaplotypes(Multimap<Strand, HLAType> bHaps,
-      Multimap<Strand, HLAType> cHaps) {
+  private Multimap<RaceGroup, Haplotype> buildBCHaplotypes(Multimap<Strand, HLAType> bHaps, Multimap<Strand, HLAType> cHaps) {
     if (bw4 && bw6) {
       // One strand is Bw4 and one is Bw6, but we can't know for sure which. So we try both
       Multimap<Strand, HLAType> s4s6 = enforceBws(BwGroup.Bw4, BwGroup.Bw6, bHaps);
       Multimap<Strand, HLAType> s6s4 = enforceBws(BwGroup.Bw6, BwGroup.Bw4, bHaps);
-      Multimap<RaceGroup, Haplotype> s4s6Haplotypes = s4s6.isEmpty() ? ImmutableMultimap.of()
-          : buildHaplotypes(ImmutableList.of(s4s6, cHaplotypes));
-      Multimap<RaceGroup, Haplotype> s6s4Haplotypes = s6s4.isEmpty() ? ImmutableMultimap.of()
-          : buildHaplotypes(ImmutableList.of(s6s4, cHaplotypes));
+      Multimap<RaceGroup, Haplotype> s4s6Haplotypes = s4s6.isEmpty() ? ImmutableMultimap.of() : buildHaplotypes(ImmutableList.of(s4s6, cHaplotypes));
+      Multimap<RaceGroup, Haplotype> s6s4Haplotypes = s6s4.isEmpty() ? ImmutableMultimap.of() : buildHaplotypes(ImmutableList.of(s6s4, cHaplotypes));
 
       // Merge the bw4/bw6 sets into a combined Scoring set
       List<ScoredHaplotypes> scoredHaplotypePairs = new ArrayList<>();
@@ -749,8 +751,7 @@ public class ValidationModelBuilder {
         for (RaceGroup ethnicity : RaceGroup.values()) {
 
           // Sort the haplotype pairs to find the most likely pairing for this ethnicity
-          ScoredHaplotypes max =
-              Collections.max(scoredHaplotypePairs, new EthnicityHaplotypeComp(ethnicity));
+          ScoredHaplotypes max = Collections.max(scoredHaplotypePairs, new EthnicityHaplotypeComp(ethnicity));
 
           // Record each haplotype in the pair
           for (Haplotype t : max) {
@@ -773,21 +774,18 @@ public class ValidationModelBuilder {
   }
 
   /**
-   * Helper method to enforce a particular Bw strand alignment for any B alleles in the given
-   * multimap
+   * Helper method to enforce a particular Bw strand alignment for any B alleles in the given multimap
    */
-  private Multimap<Strand, HLAType> enforceBws(BwGroup strandOneGroup, BwGroup strandTwoGroup,
-      Multimap<Strand, HLAType> haplotypes) {
+  private Multimap<Strand, HLAType> enforceBws(BwGroup strandOneGroup, BwGroup strandTwoGroup, Multimap<Strand, HLAType> haplotypes) {
     ListMultimap<Strand, HLAType> enforced = ArrayListMultimap.create();
+    // check alleles in first strand
     for (HLAType t : haplotypes.get(Strand.FIRST)) {
-      if (!HLALocus.B.equals(t.locus()) || strandOneGroup.equals(BwSerotypes.getBwGroup(t))
-          || BwGroup.Unknown.equals(BwSerotypes.getBwGroup(t))) {
+      if (!HLALocus.B.equals(t.locus()) || strandOneGroup.equals(BwSerotypes.getBwGroup(t)) || BwGroup.Unknown.equals(BwSerotypes.getBwGroup(t))) {
         enforced.put(Strand.FIRST, t);
       }
     }
     for (HLAType t : haplotypes.get(Strand.SECOND)) {
-      if (!HLALocus.B.equals(t.locus()) || strandTwoGroup.equals(BwSerotypes.getBwGroup(t))
-          || BwGroup.Unknown.equals(BwSerotypes.getBwGroup(t))) {
+      if (!HLALocus.B.equals(t.locus()) || strandTwoGroup.equals(BwSerotypes.getBwGroup(t)) || BwGroup.Unknown.equals(BwSerotypes.getBwGroup(t))) {
         enforced.put(Strand.SECOND, t);
       }
     }
@@ -799,14 +797,11 @@ public class ValidationModelBuilder {
   }
 
   /** @return A table of the highest-probability haplotypes for each ethnicity */
-  private Multimap<RaceGroup, Haplotype> buildHaplotypes(
-      List<Multimap<Strand, HLAType>> typesByLocus) {
+  private Multimap<RaceGroup, Haplotype> buildHaplotypes(List<Multimap<Strand, HLAType>> typesByLocus) {
     Map<RaceGroup, ScoredHaplotypes> maxScorePairsByEthnicity = new HashMap<>();
-    Multimap<RaceGroup, Haplotype> haplotypesByEthnicity =
-        MultimapBuilder.enumKeys(RaceGroup.class).arrayListValues().build();
+    Multimap<RaceGroup, Haplotype> haplotypesByEthnicity = MultimapBuilder.enumKeys(RaceGroup.class).arrayListValues().build();
 
-    List<Multimap<Strand, HLAType>> presentTypesByLocus =
-        typesByLocus.stream().filter(m -> !m.isEmpty()).collect(Collectors.toList());
+    List<Multimap<Strand, HLAType>> presentTypesByLocus = typesByLocus.stream().filter(m -> !m.isEmpty()).collect(Collectors.toList());
     presentTypesByLocus.forEach(this::pruneUnknown);
     presentTypesByLocus.forEach(this::condenseGroups);
 
@@ -830,15 +825,13 @@ public class ValidationModelBuilder {
    * @param typesByLocus List of mappings, one per locus, of {@link Strand} to possible alleles for
    *        that strand.
    */
-  private void generateHaplotypePairs(Map<RaceGroup, ScoredHaplotypes> maxScorePairsByEthnicity,
-      List<Multimap<Strand, HLAType>> typesByLocus) {
+  private void generateHaplotypePairs(Map<RaceGroup, ScoredHaplotypes> maxScorePairsByEthnicity, List<Multimap<Strand, HLAType>> typesByLocus) {
     // Overview:
     // 1. Recurse through strand 1 sets - for each locus, record the possible complementary options
     // 2. At the terminal strand 1 step, start recursing through the possible strand 2 options
     // 3. At the terminal strand 2 step, create a ScoredHaplotype for the pair
 
-    generateStrandOneHaplotypes(maxScorePairsByEthnicity, typesByLocus, new ArrayList<>(),
-        new ArrayList<>(), 0);
+    generateStrandOneHaplotypes(maxScorePairsByEthnicity, typesByLocus, new ArrayList<>(), new ArrayList<>(), 0);
   }
 
   /**
@@ -852,15 +845,12 @@ public class ValidationModelBuilder {
    *        haplotype generation.
    * @param locusIndex Current locus index in the {@code strandTwoOptionsByLocus} list
    */
-  private void generateStrandOneHaplotypes(
-      Map<RaceGroup, ScoredHaplotypes> maxScorePairsByEthnicity,
-      List<Multimap<Strand, HLAType>> typesByLocus, List<HLAType> currentHaplotypeAlleles,
-      List<List<HLAType>> strandTwoOptionsByLocus, int locusIndex) {
+  private void generateStrandOneHaplotypes(Map<RaceGroup, ScoredHaplotypes> maxScorePairsByEthnicity, List<Multimap<Strand, HLAType>> typesByLocus,
+      List<HLAType> currentHaplotypeAlleles, List<List<HLAType>> strandTwoOptionsByLocus, int locusIndex) {
     if (locusIndex == typesByLocus.size()) {
       // Terminal step - we now have one haplotype; recursively generate the second
       Haplotype firstHaplotype = new Haplotype(currentHaplotypeAlleles);
-      generateStrandTwoHaplotypes(maxScorePairsByEthnicity, firstHaplotype, strandTwoOptionsByLocus,
-          new ArrayList<>(), 0);
+      generateStrandTwoHaplotypes(maxScorePairsByEthnicity, firstHaplotype, strandTwoOptionsByLocus, new ArrayList<>(), 0);
     } else {
       // Recursive step -
       Multimap<Strand, HLAType> currentLocus = typesByLocus.get(locusIndex);
@@ -869,8 +859,7 @@ public class ValidationModelBuilder {
       // alignment of the alleles - including whether they are heterozygous or homozygous.
       // However at the first locus we do not need to consider Strand1 + Strand2 AND
       // Strand2 + Strand1, as the resulting haplotype pairs would mirror each other.
-      Set<Strand> firstStrandsSet =
-          locusIndex == 0 ? ImmutableSet.of(Strand.FIRST) : currentLocus.keySet();
+      Set<Strand> firstStrandsSet = locusIndex == 0 ? ImmutableSet.of(Strand.FIRST) : currentLocus.keySet();
 
       // Build the combinations of strand1 + strand2 alleles at this locus
       for (Strand strandOne : firstStrandsSet) {
@@ -882,8 +871,7 @@ public class ValidationModelBuilder {
 
         // sorts in descending order, notice h2's weight is found first
         Comparator<HLAType> c = ((h1, h2) -> {
-          int d = Double.compare(CommonWellDocumented.getEquivStatus(h2).getWeight(),
-              CommonWellDocumented.getEquivStatus(h1).getWeight());
+          int d = Double.compare(CommonWellDocumented.getEquivStatus(h2).getWeight(), CommonWellDocumented.getEquivStatus(h1).getWeight());
           if (d != 0)
             return d;
           return h2.compareTo(h1);
@@ -897,8 +885,7 @@ public class ValidationModelBuilder {
         if (!firstStrandTypes.isEmpty()) {
           bestCWD = CommonWellDocumented.getEquivStatus(firstStrandTypes.get(0)).getWeight();
           i = 1;
-          while (i < firstStrandTypes.size() && CommonWellDocumented
-              .getEquivStatus(firstStrandTypes.get(i)).getWeight() == bestCWD) {
+          while (i < firstStrandTypes.size() && CommonWellDocumented.getEquivStatus(firstStrandTypes.get(i)).getWeight() == bestCWD) {
             i++;
           }
           for (int j = firstStrandTypes.size() - 1; j >= i; j--) {
@@ -909,8 +896,7 @@ public class ValidationModelBuilder {
         if (!secondStrandTypes.isEmpty()) {
           bestCWD = CommonWellDocumented.getEquivStatus(secondStrandTypes.get(0)).getWeight();
           i = 1;
-          while (i < secondStrandTypes.size() && CommonWellDocumented
-              .getEquivStatus(secondStrandTypes.get(i)).getWeight() == bestCWD) {
+          while (i < secondStrandTypes.size() && CommonWellDocumented.getEquivStatus(secondStrandTypes.get(i)).getWeight() == bestCWD) {
             i++;
           }
           for (int j = secondStrandTypes.size() - 1; j >= i; j--) {
@@ -926,8 +912,7 @@ public class ValidationModelBuilder {
           setOrAdd(currentHaplotypeAlleles, currentType, locusIndex);
 
           // Recurse to the next locus
-          generateStrandOneHaplotypes(maxScorePairsByEthnicity, typesByLocus,
-              currentHaplotypeAlleles, strandTwoOptionsByLocus, locusIndex + 1);
+          generateStrandOneHaplotypes(maxScorePairsByEthnicity, typesByLocus, currentHaplotypeAlleles, strandTwoOptionsByLocus, locusIndex + 1);
         }
       }
     }
@@ -943,10 +928,8 @@ public class ValidationModelBuilder {
    * @param currentHaplotypeAlleles Current alleles of the second haplotype
    * @param locusIndex Current locus index in the {@code strandTwoOptionsByLocus} list
    */
-  private void generateStrandTwoHaplotypes(
-      Map<RaceGroup, ScoredHaplotypes> maxScorePairsByEthnicity, Haplotype firstHaplotype,
-      List<List<HLAType>> strandTwoOptionsByLocus, List<HLAType> currentHaplotypeAlleles,
-      int locusIndex) {
+  private void generateStrandTwoHaplotypes(Map<RaceGroup, ScoredHaplotypes> maxScorePairsByEthnicity, Haplotype firstHaplotype,
+      List<List<HLAType>> strandTwoOptionsByLocus, List<HLAType> currentHaplotypeAlleles, int locusIndex) {
     if (locusIndex == strandTwoOptionsByLocus.size()) {
       // Terminal step - we now have two haplotypes so we score them and compare
       final Haplotype e2 = new Haplotype(currentHaplotypeAlleles);
@@ -967,8 +950,8 @@ public class ValidationModelBuilder {
           // if the map doesn't have a value yet
           // or if the current value is less than the new value
           // put the value into the map
-          if (!maxScorePairsByEthnicity.containsKey(ethnicity) || comparators.get(ethnicity)
-              .compare(maxScorePairsByEthnicity.get(ethnicity), scored) < 0) {
+          if (!maxScorePairsByEthnicity.containsKey(ethnicity)
+              || comparators.get(ethnicity).compare(maxScorePairsByEthnicity.get(ethnicity), scored) < 0) {
             maxScorePairsByEthnicity.put(ethnicity, scored);
           }
         }
@@ -979,8 +962,7 @@ public class ValidationModelBuilder {
       // current haplotype
       for (HLAType currentType : strandTwoOptionsByLocus.get(locusIndex)) {
         setOrAdd(currentHaplotypeAlleles, currentType, locusIndex);
-        generateStrandTwoHaplotypes(maxScorePairsByEthnicity, firstHaplotype,
-            strandTwoOptionsByLocus, currentHaplotypeAlleles, locusIndex + 1);
+        generateStrandTwoHaplotypes(maxScorePairsByEthnicity, firstHaplotype, strandTwoOptionsByLocus, currentHaplotypeAlleles, locusIndex + 1);
       }
     }
   }
@@ -1026,8 +1008,7 @@ public class ValidationModelBuilder {
 
     // Sort out our types by CWD status
     for (Strand strand : typesForStrand.keySet()) {
-      Multimap<Status, HLAType> typesByStatus =
-          MultimapBuilder.enumKeys(Status.class).hashSetValues().build();
+      Multimap<Status, HLAType> typesByStatus = MultimapBuilder.enumKeys(Status.class).hashSetValues().build();
       Collection<HLAType> values = typesForStrand.get(strand);
       values.forEach(t -> typesByStatus.put(CommonWellDocumented.getEquivStatus(t), t));
 
@@ -1047,23 +1028,21 @@ public class ValidationModelBuilder {
   }
 
   /**
-   * @return Optional<String> Value is present if the model has not been fully populated, or
-   *         populated incorrectly.
+   * @return Optional<String> Value is present if the model has not been fully populated, or populated
+   *         incorrectly.
    */
   private ValidationResult ensureValidity(boolean show) {
     // Ensure all fields have been set
-    for (Object o : Lists.newArrayList(donorId, source, aLocusCWD, bLocusCWD, cLocusCWD, drbLocus,
-        dqbLocus, dqaLocus, getFinalDPBTypes(), bw4, bw6)) {
+    for (Object o : Lists.newArrayList(donorId, source, aLocusCWD, bLocusCWD, cLocusCWD, drbLocus, dqbLocus, dqaLocus, getFinalDPBTypes(), bw4,
+        bw6)) {
       if (Objects.isNull(o)) {
         return new ValidationResult(false, Optional.of("ValidationModel incomplete"));
       }
     }
     // Ensure all sets have a reasonable number of entries
-    for (Set<?> set : ImmutableList.of(aLocusCWD, bLocusCWD, cLocusCWD, drbLocus, dqbLocus,
-        dqaLocus, getFinalDPBTypes())) {
+    for (Set<?> set : ImmutableList.of(aLocusCWD, bLocusCWD, cLocusCWD, drbLocus, dqbLocus, dqaLocus, getFinalDPBTypes())) {
       if (set.isEmpty() || set.size() > 2) {
-        return new ValidationResult(false,
-            Optional.of("ValidationModel contains invalid allele count: " + set));
+        return new ValidationResult(false, Optional.of("ValidationModel contains invalid allele count: " + set));
       }
     }
     // Note: haplotype maps are OPTIONAL
@@ -1071,8 +1050,7 @@ public class ValidationModelBuilder {
     // DPA was more recently added and in an effort not to error out every time DPA is missing from
     // old files we need to throw a warning
     if (Objects.isNull(dpaLocus)) {
-      JOptionPane.showMessageDialog(new JFrame(), "DPA is missing from this file", "Dialog",
-          JOptionPane.WARNING_MESSAGE);
+      JOptionPane.showMessageDialog(new JFrame(), "DPA is missing from this file", "Dialog", JOptionPane.WARNING_MESSAGE);
     }
 
     // Note: Some DRB345 loci may be empty, but should be sorted
@@ -1177,8 +1155,7 @@ public class ValidationModelBuilder {
     List<String> seroStr = new ArrayList<>();
     seroStr.add(String.valueOf(hlaType.spec().get(0)));
 
-    if (Objects.equals(HLALocus.DPA1, hlaType.locus())
-        || Objects.equals(HLALocus.DPB1, hlaType.locus())) {
+    if (Objects.equals(HLALocus.DPA1, hlaType.locus()) || Objects.equals(HLALocus.DPB1, hlaType.locus())) {
       // DPA and DPB report two fields
       seroStr.add(String.valueOf(hlaType.spec().get(1)));
     }
@@ -1305,8 +1282,7 @@ public class ValidationModelBuilder {
 
     public Collection<String> getMatchingAlleles(String pattern) {
       final RabinKarp rabinKarp = new RabinKarp(pattern);
-      return map.keySet().stream().filter(s -> rabinKarp.search(s) < s.length())
-          .collect(Collectors.toSet());
+      return map.keySet().stream().filter(s -> rabinKarp.search(s) < s.length()).collect(Collectors.toSet());
     }
 
   }
@@ -1336,8 +1312,7 @@ public class ValidationModelBuilder {
 
     @Override
     public String toString() {
-      return seroType.specString() + " [" + hlaType.specString() + " - "
-          + CommonWellDocumented.getStatus(getHlaType()) + "]";
+      return seroType.specString() + " [" + hlaType.specString() + " - " + CommonWellDocumented.getStatus(getHlaType()) + "]";
     }
 
     @Override
@@ -1372,8 +1347,7 @@ public class ValidationModelBuilder {
         }
 
         for (HLAType allele : haplotype.getTypes()) {
-          cwdScore1 = cwdScore1
-              .add(new BigDecimal(CommonWellDocumented.getEquivStatus(allele).getWeight()));
+          cwdScore1 = cwdScore1.add(new BigDecimal(CommonWellDocumented.getEquivStatus(allele).getWeight()));
         }
       }
       BigDecimal cwdScore = cwdScore1;
@@ -1397,8 +1371,7 @@ public class ValidationModelBuilder {
               }
             }
 
-            BigDecimal weights =
-                cwdScore.add(BigDecimal.valueOf(NO_MISSING_WEIGHT * noMissingCount));
+            BigDecimal weights = cwdScore.add(BigDecimal.valueOf(NO_MISSING_WEIGHT * noMissingCount));
 
             double s = weights.add(frequency).doubleValue();
 
@@ -1412,8 +1385,7 @@ public class ValidationModelBuilder {
     }
 
     /**
-     * @return A weighted score for this ethnicity, prioritizing haplotypes without missing
-     *         frequencies.
+     * @return A weighted score for this ethnicity, prioritizing haplotypes without missing frequencies.
      */
     public double getScore(RaceGroup ethnicity) {
       return scoresByEthnicity.get(ethnicity);
@@ -1433,8 +1405,8 @@ public class ValidationModelBuilder {
   }
 
   /**
-   * {@link Comparator} to sort collections of {@link Haplotype}s based on their frequency and the
-   * CWD status of their alleles.
+   * {@link Comparator} to sort collections of {@link Haplotype}s based on their frequency and the CWD
+   * status of their alleles.
    */
   private static class EthnicityHaplotypeComp implements Comparator<ScoredHaplotypes> {
     private RaceGroup ethnicity;
@@ -1474,8 +1446,8 @@ public class ValidationModelBuilder {
     }
 
     /**
-     * Helper method to convert a {@link Haplotype} collection to a sorted list of the alleles
-     * contained in that haplotype.
+     * Helper method to convert a {@link Haplotype} collection to a sorted list of the alleles contained
+     * in that haplotype.
      */
     private List<HLAType> makeList(Collection<Haplotype> haplotypes) {
       List<HLAType> sorted = new ArrayList<>();

--- a/src/main/java/org/pankratzlab/unet/model/ValidationTable.java
+++ b/src/main/java/org/pankratzlab/unet/model/ValidationTable.java
@@ -396,10 +396,13 @@ public class ValidationTable {
   public String generateCSV() {
     StringBuilder builder = new StringBuilder();
 
+    SourceType st = getFirstField(ValidationModel::getSourceType);
+    SourceType st1 = getSecondField(ValidationModel::getSourceType);
+    String sourceType = st == null ? "" : st.getDisplayName();
+    String sourceType2 = st1 == null ? "" : st1.getDisplayName();
     builder.append("Donor ID" + "," + Objects.toString(getFirstField(ValidationModel::getDonorId), "") + ","
         + Objects.toString(getSecondField(ValidationModel::getDonorId), "") + "\n");
-    builder.append("Source" + "," + Objects.toString(getFirstField(ValidationModel::getSourceType), "") + ","
-        + Objects.toString(getSecondField(ValidationModel::getSourceType), "") + "\n");
+    builder.append("Source" + "," + sourceType + "," + sourceType2 + "\n");
     builder.append("A" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getA1) + "\n");
     builder.append("A" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getA2) + "\n");
     builder.append("B" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getB1) + "\n");
@@ -436,7 +439,7 @@ public class ValidationTable {
 
   public enum ValidationKey {
     DONORID("Donor ID", Optional.empty(), ValidationModel::getDonorId, Objects::toString), //
-    SOURCE("Source", Optional.empty(), ValidationModel::getSourceType, Objects::toString), //
+    SOURCE("Source", Optional.empty(), ValidationModel::getSourceType, (o) -> ((SourceType) o).getDisplayName()), //
     A1("A", Optional.of(HLALocus.A), ValidationModel::getA1, ValidationTable::antigenToString), //
     A2("A", Optional.of(HLALocus.A), ValidationModel::getA2, ValidationTable::antigenToString), //
     B1("B", Optional.of(HLALocus.B), ValidationModel::getB1, ValidationTable::antigenToString), //
@@ -572,7 +575,8 @@ public class ValidationTable {
           e.getValue().getLeft().stream().sorted().map(TypePair::getHlaType).map((h) -> h.specString()).collect(Collectors.joining(" / "));
       final String collectTo =
           e.getValue().getRight().stream().sorted().map(TypePair::getHlaType).map((h) -> h.specString()).collect(Collectors.joining(" / "));
-      return "HLA-" + e.getKey().name() + " was remapped from { " + collectFrom + " } to { " + collectTo + " } in " + model.getSourceType();
+      return "HLA-" + e.getKey().name() + " was remapped from { " + collectFrom + " } to { " + collectTo + " } in "
+          + model.getSourceType().getDisplayName();
     }).sorted().distinct().toArray(String[]::new);
   }
 

--- a/src/main/java/org/pankratzlab/unet/model/ValidationTable.java
+++ b/src/main/java/org/pankratzlab/unet/model/ValidationTable.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.pankratzlab.unet.deprecated.hla.HLALocus;
 import org.pankratzlab.unet.deprecated.hla.HLAType;
@@ -36,7 +37,9 @@ import org.pankratzlab.unet.hapstats.HaplotypeFrequencies;
 import org.pankratzlab.unet.hapstats.RaceGroup;
 import org.pankratzlab.unet.model.ValidationModelBuilder.TypePair;
 import org.pankratzlab.unet.model.ValidationRow.RowBuilder;
+
 import com.google.common.collect.ImmutableMap;
+
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.BooleanProperty;
@@ -72,7 +75,7 @@ public class ValidationTable {
   private final ReadOnlyListWrapper<DRDQHaplotypeRow> drdqHaplotypeRows;
   private WritableImage validationImage = null;
 
-  public final static String REMAP_SYMBOL = "⦿";
+  public static final String REMAP_SYMBOL = "⦿";
 
   public ValidationTable() {
     isValidWrapper = new ReadOnlyBooleanWrapper();
@@ -98,7 +101,9 @@ public class ValidationTable {
     secondModelWrapper.addListener((v, o, n) -> generateCSV());
   }
 
-  /** @return The donor ID for this validation (if available) */
+  /**
+   * @return The donor ID for this validation (if available)
+   */
   public String getId() {
     if (firstModelWrapper != null) {
       return firstModelWrapper.get().getDonorId();
@@ -133,17 +138,23 @@ public class ValidationTable {
     return secondSourceTypeWrapper.getReadOnlyProperty();
   }
 
-  /** @return An image of the validation state */
+  /**
+   * @return An image of the validation state
+   */
   public WritableImage getValidationImage() {
     return validationImage;
   }
 
-  /** @param validationImage An image representation of the validation state */
+  /**
+   * @param validationImage An image representation of the validation state
+   */
   public void setValidationImage(WritableImage validationImage) {
     this.validationImage = validationImage;
   }
 
-  /** @param model New {@link ValidationModel} for the first column in the table */
+  /**
+   * @param model New {@link ValidationModel} for the first column in the table
+   */
   public void setFirstModel(ValidationModel model) {
     firstFileWrapper.set(model.getFile());
     firstSourceWrapper.set(model.getSource());
@@ -151,7 +162,9 @@ public class ValidationTable {
     firstModelWrapper.set(model);
   }
 
-  /** @param model New {@link ValidationModel} for the second column in the table */
+  /**
+   * @param model New {@link ValidationModel} for the second column in the table
+   */
   public void setSecondModel(ValidationModel model) {
     secondFileWrapper.set(model.getFile());
     secondSourceWrapper.set(model.getSource());
@@ -159,27 +172,37 @@ public class ValidationTable {
     secondModelWrapper.set(model);
   }
 
-  /** @return A {@link BooleanProperty} tracking the validity of the complete table */
+  /**
+   * @return A {@link BooleanProperty} tracking the validity of the complete table
+   */
   public ReadOnlyBooleanProperty isValidProperty() {
     return isValidWrapper.getReadOnlyProperty();
   }
 
-  /** @return A {@link BooleanProperty} tracking the validity of the complete table */
+  /**
+   * @return A {@link BooleanProperty} tracking the validity of the complete table
+   */
   public BooleanBinding hasAuditLines() {
     return auditLogLines.emptyProperty().not();
   }
 
-  /** @return The {@link ValidationRow}s for this model, e.g. for display */
+  /**
+   * @return The {@link ValidationRow}s for this model, e.g. for display
+   */
   public ReadOnlyListProperty<ValidationRow<?>> getValidationRows() {
     return validationRows.getReadOnlyProperty();
   }
 
-  /** @return The B-C Haplotype rows for this model, e.g. for display */
+  /**
+   * @return The B-C Haplotype rows for this model, e.g. for display
+   */
   public ReadOnlyListProperty<BCHaplotypeRow> getBCHaplotypeRows() {
     return bcHaplotypeRows.getReadOnlyProperty();
   }
 
-  /** @return The DRB1-DQB1-DRB345 Haplotype rows for this model, e.g. for display */
+  /**
+   * @return The DRB1-DQB1-DRB345 Haplotype rows for this model, e.g. for display
+   */
   public ReadOnlyListProperty<DRDQHaplotypeRow> getDRDQHaplotypeRows() {
     return drdqHaplotypeRows.getReadOnlyProperty();
   }
@@ -188,81 +211,180 @@ public class ValidationTable {
   private void generateRows() {
     // FIXME the row labels and row type should probably be linked in the ValidationModel
     validationRows.clear();
-    makeValidationRow(validationRows, "Donor ID", ValidationModel::getDonorId,
-        StringValidationRow::makeRow, false, false);
-    makeValidationRow(validationRows, generateRowLabel(HLALocus.A), ValidationModel::getA1,
-        AntigenValidationRow::makeRow, wasRemapped(HLALocus.A, firstModelWrapper),
+    makeValidationRow(
+        validationRows,
+        "Donor ID",
+        ValidationModel::getDonorId,
+        StringValidationRow::makeRow,
+        false,
+        false);
+    makeValidationRow(
+        validationRows,
+        generateRowLabel(HLALocus.A),
+        ValidationModel::getA1,
+        AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.A, firstModelWrapper),
         wasRemapped(HLALocus.A, secondModelWrapper));
-    makeValidationRow(validationRows, generateRowLabel(HLALocus.A), ValidationModel::getA2,
-        AntigenValidationRow::makeRow, wasRemapped(HLALocus.A, firstModelWrapper),
+    makeValidationRow(
+        validationRows,
+        generateRowLabel(HLALocus.A),
+        ValidationModel::getA2,
+        AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.A, firstModelWrapper),
         wasRemapped(HLALocus.A, secondModelWrapper));
 
-    makeValidationRow(validationRows, generateRowLabel(HLALocus.B), ValidationModel::getB1,
-        AntigenValidationRow::makeRow, wasRemapped(HLALocus.B, firstModelWrapper),
+    makeValidationRow(
+        validationRows,
+        generateRowLabel(HLALocus.B),
+        ValidationModel::getB1,
+        AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.B, firstModelWrapper),
         wasRemapped(HLALocus.B, secondModelWrapper));
-    makeValidationRow(validationRows, generateRowLabel(HLALocus.B), ValidationModel::getB2,
-        AntigenValidationRow::makeRow, wasRemapped(HLALocus.B, firstModelWrapper),
+    makeValidationRow(
+        validationRows,
+        generateRowLabel(HLALocus.B),
+        ValidationModel::getB2,
+        AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.B, firstModelWrapper),
         wasRemapped(HLALocus.B, secondModelWrapper));
 
-    makeValidationRow(validationRows, "BW4", ValidationModel::isBw4, StringValidationRow::makeRow,
-        false, false);
-    makeValidationRow(validationRows, "BW6", ValidationModel::isBw6, StringValidationRow::makeRow,
-        false, false);
+    makeValidationRow(
+        validationRows, "BW4", ValidationModel::isBw4, StringValidationRow::makeRow, false, false);
+    makeValidationRow(
+        validationRows, "BW6", ValidationModel::isBw6, StringValidationRow::makeRow, false, false);
 
-    makeValidationRow(validationRows, generateRowLabel(HLALocus.C), ValidationModel::getC1,
-        AntigenValidationRow::makeRow, wasRemapped(HLALocus.C, firstModelWrapper),
+    makeValidationRow(
+        validationRows,
+        generateRowLabel(HLALocus.C),
+        ValidationModel::getC1,
+        AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.C, firstModelWrapper),
         wasRemapped(HLALocus.C, secondModelWrapper));
-    makeValidationRow(validationRows, generateRowLabel(HLALocus.C), ValidationModel::getC2,
-        AntigenValidationRow::makeRow, wasRemapped(HLALocus.C, firstModelWrapper),
+    makeValidationRow(
+        validationRows,
+        generateRowLabel(HLALocus.C),
+        ValidationModel::getC2,
+        AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.C, firstModelWrapper),
         wasRemapped(HLALocus.C, secondModelWrapper));
 
-    makeValidationRow(validationRows, generateRowLabel(HLALocus.DRB1), ValidationModel::getDRB1,
-        AntigenValidationRow::makeRow, wasRemapped(HLALocus.DRB1, firstModelWrapper),
+    makeValidationRow(
+        validationRows,
+        generateRowLabel(HLALocus.DRB1),
+        ValidationModel::getDRB1,
+        AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.DRB1, firstModelWrapper),
         wasRemapped(HLALocus.DRB1, secondModelWrapper));
-    makeValidationRow(validationRows, generateRowLabel(HLALocus.DRB1), ValidationModel::getDRB2,
-        AntigenValidationRow::makeRow, wasRemapped(HLALocus.DRB1, firstModelWrapper),
+    makeValidationRow(
+        validationRows,
+        generateRowLabel(HLALocus.DRB1),
+        ValidationModel::getDRB2,
+        AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.DRB1, firstModelWrapper),
         wasRemapped(HLALocus.DRB1, secondModelWrapper));
 
-    makeValidationRow(validationRows, generateRowLabel(HLALocus.DQB1), ValidationModel::getDQB1,
-        AntigenValidationRow::makeRow, wasRemapped(HLALocus.DQB1, firstModelWrapper),
+    makeValidationRow(
+        validationRows,
+        generateRowLabel(HLALocus.DQB1),
+        ValidationModel::getDQB1,
+        AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.DQB1, firstModelWrapper),
         wasRemapped(HLALocus.DQB1, secondModelWrapper));
-    makeValidationRow(validationRows, generateRowLabel(HLALocus.DQB1), ValidationModel::getDQB2,
-        AntigenValidationRow::makeRow, wasRemapped(HLALocus.DQB1, firstModelWrapper),
+    makeValidationRow(
+        validationRows,
+        generateRowLabel(HLALocus.DQB1),
+        ValidationModel::getDQB2,
+        AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.DQB1, firstModelWrapper),
         wasRemapped(HLALocus.DQB1, secondModelWrapper));
 
-    makeValidationRow(validationRows, generateRowLabel(HLALocus.DQA1), ValidationModel::getDQA1,
-        AntigenValidationRow::makeRow, wasRemapped(HLALocus.DQA1, firstModelWrapper),
+    makeValidationRow(
+        validationRows,
+        generateRowLabel(HLALocus.DQA1),
+        ValidationModel::getDQA1,
+        AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.DQA1, firstModelWrapper),
         wasRemapped(HLALocus.DQA1, secondModelWrapper));
-    makeValidationRow(validationRows, generateRowLabel(HLALocus.DQA1), ValidationModel::getDQA2,
-        AntigenValidationRow::makeRow, wasRemapped(HLALocus.DQA1, firstModelWrapper),
+    makeValidationRow(
+        validationRows,
+        generateRowLabel(HLALocus.DQA1),
+        ValidationModel::getDQA2,
+        AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.DQA1, firstModelWrapper),
         wasRemapped(HLALocus.DQA1, secondModelWrapper));
 
-    makeValidationRow(validationRows, generateRowLabel(HLALocus.DPA1), ValidationModel::getDPA1,
-        AntigenValidationRow::makeRow, wasRemapped(HLALocus.DPA1, firstModelWrapper),
+    makeValidationRow(
+        validationRows,
+        generateRowLabel(HLALocus.DPA1),
+        ValidationModel::getDPA1,
+        AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.DPA1, firstModelWrapper),
         wasRemapped(HLALocus.DPA1, secondModelWrapper));
-    makeValidationRow(validationRows, generateRowLabel(HLALocus.DPA1), ValidationModel::getDPA2,
-        AntigenValidationRow::makeRow, wasRemapped(HLALocus.DPA1, firstModelWrapper),
+    makeValidationRow(
+        validationRows,
+        generateRowLabel(HLALocus.DPA1),
+        ValidationModel::getDPA2,
+        AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.DPA1, firstModelWrapper),
         wasRemapped(HLALocus.DPA1, secondModelWrapper));
 
-    makeValidationRow(validationRows, generateRowLabel(HLALocus.DPB1), ValidationModel::getDPB1,
-        AlleleValidationRow::makeRow, wasRemapped(HLALocus.DPB1, firstModelWrapper),
+    makeValidationRow(
+        validationRows,
+        generateRowLabel(HLALocus.DPB1),
+        ValidationModel::getDPB1,
+        AlleleValidationRow::makeRow,
+        wasRemapped(HLALocus.DPB1, firstModelWrapper),
         wasRemapped(HLALocus.DPB1, secondModelWrapper));
-    makeValidationRow(validationRows, generateRowLabel(HLALocus.DPB1), ValidationModel::getDPB2,
-        AlleleValidationRow::makeRow, wasRemapped(HLALocus.DPB1, firstModelWrapper),
+    makeValidationRow(
+        validationRows,
+        generateRowLabel(HLALocus.DPB1),
+        ValidationModel::getDPB2,
+        AlleleValidationRow::makeRow,
+        wasRemapped(HLALocus.DPB1, firstModelWrapper),
         wasRemapped(HLALocus.DPB1, secondModelWrapper));
 
-    makeValidationRow(validationRows, "DR51 1", ValidationModel::getDR51_1,
-        DR345ValidationRow::makeRow, false, false);
-    makeValidationRow(validationRows, "DR51 2", ValidationModel::getDR51_2,
-        DR345ValidationRow::makeRow, false, false);
-    makeValidationRow(validationRows, "DR52 1", ValidationModel::getDR52_1,
-        DR345ValidationRow::makeRow, false, false);
-    makeValidationRow(validationRows, "DR52 2", ValidationModel::getDR52_2,
-        DR345ValidationRow::makeRow, false, false);
-    makeValidationRow(validationRows, "DR53 1", ValidationModel::getDR53_1,
-        DR345ValidationRow::makeRow, false, false);
-    makeValidationRow(validationRows, "DR53 2", ValidationModel::getDR53_2,
-        DR345ValidationRow::makeRow, false, false);
+    makeValidationRow(
+        validationRows,
+        "DR51 1",
+        ValidationModel::getDR51_1,
+        DR345ValidationRow::makeRow,
+        false,
+        false);
+    makeValidationRow(
+        validationRows,
+        "DR51 2",
+        ValidationModel::getDR51_2,
+        DR345ValidationRow::makeRow,
+        false,
+        false);
+    makeValidationRow(
+        validationRows,
+        "DR52 1",
+        ValidationModel::getDR52_1,
+        DR345ValidationRow::makeRow,
+        false,
+        false);
+    makeValidationRow(
+        validationRows,
+        "DR52 2",
+        ValidationModel::getDR52_2,
+        DR345ValidationRow::makeRow,
+        false,
+        false);
+    makeValidationRow(
+        validationRows,
+        "DR53 1",
+        ValidationModel::getDR53_1,
+        DR345ValidationRow::makeRow,
+        false,
+        false);
+    makeValidationRow(
+        validationRows,
+        "DR53 2",
+        ValidationModel::getDR53_2,
+        DR345ValidationRow::makeRow,
+        false,
+        false);
 
     // A Table is valid if all its Rows are valid
     ObservableBooleanValue validBinding = null;
@@ -275,7 +397,7 @@ public class ValidationTable {
     drdqHaplotypeRows.clear();
 
     ValidationModel model = chooseHaplotypeModel(firstModelWrapper.get(), secondModelWrapper.get());
-    if (Objects.nonNull(model) && HaplotypeFrequencies.successfullyInitialized()) {
+    if (Objects.nonNull(model) && HaplotypeFrequencies.successfullyInitialized().get()) {
       makeBCHaplotypeRows(bcHaplotypeRows, model);
       makeDRDQHaplotypeRows(drdqHaplotypeRows, model);
     }
@@ -294,23 +416,33 @@ public class ValidationTable {
     return (modelWrapper.isNotNull().get() && modelWrapper.get().wasRemapped(locus));
   }
 
-  private void makeDRDQHaplotypeRows(ReadOnlyListWrapper<DRDQHaplotypeRow> rows,
-      ValidationModel model) {
+  private void makeDRDQHaplotypeRows(
+      ReadOnlyListWrapper<DRDQHaplotypeRow> rows, ValidationModel model) {
     for (RaceGroup ethnicity : RaceGroup.values()) {
-      model.getDRDQHaplotypes().get(ethnicity).forEach(haplotype -> {
-        rows.add(new DRDQHaplotypeRow(ethnicity, haplotype));
-      });
-    } ;
+      model
+          .getDRDQHaplotypes()
+          .get(ethnicity)
+          .forEach(
+              haplotype -> {
+                rows.add(new DRDQHaplotypeRow(ethnicity, haplotype));
+              });
+    }
+    ;
   }
 
   /** Use the given model to populate a list of {@link BCHaplotypeRow}s */
-  private void makeBCHaplotypeRows(ReadOnlyListWrapper<BCHaplotypeRow> rows,
-      ValidationModel model) {
+  private void makeBCHaplotypeRows(
+      ReadOnlyListWrapper<BCHaplotypeRow> rows, ValidationModel model) {
     for (RaceGroup ethnicity : RaceGroup.values()) {
-      model.getBCHaplotypes().get(ethnicity).forEach(haplotype -> {
-        rows.add(new BCHaplotypeRow(ethnicity, haplotype));
-      });
-    } ;
+      model
+          .getBCHaplotypes()
+          .get(ethnicity)
+          .forEach(
+              haplotype -> {
+                rows.add(new BCHaplotypeRow(ethnicity, haplotype));
+              });
+    }
+    ;
   }
 
   /**
@@ -332,11 +464,20 @@ public class ValidationTable {
    * @param rowLabel Description of this row (first column)
    * @param getter Method to use to retrieve this row's value
    */
-  private <T> void makeValidationRow(List<ValidationRow<?>> rows, String rowLabel,
-      Function<ValidationModel, T> getter, RowBuilder<T> builder, boolean wasRemappedFirst,
+  private <T> void makeValidationRow(
+      List<ValidationRow<?>> rows,
+      String rowLabel,
+      Function<ValidationModel, T> getter,
+      RowBuilder<T> builder,
+      boolean wasRemappedFirst,
       boolean wasRemappedSecond) {
-    rows.add(builder.makeRow(rowLabel, getFirstField(getter), getSecondField(getter),
-        wasRemappedFirst, wasRemappedSecond));
+    rows.add(
+        builder.makeRow(
+            rowLabel,
+            getFirstField(getter),
+            getSecondField(getter),
+            wasRemappedFirst,
+            wasRemappedSecond));
   }
 
   /**
@@ -393,42 +534,60 @@ public class ValidationTable {
   public String generateCSV() {
     StringBuilder builder = new StringBuilder();
 
-    builder
-        .append("Donor ID" + "," + Objects.toString(getFirstField(ValidationModel::getDonorId), "")
-            + "," + Objects.toString(getSecondField(ValidationModel::getDonorId), "") + "\n");
-    builder
-        .append("Source" + "," + Objects.toString(getFirstField(ValidationModel::getSourceType), "")
-            + "," + Objects.toString(getSecondField(ValidationModel::getSourceType), "") + "\n");
+    builder.append(
+        "Donor ID"
+            + ","
+            + Objects.toString(getFirstField(ValidationModel::getDonorId), "")
+            + ","
+            + Objects.toString(getSecondField(ValidationModel::getDonorId), "")
+            + "\n");
+    builder.append(
+        "Source"
+            + ","
+            + Objects.toString(getFirstField(ValidationModel::getSourceType), "")
+            + ","
+            + Objects.toString(getSecondField(ValidationModel::getSourceType), "")
+            + "\n");
     builder.append("A" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getA1) + "\n");
     builder.append("A" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getA2) + "\n");
     builder.append("B" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getB1) + "\n");
     builder.append("B" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getB2) + "\n");
-    builder.append("BW4" + "," + Objects.toString(getFirstField(ValidationModel::isBw4), "") + ","
-        + Objects.toString(getSecondField(ValidationModel::isBw4), "") + "\n");
-    builder.append("BW6" + "," + Objects.toString(getFirstField(ValidationModel::isBw6), "") + ","
-        + Objects.toString(getSecondField(ValidationModel::isBw6), "") + "\n");
+    builder.append(
+        "BW4"
+            + ","
+            + Objects.toString(getFirstField(ValidationModel::isBw4), "")
+            + ","
+            + Objects.toString(getSecondField(ValidationModel::isBw4), "")
+            + "\n");
+    builder.append(
+        "BW6"
+            + ","
+            + Objects.toString(getFirstField(ValidationModel::isBw6), "")
+            + ","
+            + Objects.toString(getSecondField(ValidationModel::isBw6), "")
+            + "\n");
     builder.append("C" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getC1) + "\n");
     builder.append("C" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getC2) + "\n");
-    builder
-        .append("DRB1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDRB1) + "\n");
-    builder
-        .append("DRB1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDRB2) + "\n");
-    builder
-        .append("DQB1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDQB1) + "\n");
-    builder
-        .append("DQB1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDQB2) + "\n");
-    builder
-        .append("DQA1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDQA1) + "\n");
-    builder
-        .append("DQA1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDQA2) + "\n");
+    builder.append(
+        "DRB1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDRB1) + "\n");
+    builder.append(
+        "DRB1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDRB2) + "\n");
+    builder.append(
+        "DQB1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDQB1) + "\n");
+    builder.append(
+        "DQB1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDQB2) + "\n");
+    builder.append(
+        "DQA1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDQA1) + "\n");
+    builder.append(
+        "DQA1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDQA2) + "\n");
     builder.append(
         "DPB1" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDPB1) + "\n");
     builder.append(
         "DPB1" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDPB2) + "\n");
-    builder
-        .append("DPA1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDPA1) + "\n");
-    builder
-        .append("DPA1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDPA2) + "\n");
+    builder.append(
+        "DPA1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDPA1) + "\n");
+    builder.append(
+        "DPA1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDPA2) + "\n");
     builder.append(
         "DR51 1" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDR51_1) + "\n");
     builder.append(
@@ -443,15 +602,14 @@ public class ValidationTable {
         "DPB3 2" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDR53_2) + "\n");
 
     return builder.toString();
-
   }
 
   /**
    * @return The value of the given getter in the given model, or {@code null} if the target model
-   *         is null.
+   *     is null.
    */
-  private <T> T getValueFromModel(Function<ValidationModel, T> getter,
-      ReadOnlyObjectWrapper<ValidationModel> wrapper) {
+  private <T> T getValueFromModel(
+      Function<ValidationModel, T> getter, ReadOnlyObjectWrapper<ValidationModel> wrapper) {
     if (Objects.isNull(wrapper.get())) {
       return null;
     }
@@ -467,31 +625,52 @@ public class ValidationTable {
   }
 
   public ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> getFirstRemappings() {
-    if (firstModelWrapper.isNotNull().get())
-      return firstModelWrapper.get().getRemappings();
+    if (firstModelWrapper.isNotNull().get()) return firstModelWrapper.get().getRemappings();
     return ImmutableMap.of();
   }
 
   public ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> getSecondRemappings() {
-    if (secondModelWrapper.isNotNull().get())
-      return secondModelWrapper.get().getRemappings();
+    if (secondModelWrapper.isNotNull().get()) return secondModelWrapper.get().getRemappings();
     return ImmutableMap.of();
   }
 
   private String[] generateRemappings(ValidationModel model) {
-    return model.getRemappings().entrySet().stream().map(e -> {
-      final String collectFrom = e.getValue().getLeft().stream().sorted().map(TypePair::getHlaType)
-          .map((h) -> h.specString()).collect(Collectors.joining(" / "));
-      final String collectTo = e.getValue().getRight().stream().sorted().map(TypePair::getHlaType)
-          .map((h) -> h.specString()).collect(Collectors.joining(" / "));
-      return "HLA-" + e.getKey().name() + " was remapped from { " + collectFrom + " } to { "
-          + collectTo + " } in " + model.getSourceType();
-    }).sorted().distinct().toArray(String[]::new);
+    return model.getRemappings().entrySet().stream()
+        .map(
+            e -> {
+              final String collectFrom =
+                  e.getValue().getLeft().stream()
+                      .sorted()
+                      .map(TypePair::getHlaType)
+                      .map((h) -> h.specString())
+                      .collect(Collectors.joining(" / "));
+              final String collectTo =
+                  e.getValue().getRight().stream()
+                      .sorted()
+                      .map(TypePair::getHlaType)
+                      .map((h) -> h.specString())
+                      .collect(Collectors.joining(" / "));
+              return "HLA-"
+                  + e.getKey().name()
+                  + " was remapped from { "
+                  + collectFrom
+                  + " } to { "
+                  + collectTo
+                  + " } in "
+                  + model.getSourceType();
+            })
+        .sorted()
+        .distinct()
+        .toArray(String[]::new);
   }
 
   public ObservableValue<String> getAuditLogLines() {
-    return Bindings.createStringBinding(() -> auditLogLines.stream()
-        .map(s -> REMAP_SYMBOL + " " + s).collect(Collectors.joining("\n")), auditLogLines);
+    return Bindings.createStringBinding(
+        () ->
+            auditLogLines.stream()
+                .map(s -> REMAP_SYMBOL + " " + s)
+                .collect(Collectors.joining("\n")),
+        auditLogLines);
   }
 
   public ObservableValue<Number> getAuditLogLineCount() {

--- a/src/main/java/org/pankratzlab/unet/model/ValidationTable.java
+++ b/src/main/java/org/pankratzlab/unet/model/ValidationTable.java
@@ -21,13 +21,11 @@
  */
 package org.pankratzlab.unet.model;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
@@ -433,10 +431,6 @@ public class ValidationTable {
     return builder.toString();
   }
 
-  public TableData getTableData() {
-    return new TableData(this);
-  }
-
   public enum ValidationKey {
     DONORID("Donor ID", Optional.empty(), ValidationModel::getDonorId, Objects::toString), //
     SOURCE("Source", Optional.empty(), ValidationModel::getSourceType, (o) -> ((SourceType) o).getDisplayName()), //
@@ -478,62 +472,16 @@ public class ValidationTable {
       this.toString = toString;
     }
 
+    public String get(ValidationModel model) {
+      return toString.apply(getter.apply(model));
+    }
+
     public String getFirst(ValidationTable table) {
       return toString.apply(table.getFirstField(getter));
     }
 
     public String getSecond(ValidationTable table) {
       return toString.apply(table.getSecondField(getter));
-    }
-
-  }
-
-  public static class TableData {
-    private final Map<ValidationKey, String> first = new HashMap<>();
-    private final Map<ValidationKey, String> second = new HashMap<>();
-    private final ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> firstRemaps;
-    private final ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> secondRemaps;
-
-    public TableData(ValidationTable t) {
-      for (ValidationKey k : ValidationKey.values()) {
-        first.put(k, k.getFirst(t));
-        second.put(k, k.getSecond(t));
-      }
-      this.firstRemaps = t.getFirstRemappings();
-      this.secondRemaps = t.getSecondRemappings();
-    }
-
-    public String getCSVLine(ValidationKey k) {
-      StringJoiner sj = new StringJoiner(",");
-      sj.add(k.fieldName).add(first.get(k)).add(second.get(k)).add(Boolean.toString(first.getOrDefault(k, "").equals(second.getOrDefault(k, ""))));
-      return sj.toString();
-    }
-
-    public boolean isValid() {
-      for (ValidationKey k : ValidationKey.values()) {
-        if (k == ValidationKey.SOURCE)
-          continue;
-        if (!getFirst(k).equals(getSecond(k))) {
-          return false;
-        }
-      }
-      return true;
-    }
-
-    public String getFirst(ValidationKey key) {
-      return first.getOrDefault(key, "");
-    }
-
-    public String getSecond(ValidationKey key) {
-      return second.getOrDefault(key, "");
-    }
-
-    public ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> getFirstRemaps() {
-      return firstRemaps;
-    }
-
-    public ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> getSecondRemaps() {
-      return secondRemaps;
     }
 
   }
@@ -551,10 +499,52 @@ public class ValidationTable {
 
   private void generateAuditLogLines() {
     auditLogLines.clear();
-    if (firstModelWrapper.isNotNull().get())
+    if (firstModelWrapper.isNotNull().get()) {
       auditLogLines.addAll(generateRemappings(firstModelWrapper.get()));
-    if (secondModelWrapper.isNotNull().get())
+      auditLogLines.addAll(firstModelWrapper.get().getAuditMessages());
+      auditLogLines.addAll(generateManualAssignments(firstModelWrapper.get()));
+    }
+    if (secondModelWrapper.isNotNull().get()) {
       auditLogLines.addAll(generateRemappings(secondModelWrapper.get()));
+      auditLogLines.addAll(secondModelWrapper.get().getAuditMessages());
+      auditLogLines.addAll(generateManualAssignments(secondModelWrapper.get()));
+    }
+  }
+
+  private String[] generateManualAssignments(ValidationModel validationModel) {
+    return validationModel.getManuallyAssignedLoci().entrySet().stream().sorted((e1, e2) -> e1.getKey().compareTo(e2.getKey()))
+        .map(e -> "HLA-" + e.getKey().name() + " was manually assigned to ["
+            + e.getValue().stream().sorted().map(HLAType::toString).collect(Collectors.joining(" / ")) + "] in "
+            + validationModel.getSourceType().getDisplayName())
+        .toArray(String[]::new);
+  }
+
+  public List<String> getFirstModelAuditLog() {
+    List<String> log = new ArrayList<>();
+    if (firstModelWrapper.isNotNull().get()) {
+      for (String s : generateRemappings(firstModelWrapper.get())) {
+        log.add(s);
+      }
+      log.addAll(firstModelWrapper.get().getAuditMessages());
+      for (String s : generateManualAssignments(firstModelWrapper.get())) {
+        log.add(s);
+      }
+    }
+    return log;
+  }
+
+  public List<String> getSecondModelAuditLog() {
+    List<String> log = new ArrayList<>();
+    if (secondModelWrapper.isNotNull().get()) {
+      for (String s : generateRemappings(secondModelWrapper.get())) {
+        log.add(s);
+      }
+      log.addAll(firstModelWrapper.get().getAuditMessages());
+      for (String s : generateManualAssignments(secondModelWrapper.get())) {
+        log.add(s);
+      }
+    }
+    return log;
   }
 
   public ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> getFirstRemappings() {

--- a/src/main/java/org/pankratzlab/unet/model/ValidationTable.java
+++ b/src/main/java/org/pankratzlab/unet/model/ValidationTable.java
@@ -21,13 +21,17 @@
  */
 package org.pankratzlab.unet.model;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import org.apache.commons.lang3.tuple.Pair;
+import org.pankratzlab.unet.deprecated.hla.Antigen;
 import org.pankratzlab.unet.deprecated.hla.HLALocus;
 import org.pankratzlab.unet.deprecated.hla.HLAType;
 import org.pankratzlab.unet.deprecated.hla.SeroType;
@@ -37,9 +41,7 @@ import org.pankratzlab.unet.hapstats.HaplotypeFrequencies;
 import org.pankratzlab.unet.hapstats.RaceGroup;
 import org.pankratzlab.unet.model.ValidationModelBuilder.TypePair;
 import org.pankratzlab.unet.model.ValidationRow.RowBuilder;
-
 import com.google.common.collect.ImmutableMap;
-
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.BooleanProperty;
@@ -211,180 +213,56 @@ public class ValidationTable {
   private void generateRows() {
     // FIXME the row labels and row type should probably be linked in the ValidationModel
     validationRows.clear();
-    makeValidationRow(
-        validationRows,
-        "Donor ID",
-        ValidationModel::getDonorId,
-        StringValidationRow::makeRow,
-        false,
-        false);
-    makeValidationRow(
-        validationRows,
-        generateRowLabel(HLALocus.A),
-        ValidationModel::getA1,
-        AntigenValidationRow::makeRow,
-        wasRemapped(HLALocus.A, firstModelWrapper),
-        wasRemapped(HLALocus.A, secondModelWrapper));
-    makeValidationRow(
-        validationRows,
-        generateRowLabel(HLALocus.A),
-        ValidationModel::getA2,
-        AntigenValidationRow::makeRow,
-        wasRemapped(HLALocus.A, firstModelWrapper),
-        wasRemapped(HLALocus.A, secondModelWrapper));
+    makeValidationRow(validationRows, "Donor ID", ValidationModel::getDonorId, StringValidationRow::makeRow, false, false);
+    makeValidationRow(validationRows, generateRowLabel(HLALocus.A), ValidationModel::getA1, AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.A, firstModelWrapper), wasRemapped(HLALocus.A, secondModelWrapper));
+    makeValidationRow(validationRows, generateRowLabel(HLALocus.A), ValidationModel::getA2, AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.A, firstModelWrapper), wasRemapped(HLALocus.A, secondModelWrapper));
 
-    makeValidationRow(
-        validationRows,
-        generateRowLabel(HLALocus.B),
-        ValidationModel::getB1,
-        AntigenValidationRow::makeRow,
-        wasRemapped(HLALocus.B, firstModelWrapper),
-        wasRemapped(HLALocus.B, secondModelWrapper));
-    makeValidationRow(
-        validationRows,
-        generateRowLabel(HLALocus.B),
-        ValidationModel::getB2,
-        AntigenValidationRow::makeRow,
-        wasRemapped(HLALocus.B, firstModelWrapper),
-        wasRemapped(HLALocus.B, secondModelWrapper));
+    makeValidationRow(validationRows, generateRowLabel(HLALocus.B), ValidationModel::getB1, AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.B, firstModelWrapper), wasRemapped(HLALocus.B, secondModelWrapper));
+    makeValidationRow(validationRows, generateRowLabel(HLALocus.B), ValidationModel::getB2, AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.B, firstModelWrapper), wasRemapped(HLALocus.B, secondModelWrapper));
 
-    makeValidationRow(
-        validationRows, "BW4", ValidationModel::isBw4, StringValidationRow::makeRow, false, false);
-    makeValidationRow(
-        validationRows, "BW6", ValidationModel::isBw6, StringValidationRow::makeRow, false, false);
+    makeValidationRow(validationRows, "BW4", ValidationModel::isBw4, StringValidationRow::makeRow, false, false);
+    makeValidationRow(validationRows, "BW6", ValidationModel::isBw6, StringValidationRow::makeRow, false, false);
 
-    makeValidationRow(
-        validationRows,
-        generateRowLabel(HLALocus.C),
-        ValidationModel::getC1,
-        AntigenValidationRow::makeRow,
-        wasRemapped(HLALocus.C, firstModelWrapper),
-        wasRemapped(HLALocus.C, secondModelWrapper));
-    makeValidationRow(
-        validationRows,
-        generateRowLabel(HLALocus.C),
-        ValidationModel::getC2,
-        AntigenValidationRow::makeRow,
-        wasRemapped(HLALocus.C, firstModelWrapper),
-        wasRemapped(HLALocus.C, secondModelWrapper));
+    makeValidationRow(validationRows, generateRowLabel(HLALocus.C), ValidationModel::getC1, AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.C, firstModelWrapper), wasRemapped(HLALocus.C, secondModelWrapper));
+    makeValidationRow(validationRows, generateRowLabel(HLALocus.C), ValidationModel::getC2, AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.C, firstModelWrapper), wasRemapped(HLALocus.C, secondModelWrapper));
 
-    makeValidationRow(
-        validationRows,
-        generateRowLabel(HLALocus.DRB1),
-        ValidationModel::getDRB1,
-        AntigenValidationRow::makeRow,
-        wasRemapped(HLALocus.DRB1, firstModelWrapper),
-        wasRemapped(HLALocus.DRB1, secondModelWrapper));
-    makeValidationRow(
-        validationRows,
-        generateRowLabel(HLALocus.DRB1),
-        ValidationModel::getDRB2,
-        AntigenValidationRow::makeRow,
-        wasRemapped(HLALocus.DRB1, firstModelWrapper),
-        wasRemapped(HLALocus.DRB1, secondModelWrapper));
+    makeValidationRow(validationRows, generateRowLabel(HLALocus.DRB1), ValidationModel::getDRB1, AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.DRB1, firstModelWrapper), wasRemapped(HLALocus.DRB1, secondModelWrapper));
+    makeValidationRow(validationRows, generateRowLabel(HLALocus.DRB1), ValidationModel::getDRB2, AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.DRB1, firstModelWrapper), wasRemapped(HLALocus.DRB1, secondModelWrapper));
 
-    makeValidationRow(
-        validationRows,
-        generateRowLabel(HLALocus.DQB1),
-        ValidationModel::getDQB1,
-        AntigenValidationRow::makeRow,
-        wasRemapped(HLALocus.DQB1, firstModelWrapper),
-        wasRemapped(HLALocus.DQB1, secondModelWrapper));
-    makeValidationRow(
-        validationRows,
-        generateRowLabel(HLALocus.DQB1),
-        ValidationModel::getDQB2,
-        AntigenValidationRow::makeRow,
-        wasRemapped(HLALocus.DQB1, firstModelWrapper),
-        wasRemapped(HLALocus.DQB1, secondModelWrapper));
+    makeValidationRow(validationRows, generateRowLabel(HLALocus.DQB1), ValidationModel::getDQB1, AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.DQB1, firstModelWrapper), wasRemapped(HLALocus.DQB1, secondModelWrapper));
+    makeValidationRow(validationRows, generateRowLabel(HLALocus.DQB1), ValidationModel::getDQB2, AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.DQB1, firstModelWrapper), wasRemapped(HLALocus.DQB1, secondModelWrapper));
 
-    makeValidationRow(
-        validationRows,
-        generateRowLabel(HLALocus.DQA1),
-        ValidationModel::getDQA1,
-        AntigenValidationRow::makeRow,
-        wasRemapped(HLALocus.DQA1, firstModelWrapper),
-        wasRemapped(HLALocus.DQA1, secondModelWrapper));
-    makeValidationRow(
-        validationRows,
-        generateRowLabel(HLALocus.DQA1),
-        ValidationModel::getDQA2,
-        AntigenValidationRow::makeRow,
-        wasRemapped(HLALocus.DQA1, firstModelWrapper),
-        wasRemapped(HLALocus.DQA1, secondModelWrapper));
+    makeValidationRow(validationRows, generateRowLabel(HLALocus.DQA1), ValidationModel::getDQA1, AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.DQA1, firstModelWrapper), wasRemapped(HLALocus.DQA1, secondModelWrapper));
+    makeValidationRow(validationRows, generateRowLabel(HLALocus.DQA1), ValidationModel::getDQA2, AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.DQA1, firstModelWrapper), wasRemapped(HLALocus.DQA1, secondModelWrapper));
 
-    makeValidationRow(
-        validationRows,
-        generateRowLabel(HLALocus.DPA1),
-        ValidationModel::getDPA1,
-        AntigenValidationRow::makeRow,
-        wasRemapped(HLALocus.DPA1, firstModelWrapper),
-        wasRemapped(HLALocus.DPA1, secondModelWrapper));
-    makeValidationRow(
-        validationRows,
-        generateRowLabel(HLALocus.DPA1),
-        ValidationModel::getDPA2,
-        AntigenValidationRow::makeRow,
-        wasRemapped(HLALocus.DPA1, firstModelWrapper),
-        wasRemapped(HLALocus.DPA1, secondModelWrapper));
+    makeValidationRow(validationRows, generateRowLabel(HLALocus.DPA1), ValidationModel::getDPA1, AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.DPA1, firstModelWrapper), wasRemapped(HLALocus.DPA1, secondModelWrapper));
+    makeValidationRow(validationRows, generateRowLabel(HLALocus.DPA1), ValidationModel::getDPA2, AntigenValidationRow::makeRow,
+        wasRemapped(HLALocus.DPA1, firstModelWrapper), wasRemapped(HLALocus.DPA1, secondModelWrapper));
 
-    makeValidationRow(
-        validationRows,
-        generateRowLabel(HLALocus.DPB1),
-        ValidationModel::getDPB1,
-        AlleleValidationRow::makeRow,
-        wasRemapped(HLALocus.DPB1, firstModelWrapper),
-        wasRemapped(HLALocus.DPB1, secondModelWrapper));
-    makeValidationRow(
-        validationRows,
-        generateRowLabel(HLALocus.DPB1),
-        ValidationModel::getDPB2,
-        AlleleValidationRow::makeRow,
-        wasRemapped(HLALocus.DPB1, firstModelWrapper),
-        wasRemapped(HLALocus.DPB1, secondModelWrapper));
+    makeValidationRow(validationRows, generateRowLabel(HLALocus.DPB1), ValidationModel::getDPB1, AlleleValidationRow::makeRow,
+        wasRemapped(HLALocus.DPB1, firstModelWrapper), wasRemapped(HLALocus.DPB1, secondModelWrapper));
+    makeValidationRow(validationRows, generateRowLabel(HLALocus.DPB1), ValidationModel::getDPB2, AlleleValidationRow::makeRow,
+        wasRemapped(HLALocus.DPB1, firstModelWrapper), wasRemapped(HLALocus.DPB1, secondModelWrapper));
 
-    makeValidationRow(
-        validationRows,
-        "DR51 1",
-        ValidationModel::getDR51_1,
-        DR345ValidationRow::makeRow,
-        false,
-        false);
-    makeValidationRow(
-        validationRows,
-        "DR51 2",
-        ValidationModel::getDR51_2,
-        DR345ValidationRow::makeRow,
-        false,
-        false);
-    makeValidationRow(
-        validationRows,
-        "DR52 1",
-        ValidationModel::getDR52_1,
-        DR345ValidationRow::makeRow,
-        false,
-        false);
-    makeValidationRow(
-        validationRows,
-        "DR52 2",
-        ValidationModel::getDR52_2,
-        DR345ValidationRow::makeRow,
-        false,
-        false);
-    makeValidationRow(
-        validationRows,
-        "DR53 1",
-        ValidationModel::getDR53_1,
-        DR345ValidationRow::makeRow,
-        false,
-        false);
-    makeValidationRow(
-        validationRows,
-        "DR53 2",
-        ValidationModel::getDR53_2,
-        DR345ValidationRow::makeRow,
-        false,
-        false);
+    makeValidationRow(validationRows, "DR51 1", ValidationModel::getDR51_1, DR345ValidationRow::makeRow, false, false);
+    makeValidationRow(validationRows, "DR51 2", ValidationModel::getDR51_2, DR345ValidationRow::makeRow, false, false);
+    makeValidationRow(validationRows, "DR52 1", ValidationModel::getDR52_1, DR345ValidationRow::makeRow, false, false);
+    makeValidationRow(validationRows, "DR52 2", ValidationModel::getDR52_2, DR345ValidationRow::makeRow, false, false);
+    makeValidationRow(validationRows, "DR53 1", ValidationModel::getDR53_1, DR345ValidationRow::makeRow, false, false);
+    makeValidationRow(validationRows, "DR53 2", ValidationModel::getDR53_2, DR345ValidationRow::makeRow, false, false);
 
     // A Table is valid if all its Rows are valid
     ObservableBooleanValue validBinding = null;
@@ -406,52 +284,36 @@ public class ValidationTable {
   }
 
   private String generateRowLabel(HLALocus locus) {
-    return locus.name()
-        + (wasRemapped(locus, firstModelWrapper) || wasRemapped(locus, secondModelWrapper)
-            ? (" " + REMAP_SYMBOL)
-            : "");
+    return locus.name() + (wasRemapped(locus, firstModelWrapper) || wasRemapped(locus, secondModelWrapper) ? (" " + REMAP_SYMBOL) : "");
   }
 
   private boolean wasRemapped(HLALocus locus, ReadOnlyObjectWrapper<ValidationModel> modelWrapper) {
     return (modelWrapper.isNotNull().get() && modelWrapper.get().wasRemapped(locus));
   }
 
-  private void makeDRDQHaplotypeRows(
-      ReadOnlyListWrapper<DRDQHaplotypeRow> rows, ValidationModel model) {
+  private void makeDRDQHaplotypeRows(ReadOnlyListWrapper<DRDQHaplotypeRow> rows, ValidationModel model) {
     for (RaceGroup ethnicity : RaceGroup.values()) {
-      model
-          .getDRDQHaplotypes()
-          .get(ethnicity)
-          .forEach(
-              haplotype -> {
-                rows.add(new DRDQHaplotypeRow(ethnicity, haplotype));
-              });
-    }
-    ;
+      model.getDRDQHaplotypes().get(ethnicity).forEach(haplotype -> {
+        rows.add(new DRDQHaplotypeRow(ethnicity, haplotype));
+      });
+    } ;
   }
 
   /** Use the given model to populate a list of {@link BCHaplotypeRow}s */
-  private void makeBCHaplotypeRows(
-      ReadOnlyListWrapper<BCHaplotypeRow> rows, ValidationModel model) {
+  private void makeBCHaplotypeRows(ReadOnlyListWrapper<BCHaplotypeRow> rows, ValidationModel model) {
     for (RaceGroup ethnicity : RaceGroup.values()) {
-      model
-          .getBCHaplotypes()
-          .get(ethnicity)
-          .forEach(
-              haplotype -> {
-                rows.add(new BCHaplotypeRow(ethnicity, haplotype));
-              });
-    }
-    ;
+      model.getBCHaplotypes().get(ethnicity).forEach(haplotype -> {
+        rows.add(new BCHaplotypeRow(ethnicity, haplotype));
+      });
+    } ;
   }
 
   /**
-   * We only report one set of haplotypes, so we have to choose which model to use. We default to
-   * the first, but if the first is empty we use the second.
+   * We only report one set of haplotypes, so we have to choose which model to use. We default to the
+   * first, but if the first is empty we use the second.
    */
   private ValidationModel chooseHaplotypeModel(ValidationModel model1, ValidationModel model2) {
-    if (Objects.isNull(model1)
-        || (model1.getBCHaplotypes().isEmpty() && model1.getDRDQHaplotypes().isEmpty())) {
+    if (Objects.isNull(model1) || (model1.getBCHaplotypes().isEmpty() && model1.getDRDQHaplotypes().isEmpty())) {
       return model2;
     }
     return model1;
@@ -464,20 +326,9 @@ public class ValidationTable {
    * @param rowLabel Description of this row (first column)
    * @param getter Method to use to retrieve this row's value
    */
-  private <T> void makeValidationRow(
-      List<ValidationRow<?>> rows,
-      String rowLabel,
-      Function<ValidationModel, T> getter,
-      RowBuilder<T> builder,
-      boolean wasRemappedFirst,
-      boolean wasRemappedSecond) {
-    rows.add(
-        builder.makeRow(
-            rowLabel,
-            getFirstField(getter),
-            getSecondField(getter),
-            wasRemappedFirst,
-            wasRemappedSecond));
+  private <T> void makeValidationRow(List<ValidationRow<?>> rows, String rowLabel, Function<ValidationModel, T> getter, RowBuilder<T> builder,
+      boolean wasRemappedFirst, boolean wasRemappedSecond) {
+    rows.add(builder.makeRow(rowLabel, getFirstField(getter), getSecondField(getter), wasRemappedFirst, wasRemappedSecond));
   }
 
   /**
@@ -512,6 +363,17 @@ public class ValidationTable {
     return s1 + "," + s2;
   }
 
+  private static String antigenToString(Object raw) {
+    if (!(raw instanceof Antigen type)) {
+      return "";
+    }
+    String s = "";
+    if (type != null) {
+      s = type.specString();
+    }
+    return s;
+  }
+
   /**
    * @param getter Accessor for {@link ValidationModel} field of interest
    * @return comma seperated first and second field for the gene given
@@ -534,82 +396,150 @@ public class ValidationTable {
   public String generateCSV() {
     StringBuilder builder = new StringBuilder();
 
-    builder.append(
-        "Donor ID"
-            + ","
-            + Objects.toString(getFirstField(ValidationModel::getDonorId), "")
-            + ","
-            + Objects.toString(getSecondField(ValidationModel::getDonorId), "")
-            + "\n");
-    builder.append(
-        "Source"
-            + ","
-            + Objects.toString(getFirstField(ValidationModel::getSourceType), "")
-            + ","
-            + Objects.toString(getSecondField(ValidationModel::getSourceType), "")
-            + "\n");
+    builder.append("Donor ID" + "," + Objects.toString(getFirstField(ValidationModel::getDonorId), "") + ","
+        + Objects.toString(getSecondField(ValidationModel::getDonorId), "") + "\n");
+    builder.append("Source" + "," + Objects.toString(getFirstField(ValidationModel::getSourceType), "") + ","
+        + Objects.toString(getSecondField(ValidationModel::getSourceType), "") + "\n");
     builder.append("A" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getA1) + "\n");
     builder.append("A" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getA2) + "\n");
     builder.append("B" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getB1) + "\n");
     builder.append("B" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getB2) + "\n");
-    builder.append(
-        "BW4"
-            + ","
-            + Objects.toString(getFirstField(ValidationModel::isBw4), "")
-            + ","
-            + Objects.toString(getSecondField(ValidationModel::isBw4), "")
-            + "\n");
-    builder.append(
-        "BW6"
-            + ","
-            + Objects.toString(getFirstField(ValidationModel::isBw6), "")
-            + ","
-            + Objects.toString(getSecondField(ValidationModel::isBw6), "")
-            + "\n");
+    builder.append("BW4" + "," + Objects.toString(getFirstField(ValidationModel::isBw4), "") + ","
+        + Objects.toString(getSecondField(ValidationModel::isBw4), "") + "\n");
+    builder.append("BW6" + "," + Objects.toString(getFirstField(ValidationModel::isBw6), "") + ","
+        + Objects.toString(getSecondField(ValidationModel::isBw6), "") + "\n");
     builder.append("C" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getC1) + "\n");
     builder.append("C" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getC2) + "\n");
-    builder.append(
-        "DRB1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDRB1) + "\n");
-    builder.append(
-        "DRB1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDRB2) + "\n");
-    builder.append(
-        "DQB1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDQB1) + "\n");
-    builder.append(
-        "DQB1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDQB2) + "\n");
-    builder.append(
-        "DQA1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDQA1) + "\n");
-    builder.append(
-        "DQA1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDQA2) + "\n");
-    builder.append(
-        "DPB1" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDPB1) + "\n");
-    builder.append(
-        "DPB1" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDPB2) + "\n");
-    builder.append(
-        "DPA1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDPA1) + "\n");
-    builder.append(
-        "DPA1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDPA2) + "\n");
-    builder.append(
-        "DR51 1" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDR51_1) + "\n");
-    builder.append(
-        "DR51 2" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDR51_2) + "\n");
-    builder.append(
-        "DR52 1" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDR52_1) + "\n");
-    builder.append(
-        "DR52 2" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDR52_2) + "\n");
-    builder.append(
-        "DPB3 1" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDR53_1) + "\n");
-    builder.append(
-        "DPB3 2" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDR53_2) + "\n");
+    builder.append("DRB1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDRB1) + "\n");
+    builder.append("DRB1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDRB2) + "\n");
+    builder.append("DQB1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDQB1) + "\n");
+    builder.append("DQB1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDQB2) + "\n");
+    builder.append("DQA1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDQA1) + "\n");
+    builder.append("DQA1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDQA2) + "\n");
+    builder.append("DPB1" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDPB1) + "\n");
+    builder.append("DPB1" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDPB2) + "\n");
+    builder.append("DPA1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDPA1) + "\n");
+    builder.append("DPA1" + "," + getComaSeperatedFieldSpecStrings(ValidationModel::getDPA2) + "\n");
+    builder.append("DR51 1" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDR51_1) + "\n");
+    builder.append("DR51 2" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDR51_2) + "\n");
+    builder.append("DR52 1" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDR52_1) + "\n");
+    builder.append("DR52 2" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDR52_2) + "\n");
+    builder.append("DR53 1" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDR53_1) + "\n");
+    builder.append("DR53 2" + "," + getComaSeperatedFieldSpecStringsHLA(ValidationModel::getDR53_2) + "\n");
 
     return builder.toString();
   }
 
+  public TableData getTableData() {
+    return new TableData(this);
+  }
+
+  public enum ValidationKey {
+    DONORID("Donor ID", Optional.empty(), ValidationModel::getDonorId, Objects::toString), //
+    SOURCE("Source", Optional.empty(), ValidationModel::getSourceType, Objects::toString), //
+    A1("A", Optional.of(HLALocus.A), ValidationModel::getA1, ValidationTable::antigenToString), //
+    A2("A", Optional.of(HLALocus.A), ValidationModel::getA2, ValidationTable::antigenToString), //
+    B1("B", Optional.of(HLALocus.B), ValidationModel::getB1, ValidationTable::antigenToString), //
+    B2("B", Optional.of(HLALocus.B), ValidationModel::getB2, ValidationTable::antigenToString), //
+    BW4("BW4", Optional.empty(), ValidationModel::isBw4, Objects::toString), //
+    BW6("BW6", Optional.empty(), ValidationModel::isBw6, Objects::toString), //
+    C1("C", Optional.of(HLALocus.C), ValidationModel::getC1, ValidationTable::antigenToString), //
+    C2("C", Optional.of(HLALocus.C), ValidationModel::getC2, ValidationTable::antigenToString), //
+    DRB1_1("DRB1", Optional.of(HLALocus.DRB1), ValidationModel::getDRB1, ValidationTable::antigenToString), //
+    DRB1_2("DRB1", Optional.of(HLALocus.DRB1), ValidationModel::getDRB2, ValidationTable::antigenToString), //
+    DQB1_1("DQB1", Optional.of(HLALocus.DQB1), ValidationModel::getDQB1, ValidationTable::antigenToString), //
+    DQB1_2("DQB1", Optional.of(HLALocus.DQB1), ValidationModel::getDQB2, ValidationTable::antigenToString), //
+    DQA1_1("DQA1", Optional.of(HLALocus.DQA1), ValidationModel::getDQA1, ValidationTable::antigenToString), //
+    DQA1_2("DQA1", Optional.of(HLALocus.DQA1), ValidationModel::getDQA2, ValidationTable::antigenToString), //
+    DPB1_1("DPB1", Optional.of(HLALocus.DPB1), ValidationModel::getDPB1, ValidationTable::antigenToString), //
+    DPB1_2("DPB1", Optional.of(HLALocus.DPB1), ValidationModel::getDPB2, ValidationTable::antigenToString), //
+    DPA1_1("DPA1", Optional.of(HLALocus.DPA1), ValidationModel::getDPA1, ValidationTable::antigenToString), //
+    DPA1_2("DPA1", Optional.of(HLALocus.DPA1), ValidationModel::getDPA2, ValidationTable::antigenToString), //
+    DR51_1("DR51 1", Optional.of(HLALocus.DRB5), ValidationModel::getDR51_1, ValidationTable::antigenToString), //
+    DR51_2("DR51 2", Optional.of(HLALocus.DRB5), ValidationModel::getDR51_2, ValidationTable::antigenToString), //
+    DR52_1("DR52 1", Optional.of(HLALocus.DRB3), ValidationModel::getDR52_1, ValidationTable::antigenToString), //
+    DR52_2("DR52 2", Optional.of(HLALocus.DRB3), ValidationModel::getDR52_2, ValidationTable::antigenToString), //
+    DR53_1("DR53 1", Optional.of(HLALocus.DRB4), ValidationModel::getDR53_1, ValidationTable::antigenToString), //
+    DR53_2("DR53 2", Optional.of(HLALocus.DRB4), ValidationModel::getDR53_2, ValidationTable::antigenToString); //
+
+    public final String fieldName;
+    public final Optional<HLALocus> locusIfPresent;
+    final Function<ValidationModel, Object> getter;
+    final Function<Object, String> toString;
+
+    private ValidationKey(String fName, Optional<HLALocus> locusIfPresent, Function<ValidationModel, Object> getter,
+        Function<Object, String> toString) {
+      this.fieldName = fName;
+      this.locusIfPresent = locusIfPresent;
+      this.getter = getter;
+      this.toString = toString;
+    }
+
+    public String getFirst(ValidationTable table) {
+      return toString.apply(table.getFirstField(getter));
+    }
+
+    public String getSecond(ValidationTable table) {
+      return toString.apply(table.getSecondField(getter));
+    }
+
+  }
+
+  public static class TableData {
+    private final Map<ValidationKey, String> first = new HashMap<>();
+    private final Map<ValidationKey, String> second = new HashMap<>();
+    private final ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> firstRemaps;
+    private final ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> secondRemaps;
+
+    public TableData(ValidationTable t) {
+      for (ValidationKey k : ValidationKey.values()) {
+        first.put(k, k.getFirst(t));
+        second.put(k, k.getSecond(t));
+      }
+      this.firstRemaps = t.getFirstRemappings();
+      this.secondRemaps = t.getSecondRemappings();
+    }
+
+    public String getCSVLine(ValidationKey k) {
+      StringJoiner sj = new StringJoiner(",");
+      sj.add(k.fieldName).add(first.get(k)).add(second.get(k)).add(Boolean.toString(first.getOrDefault(k, "").equals(second.getOrDefault(k, ""))));
+      return sj.toString();
+    }
+
+    public boolean isValid() {
+      for (ValidationKey k : ValidationKey.values()) {
+        if (k == ValidationKey.SOURCE)
+          continue;
+        if (!getFirst(k).equals(getSecond(k))) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    public String getFirst(ValidationKey key) {
+      return first.getOrDefault(key, "");
+    }
+
+    public String getSecond(ValidationKey key) {
+      return second.getOrDefault(key, "");
+    }
+
+    public ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> getFirstRemaps() {
+      return firstRemaps;
+    }
+
+    public ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> getSecondRemaps() {
+      return secondRemaps;
+    }
+
+  }
+
   /**
-   * @return The value of the given getter in the given model, or {@code null} if the target model
-   *     is null.
+   * @return The value of the given getter in the given model, or {@code null} if the target model is
+   *         null.
    */
-  private <T> T getValueFromModel(
-      Function<ValidationModel, T> getter, ReadOnlyObjectWrapper<ValidationModel> wrapper) {
+  private <T> T getValueFromModel(Function<ValidationModel, T> getter, ReadOnlyObjectWrapper<ValidationModel> wrapper) {
     if (Objects.isNull(wrapper.get())) {
       return null;
     }
@@ -625,51 +555,29 @@ public class ValidationTable {
   }
 
   public ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> getFirstRemappings() {
-    if (firstModelWrapper.isNotNull().get()) return firstModelWrapper.get().getRemappings();
+    if (firstModelWrapper.isNotNull().get())
+      return firstModelWrapper.get().getRemappings();
     return ImmutableMap.of();
   }
 
   public ImmutableMap<HLALocus, Pair<Set<TypePair>, Set<TypePair>>> getSecondRemappings() {
-    if (secondModelWrapper.isNotNull().get()) return secondModelWrapper.get().getRemappings();
+    if (secondModelWrapper.isNotNull().get())
+      return secondModelWrapper.get().getRemappings();
     return ImmutableMap.of();
   }
 
   private String[] generateRemappings(ValidationModel model) {
-    return model.getRemappings().entrySet().stream()
-        .map(
-            e -> {
-              final String collectFrom =
-                  e.getValue().getLeft().stream()
-                      .sorted()
-                      .map(TypePair::getHlaType)
-                      .map((h) -> h.specString())
-                      .collect(Collectors.joining(" / "));
-              final String collectTo =
-                  e.getValue().getRight().stream()
-                      .sorted()
-                      .map(TypePair::getHlaType)
-                      .map((h) -> h.specString())
-                      .collect(Collectors.joining(" / "));
-              return "HLA-"
-                  + e.getKey().name()
-                  + " was remapped from { "
-                  + collectFrom
-                  + " } to { "
-                  + collectTo
-                  + " } in "
-                  + model.getSourceType();
-            })
-        .sorted()
-        .distinct()
-        .toArray(String[]::new);
+    return model.getRemappings().entrySet().stream().map(e -> {
+      final String collectFrom =
+          e.getValue().getLeft().stream().sorted().map(TypePair::getHlaType).map((h) -> h.specString()).collect(Collectors.joining(" / "));
+      final String collectTo =
+          e.getValue().getRight().stream().sorted().map(TypePair::getHlaType).map((h) -> h.specString()).collect(Collectors.joining(" / "));
+      return "HLA-" + e.getKey().name() + " was remapped from { " + collectFrom + " } to { " + collectTo + " } in " + model.getSourceType();
+    }).sorted().distinct().toArray(String[]::new);
   }
 
   public ObservableValue<String> getAuditLogLines() {
-    return Bindings.createStringBinding(
-        () ->
-            auditLogLines.stream()
-                .map(s -> REMAP_SYMBOL + " " + s)
-                .collect(Collectors.joining("\n")),
+    return Bindings.createStringBinding(() -> auditLogLines.stream().map(s -> REMAP_SYMBOL + " " + s).collect(Collectors.joining("\n")),
         auditLogLines);
   }
 

--- a/src/main/java/org/pankratzlab/unet/model/remap/GUIRemapProcessor.java
+++ b/src/main/java/org/pankratzlab/unet/model/remap/GUIRemapProcessor.java
@@ -196,12 +196,15 @@ public class GUIRemapProcessor implements RemapProcessor {
     SeroType seroType1 = hlaType1.equivSafe();
     SeroType seroType2 = hlaType2.equivSafe();
 
-    boolean a1Match =
-        hlaType1.compareTo(hlaType1_First) == 0 || hlaType1.compareTo(hlaType2_First) == 0;
-    boolean a2Match =
-        hlaType2.compareTo(hlaType1_First) == 0 || hlaType2.compareTo(hlaType2_First) == 0;
+    boolean a1_11_match = hlaType1.compareTo(hlaType1_First) == 0;
+    boolean a1_12_match = hlaType1.compareTo(hlaType2_First) == 0;
+    boolean a2_21_match = hlaType2.compareTo(hlaType1_First) == 0;
+    boolean a2_22_match = hlaType2.compareTo(hlaType2_First) == 0;
 
-    if (!a1Match || !a2Match) {
+    boolean check11 = a1_11_match && a2_22_match;
+    boolean check12 = a1_12_match && a2_21_match;
+
+    if (!(check11 || check12)) {
       // locusSet.clear();
       // locusSet.add(seroType1);
       // locusSet.add(seroType2);

--- a/src/main/java/org/pankratzlab/unet/parser/HtmlDonorParser.java
+++ b/src/main/java/org/pankratzlab/unet/parser/HtmlDonorParser.java
@@ -78,6 +78,10 @@ public class HtmlDonorParser extends AbstractDonorFileParser {
     return EXTENSION_DESC;
   }
 
+  public static String getTypeString() {
+    return DISPLAY_STRING;
+  }
+
   @Override
   protected String getDisplayString() {
     return DISPLAY_STRING;

--- a/src/main/java/org/pankratzlab/unet/parser/PdfDonorParser.java
+++ b/src/main/java/org/pankratzlab/unet/parser/PdfDonorParser.java
@@ -70,6 +70,10 @@ public class PdfDonorParser extends AbstractDonorFileParser {
     return "Could not read donor data from PDF.";
   }
 
+  public static String getTypeString() {
+    return DISPLAY_STRING;
+  }
+
   @Override
   protected void doParse(ValidationModelBuilder builder, File file) {
     try (PDDocument pdf = PDDocument.load(file)) {

--- a/src/main/java/org/pankratzlab/unet/parser/XmlDonorParser.java
+++ b/src/main/java/org/pankratzlab/unet/parser/XmlDonorParser.java
@@ -71,6 +71,10 @@ public class XmlDonorParser extends AbstractDonorFileParser {
     return EXTENSION_DESC;
   }
 
+  public static String getTypeString() {
+    return DISPLAY_STRING;
+  }
+
   @Override
   protected String getDisplayString() {
     return DISPLAY_STRING;

--- a/src/main/java/org/pankratzlab/unet/parser/util/XmlScore6Parser.java
+++ b/src/main/java/org/pankratzlab/unet/parser/util/XmlScore6Parser.java
@@ -34,7 +34,6 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
-import org.apache.logging.log4j.util.TriConsumer;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -61,6 +60,11 @@ import com.google.common.collect.Multiset;
 
 /** Parses SCORE6 QType format to donor model */
 public class XmlScore6Parser {
+
+  @FunctionalInterface
+  public static interface TriConsumer<T, U, V> {
+    public void accept(T t, U u, V v);
+  }
 
   // -- Type assignment requires assessing allele frequencies, which are read from an HTML doc --
   private static final String LOCUS_SEPARATOR = "*";

--- a/src/main/java/org/pankratzlab/unet/parser/util/XmlScore6Parser.java
+++ b/src/main/java/org/pankratzlab/unet/parser/util/XmlScore6Parser.java
@@ -36,7 +36,9 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.jsoup.nodes.TextNode;
 import org.jsoup.select.Elements;
+import org.pankratzlab.unet.deprecated.hla.DonorCheckProperties;
 import org.pankratzlab.unet.deprecated.hla.HLALocus;
 import org.pankratzlab.unet.deprecated.hla.HLAType;
 import org.pankratzlab.unet.deprecated.hla.SeroType;
@@ -73,13 +75,14 @@ public class XmlScore6Parser {
   // - Specific allele values -
   private static final String UNDEFINED_TYPE = "Undefined";
   private static final String UNDEFINED_TYPE2 = "undefined";
-  private static final Set<String> UNDEFINED_TOKENS =
-      ImmutableSet.of(UNDEFINED_TYPE, UNDEFINED_TYPE2, "-");
+  private static final Set<String> UNDEFINED_TOKENS = ImmutableSet.of(UNDEFINED_TYPE, UNDEFINED_TYPE2, "-");
   private static final String NULL_TYPE = "Null";
 
   // -- XML Tags required for parsing --
   public static final String ROOT_ELEMENT = "batchsubmission";
   private static final String PATIENT_ID_TAG = "patientId";
+  private static final String ALLELE_CALL_TAG = "alleleCall";
+  private static final String BW4_BW6_TAG = "Bw4Bw6";
   private static final String ALLELE_RESULTS_TAG = "alleleResults";
   private static final String RESULT_COMBINATION_TAG = "resultCombination";
   private static final String SERO_COMBINATION_TAG = "serologicalCombination";
@@ -122,8 +125,7 @@ public class XmlScore6Parser {
 
   private static void init() {
     // -- Build mapping between loci sections, serotype prefixes and validation model setters --
-    Builder<String, BiConsumer<ValidationModelBuilder, String>> setterBuilder =
-        ImmutableMap.builder();
+    Builder<String, BiConsumer<ValidationModelBuilder, String>> setterBuilder = ImmutableMap.builder();
     setterBuilder.put(A_HEADER, ValidationModelBuilder::a);
     setterBuilder.put(B_HEADER, ValidationModelBuilder::b);
     setterBuilder.put(C_HEADER, ValidationModelBuilder::c);
@@ -144,8 +146,7 @@ public class XmlScore6Parser {
 
     // -- Build mapping bemetadataTypeMaptween loci sections, serotype prefixes and validation model
     // setters --
-    Builder<String, BiConsumer<ValidationModelBuilder, HLAType>> setterBuilderTypes =
-        ImmutableMap.builder();
+    Builder<String, BiConsumer<ValidationModelBuilder, HLAType>> setterBuilderTypes = ImmutableMap.builder();
     setterBuilderTypes.put(A_HEADER, ValidationModelBuilder::aType);
     setterBuilderTypes.put(B_HEADER, ValidationModelBuilder::bType);
     setterBuilderTypes.put(C_HEADER, ValidationModelBuilder::cType);
@@ -167,8 +168,7 @@ public class XmlScore6Parser {
 
     // -- Build mapping bemetadataTypeMaptween loci sections, serotype prefixes and validation model
     // setters --
-    Builder<String, BiConsumer<ValidationModelBuilder, HLAType>> setterBuilderTypesNonCWD =
-        ImmutableMap.builder();
+    Builder<String, BiConsumer<ValidationModelBuilder, HLAType>> setterBuilderTypesNonCWD = ImmutableMap.builder();
     setterBuilderTypesNonCWD.put(A_HEADER, ValidationModelBuilder::aTypeNonCWD);
     setterBuilderTypesNonCWD.put(B_HEADER, ValidationModelBuilder::bTypeNonCWD);
     setterBuilderTypesNonCWD.put(C_HEADER, ValidationModelBuilder::cTypeNonCWD);
@@ -189,8 +189,7 @@ public class XmlScore6Parser {
     metadataTypeNonCWDMap = setterBuilderTypesNonCWD.build();
 
     // -- Build mapping between loci sections, serotype prefixes and validation model setters --
-    Builder<String, BiConsumer<ValidationModelBuilder, String>> setterBuilderNonCWD =
-        ImmutableMap.builder();
+    Builder<String, BiConsumer<ValidationModelBuilder, String>> setterBuilderNonCWD = ImmutableMap.builder();
     setterBuilderNonCWD.put(A_HEADER, ValidationModelBuilder::aNonCWD);
     setterBuilderNonCWD.put(B_HEADER, ValidationModelBuilder::bNonCWD);
     setterBuilderNonCWD.put(C_HEADER, ValidationModelBuilder::cNonCWD);
@@ -206,8 +205,7 @@ public class XmlScore6Parser {
 
     metadataNonCWDMap = setterBuilderNonCWD.build();
 
-    Builder<String, TriConsumer<ValidationModelBuilder, HLALocus, AllelePairings>> setterBuilderAlleles =
-        ImmutableMap.builder();
+    Builder<String, TriConsumer<ValidationModelBuilder, HLALocus, AllelePairings>> setterBuilderAlleles = ImmutableMap.builder();
     setterBuilderAlleles.put(A_HEADER, ValidationModelBuilder::possibleAllelePairings);
     setterBuilderAlleles.put(B_HEADER, ValidationModelBuilder::possibleAllelePairings);
     setterBuilderAlleles.put(C_HEADER, ValidationModelBuilder::possibleAllelePairings);
@@ -219,8 +217,7 @@ public class XmlScore6Parser {
 
     possibleAlleleRecordingMap = setterBuilderAlleles.build();
 
-    Builder<String, TriConsumer<ValidationModelBuilder, HLALocus, AllelePairings>> setterBuilderDonorAlleles =
-        ImmutableMap.builder();
+    Builder<String, TriConsumer<ValidationModelBuilder, HLALocus, AllelePairings>> setterBuilderDonorAlleles = ImmutableMap.builder();
     setterBuilderDonorAlleles.put(A_HEADER, ValidationModelBuilder::donorAllelePairings);
     setterBuilderDonorAlleles.put(B_HEADER, ValidationModelBuilder::donorAllelePairings);
     setterBuilderDonorAlleles.put(C_HEADER, ValidationModelBuilder::donorAllelePairings);
@@ -234,19 +231,16 @@ public class XmlScore6Parser {
 
     // -- Build mapping specifically for DRB3/4/5 alleles. These are also under the DRB header but
     // parsed differently --
-    Builder<HLALocus, BiConsumer<ValidationModelBuilder, String>> drbBuilder =
-        ImmutableMap.builder();
+    Builder<HLALocus, BiConsumer<ValidationModelBuilder, String>> drbBuilder = ImmutableMap.builder();
     drbBuilder.put(HLALocus.DRB3, ValidationModelBuilder::dr52);
     drbBuilder.put(HLALocus.DRB4, ValidationModelBuilder::dr53);
     drbBuilder.put(HLALocus.DRB5, ValidationModelBuilder::dr51);
     drbMap = drbBuilder.build();
 
     // -- Build mapping between loci and serological/allele parsing
-    Builder<String, Function<ResultCombination, String>> specGeneratorBuilder =
-        ImmutableMap.builder();
+    Builder<String, Function<ResultCombination, String>> specGeneratorBuilder = ImmutableMap.builder();
     Builder<String, Function<HLAType, String>> specGenerator1Builder = ImmutableMap.builder();
-    Builder<String, BiFunction<SeroType, HLAType, String>> specGenerator2Builder =
-        ImmutableMap.builder();
+    Builder<String, BiFunction<SeroType, HLAType, String>> specGenerator2Builder = ImmutableMap.builder();
     specGeneratorBuilder.put(A_HEADER, XmlScore6Parser::getAlleleSpec);
     specGenerator1Builder.put(A_HEADER, XmlScore6Parser::getAlleleSpec);
     specGeneratorBuilder.put(B_HEADER, XmlScore6Parser::getAlleleLookup);
@@ -279,8 +273,7 @@ public class XmlScore6Parser {
     builder.bw4(false);
     builder.bw6(false);
 
-    DonorNetUtils.getText(doc.getElementsByTag(PATIENT_ID_TAG))
-        .ifPresent(s -> builder.donorId(s.toUpperCase()));
+    DonorNetUtils.getText(doc.getElementsByTag(PATIENT_ID_TAG)).ifPresent(s -> builder.donorId(s.toUpperCase()));
 
     Element element = doc.getElementsByTag(LOCI_LIST_TAG).get(0);
     Elements elementsByTag = element.getElementsByTag(SINGLE_LOCUS_TAG);
@@ -298,16 +291,32 @@ public class XmlScore6Parser {
         return;
       }
 
+      boolean useAlleleCallIfPresent = Boolean
+          .parseBoolean(DonorCheckProperties.get().getProperty(DonorCheckProperties.USE_ALLELE_CALL, DonorCheckProperties.USE_ALLELE_CALL_DEFAULT));
+      String alleleCall1 = null;
+      String alleleCall2 = null;
+      if (useAlleleCallIfPresent) {
+        Elements alleleCalls = typedLocus.getElementsByTag(ALLELE_CALL_TAG);
+        if (alleleCalls.size() >= 2) {
+          Element a1 = alleleCalls.get(0);
+          Element a2 = alleleCalls.get(1);
+          if (a1.childNodeSize() > 0 && a2.childNodeSize() > 0) {
+            TextNode e1 = (TextNode) a1.childNode(0);
+            TextNode e2 = (TextNode) a2.childNode(0);
+            alleleCall1 = e1.text();
+            alleleCall2 = e2.text();
+          }
+        }
+      }
+
+
       // Each locus has one allele results block which contains potential allele pairs
-      Elements resultCombinations = typedLocus.getElementsByTag(ALLELE_RESULTS_TAG).get(0)
-          .getElementsByTag(RESULT_COMBINATION_TAG);
+      Elements resultCombinationSets = typedLocus.getElementsByTag(ALLELE_RESULTS_TAG).get(0).getElementsByTag(RESULT_COMBINATION_TAG);
 
       // each locus has one allele combination block which contains possible allele pairs
-      Elements alleleCombinations = typedLocus.getElementsByTag(ALLELE_COMBINATIONS_TAG).get(0)
-          .getElementsByTag(RESULT_COMBINATION_TAG);
+      Elements alleleCombinationSets = typedLocus.getElementsByTag(ALLELE_COMBINATIONS_TAG).get(0).getElementsByTag(RESULT_COMBINATION_TAG);
 
-      Elements pairs = typedLocus.getElementsByTag("resultPairs").get(0)
-          .getElementsByTag(RESULT_COMBINATION_TAG);
+      Elements pairs = typedLocus.getElementsByTag("resultPairs").get(0).getElementsByTag(RESULT_COMBINATION_TAG);
 
 
       int selectedResultIndex = -1;
@@ -325,10 +334,8 @@ public class XmlScore6Parser {
       // first, iterate through allele list element pairs and parse possible allele pairings
       for (int i = 0; i < pairs.size(); i++) {
         Element currPair = pairs.get(i);
-        Elements a1Alleles =
-            currPair.getElementsByTag("alleleList1").get(0).getElementsByTag("allele");
-        Elements a2Alleles =
-            currPair.getElementsByTag("alleleList2").get(0).getElementsByTag("allele");
+        Elements a1Alleles = currPair.getElementsByTag("alleleList1").get(0).getElementsByTag("allele");
+        Elements a2Alleles = currPair.getElementsByTag("alleleList2").get(0).getElementsByTag("allele");
 
         for (Element a1E : a1Alleles) {
           String a1A = a1E.text();
@@ -344,54 +351,18 @@ public class XmlScore6Parser {
       /*
        * Class-1 Loci (A/B/C) have one set of possible allele pairs in the alleleResults element
        * 
-       * Class-2 Loci (DR/DP/DQ) can have multiple sets of possible allele pairs in the
-       * alleleResults element
+       * Class-2 Loci (DR/DP/DQ) can have multiple sets of possible allele pairs in the alleleResults
+       * element
        * 
        * TODO clarify how/why these are different
        */
 
-      for (int currentResult = 0; currentResult < alleleCombinations.size(); currentResult++) {
-        Element currentCombination = alleleCombinations.get(currentResult);
+      for (int currentSet = 0; currentSet < alleleCombinationSets.size(); currentSet++) {
+        Element currentCombination = alleleCombinationSets.get(currentSet);
         HLALocus locusType = null;
 
         // The DRB345 combinations are grouped into a single "DRB" header with DRB1
-        boolean isDRB345 =
-            DRB_HEADER.equals(locus) && !currentCombination.toString().contains("DRB1");
-
-        if (isDRB345) {
-          // We can't derive the locus from the header for DRB
-          locusType = parseDRBCombination(currentCombination.toString());
-          if (locusType == null) {
-            // NB: this situation is only known to arise when an individual is homozygous with
-            // unexpressed DRB345s
-            // In this scenario, we can fall back to looking at the DRB1 alleles to figure out what
-            // we should find.
-            locusType = deduceDRB345Locus(ciwdResultPairs);
-          }
-        } else {
-          locusType = HLALocus.safeValueOf(locus.substring(locus.indexOf("-") + 1));
-        }
-
-        // Each combination is an allele/antigen pair
-        parseAlleleCombinations(currentCombination, locusType, donorAllelePairs);
-      }
-
-      // Parse the allele lists in the result section
-      // the first allele in each list goes into the "firstResultPairs" list
-      // the first **CIWD allele** goes into the "actualResultPairs" list
-
-      /*
-       * if we're parsing a Class-2 locus, we find the "best" pair to use for the
-       * "actualResultPairs" list, and then use the first pairing from that pair for the
-       * "firstResultPairs" list
-       */
-      for (int currentResult = 0; currentResult < resultCombinations.size(); currentResult++) {
-        Element currentCombination = resultCombinations.get(currentResult);
-        HLALocus locusType = null;
-
-        // The DRB345 combinations are grouped into a single "DRB" header with DRB1
-        boolean isDRB345 =
-            DRB_HEADER.equals(locus) && !currentCombination.toString().contains("DRB1");
+        boolean isDRB345 = DRB_HEADER.equals(locus) && !currentCombination.toString().contains("DRB1");
 
         if (isDRB345) {
           // We can't derive the locus from the header for DRB
@@ -416,10 +387,145 @@ public class XmlScore6Parser {
         }
 
         // Each combination is an allele/antigen pair
-        List<ResultCombination> comboCIWD =
-            parseResultCombinations(currentCombination, locusType, true);
-        List<ResultCombination> comboFirst =
-            parseResultCombinations(currentCombination, locusType, false);
+        parseAlleleCombinations(currentCombination, locusType, donorAllelePairs);
+      }
+
+
+
+      HLAType h1 = null;
+      HLAType h2 = null;
+      if (useAlleleCallIfPresent) {
+        if (alleleCall1 != null && alleleCall2 != null) {
+          if (alleleCall1.startsWith(hlaLocus.name() + "*")) {
+            alleleCall1 = alleleCall1.substring(hlaLocus.name().length() + 1);
+          }
+          if (alleleCall2.startsWith(hlaLocus.name() + "*")) {
+            alleleCall2 = alleleCall2.substring(hlaLocus.name().length() + 1);
+          }
+
+          String failureStrategy = DonorCheckProperties.get().getProperty(DonorCheckProperties.FAIL_OR_DISCARD_IF_AC_INVALID,
+              DonorCheckProperties.FAIL_OR_DISCARD_IF_AC_INVALID_DEFAULT);
+
+          // check for single-fields, meaning the value is an allele group, which we can't use / is invalid
+          boolean invalidAC1 = alleleCall1.indexOf(':') == -1;
+          boolean invalidAC2 = alleleCall2.indexOf(':') == -1;
+
+          if (invalidAC1 || invalidAC2) {
+            if (failureStrategy.equalsIgnoreCase(DonorCheckProperties.AC_INVALID_FAIL)) {
+              String msg =
+                  "DonorCheck does not support SCORE 6 assigned alleles that are only allele groups (first field). Please remove these assignments or replace ["
+                      + hlaLocus.name() + "*" + alleleCall1 + " / " + hlaLocus.name() + "*" + alleleCall2 + "] with two-field typings.";
+              // ", or configure DonorCheck to skip these values by opening the Preferences and changing the value
+              // of [Data Sources -> SCORE 6 -> How to handle invalid alleles ...] from "
+              // + DonorCheckProperties.AC_INVALID_FAIL + " to " + DonorCheckProperties.AC_INVALID_DISCARD + ".";
+              throw new IllegalArgumentException(msg);
+            } else {
+              // } else if (failureStrategy.equalsIgnoreCase(DonorCheckProperties.AC_INVALID_DISCARD)) {
+              String msg = "DonorCheck does not support SCORE 6 assigned alleles that are only allele groups (first field). Found: ["
+                  + hlaLocus.name() + "*" + alleleCall1 + " / " + hlaLocus.name() + "*" + alleleCall2
+                  + "]. Please remove these assignments or replace them with two-field (or more) typings.";
+              builder.addAuditMessage(msg);
+            }
+          } else {
+            try {
+              h1 = new HLAType(hlaLocus, alleleCall1);
+            } catch (Exception e) {
+              if (failureStrategy.equalsIgnoreCase(DonorCheckProperties.AC_INVALID_FAIL)) {
+                throw new IllegalArgumentException("Invalid allele assignment in SCORE 6 for locus " + hlaLocus.name() + ": " + alleleCall1);
+              } else {
+                builder
+                    .addAuditMessage("SCORE 6: Invalid allele assignment for locus " + locus + ": " + alleleCall1 + ". This data has been ignored.");
+              }
+            }
+            try {
+              h2 = new HLAType(hlaLocus, alleleCall2);
+            } catch (Exception e) {
+              if (failureStrategy.equalsIgnoreCase(DonorCheckProperties.AC_INVALID_FAIL)) {
+                throw new IllegalArgumentException("Invalid allele assignment in SCORE 6 for locus " + hlaLocus.name() + ": " + alleleCall2);
+              } else {
+                builder.addAuditMessage(
+                    "SCORE 6: Invalid allele assignment for locus " + hlaLocus.name() + ": " + alleleCall2 + ". This data has been ignored.");
+              }
+            }
+          }
+        } else if (alleleCall1 != null || alleleCall2 != null) {
+          String ac = alleleCall1 == null ? alleleCall2 : alleleCall1;
+          // one or both alleleCall tags didn't have data in it
+          builder.addAuditMessage("SCORE 6: Only one allele assignment found for " + hlaLocus.name() + ": " + ac + ". This data has been ignored.");
+        }
+      }
+
+      boolean hasValidAlleleCall = h1 != null && h2 != null; // TODO do we need more of a validity check than just non-null?
+
+      boolean assignedBw4 = false;
+      boolean assignedBw6 = false;
+      if (hasValidAlleleCall && B_HEADER.equals(locus)) {
+        Elements bws = typedLocus.getElementsByTag(BW4_BW6_TAG);
+        if (bws.size() > 0) {
+          Element bw = bws.get(0);
+          if (bw.childNodeSize() > 0) {
+            TextNode e1 = (TextNode) bw.childNode(0);
+            String bwStr = e1.text();
+            if (bwStr.indexOf('/') != -1) { // has both
+              assignedBw4 = true;
+              assignedBw6 = true;
+            } else if (bwStr.length() > 1) { // not a dash (has one)
+              assignedBw4 = bwStr.charAt(bwStr.length() - 1) == '4';
+              assignedBw6 = !assignedBw4;
+            }
+          }
+        }
+      }
+
+
+      // Parse the allele lists in the result section
+      // the first allele in each list goes into the "firstResultPairs" list
+      // the first **CIWD allele** goes into the "actualResultPairs" list
+
+      Set<Integer> acMatchIndices = new HashSet<>();
+      /*
+       * if we're parsing a Class-2 locus, we find the "best" pair to use for the "actualResultPairs"
+       * list, and then use the first pairing from that pair for the "firstResultPairs" list
+       */
+      for (int currentResult = 0; currentResult < resultCombinationSets.size(); currentResult++) {
+        Element currentCombination = resultCombinationSets.get(currentResult);
+        HLALocus locusType = null;
+
+        // The DRB345 combinations are grouped into a single "DRB" header with DRB1
+        boolean isDRB345 = DRB_HEADER.equals(locus) && !currentCombination.toString().contains("DRB1");
+
+        if (isDRB345) {
+          // We can't derive the locus from the header for DRB
+          locusType = parseDRBCombination(currentCombination.toString());
+          if (locusType == null) {
+            // NB: this situation is only known to arise when an individual is homozygous with
+            // unexpressed DRB345s
+            // In this scenario, we can fall back to looking at the DRB1 alleles to figure out what
+            // we should find.
+            locusType = deduceDRB345Locus(ciwdResultPairs);
+          }
+        } else {
+          locusType = HLALocus.safeValueOf(locus.substring(locus.indexOf("-") + 1));
+        }
+
+        if (hlaLocus == null) {
+          hlaLocus = locusType;
+        } else if (hlaLocus.compareTo(locusType) != 0) {
+          /*
+           * This seems to only happen when parsing the DRB3/4/5 loci, as the original locus is DRB1
+           */
+        }
+
+        // Each combination is an allele/antigen pair
+        List<ResultCombination> comboCIWD = parseResultCombinations(currentCombination, locusType, true);
+        List<ResultCombination> comboFirst = parseResultCombinations(currentCombination, locusType, false);
+
+        if (hasValidAlleleCall) {
+          boolean acMatch = testIfAlleleCallPresent(h1, h2, currentCombination, hlaLocus);
+          if (acMatch) {
+            acMatchIndices.add(currentResult);
+          }
+        }
 
         List<ResultCombination> toUpdateCIWD = ciwdResultPairs;
         List<ResultCombination> toUpdateFirst = firstResultPairs;
@@ -460,6 +566,8 @@ public class XmlScore6Parser {
         }
       }
 
+
+
       // -- Locus-specific processing of the individual types --
       if (!Objects.isNull(drb345PairsFirst) && !drb345PairsFirst.isEmpty()) {
         // Set the DRB345 types
@@ -467,54 +575,107 @@ public class XmlScore6Parser {
           HLAType drbAllele = drbType.getAlleleCombination();
           if (drbMap.containsKey(drbAllele.locus())) {
             String drbString = String.valueOf(drbAllele.spec().get(0));
+            String drbString1 = drbAllele.equivSafe().specString();
             drbMap.get(drbAllele.locus()).accept(builder, drbString);
           }
         }
       }
 
+      if (hasValidAlleleCall && acMatchIndices.isEmpty()) {
+        builder.addAuditMessage("Could not find a matching haplotype for assigned alleles [" + hlaLocus.name() + "*" + alleleCall1 + " / "
+            + hlaLocus.name() + "*" + alleleCall2 + "]. Using best haplotypes instead.");
+      }
+
+      Element selectedResultCombination = resultCombinationSets.get(selectedResultIndex);
+
       // Parse haplotypes
       if (C_HEADER.equals(locus)) {
-        addHaplotypes(builder, resultCombinations.get(selectedResultIndex),
-            identityLocusMap(HLALocus.C), ValidationModelBuilder::cHaplotype);
+        addHaplotypes(builder, selectedResultCombination, identityLocusMap(HLALocus.C), ValidationModelBuilder::cHaplotype);
       } else if (DQB_HEADER.equals(locus)) {
-        addHaplotypes(builder, resultCombinations.get(selectedResultIndex),
-            identityLocusMap(HLALocus.DQB1), ValidationModelBuilder::dqHaplotype);
+        addHaplotypes(builder, selectedResultCombination, identityLocusMap(HLALocus.DQB1), ValidationModelBuilder::dqHaplotype);
       } else if (DRB_HEADER.equals(locus)) {
-        addHaplotypes(builder, resultCombinations.get(selectedResultIndex),
-            identityLocusMap(HLALocus.DRB1), ValidationModelBuilder::drHaplotype);
+        addHaplotypes(builder, selectedResultCombination, identityLocusMap(HLALocus.DRB1), ValidationModelBuilder::drHaplotype);
         if (selectedDRB345Index > 0) {
-          addHaplotypes(builder, resultCombinations.get(selectedDRB345Index),
-              drb345Map(ciwdResultPairs), ValidationModelBuilder::dr345Haplotype);
+          addHaplotypes(builder, resultCombinationSets.get(selectedDRB345Index), drb345Map(ciwdResultPairs), ValidationModelBuilder::dr345Haplotype);
         } else {
           builder.dr345Haplotype(ArrayListMultimap.create());
         }
       } else if (B_HEADER.equals(locus)) {
-        addHaplotypes(builder, resultCombinations.get(selectedResultIndex),
-            identityLocusMap(HLALocus.B), ValidationModelBuilder::bHaplotype);
+        addHaplotypes(builder, selectedResultCombination, identityLocusMap(HLALocus.B), ValidationModelBuilder::bHaplotype);
 
-        for (int strandIdx = 0; strandIdx < ciwdResultPairs.size(); strandIdx++) {
-          // B*47:03 is considered BW6 despite B47 antigen being considered BW4
-          if (ciwdResultPairs.get(strandIdx).alleleCombination.toString().contains("B*47:03")) {
-            builder.bw6(true);
-            break;
+        if (hasValidAlleleCall) {
+          BwGroup known1 = BwSerotypes.getBwGroup(h1);
+          BwGroup known2 = BwSerotypes.getBwGroup(h2);
+          boolean known4 = known1 == BwGroup.Bw4 || known2 == BwGroup.Bw4;
+          boolean known6 = known1 == BwGroup.Bw6 || known2 == BwGroup.Bw6;
+          if (assignedBw4) {
+            builder.bw4(true);
+            if (!known4) {
+              // assigned Bw4 but not known to be Bw4
+              builder.addAuditMessage("HLA-B was assigned Bw4 but neither of the assigned alleles [" + hlaLocus.name() + "*" + alleleCall1 + " / "
+                  + hlaLocus.name() + "*" + alleleCall2 + "] are known by DonorCheck to be Bw4");
+            }
+          } else if (known4) {
+            // not assigned Bw4 but known to be Bw4
+            builder.addAuditMessage("HLA-B was not assigned Bw4 but at least one of the assigned alleles [" + hlaLocus.name() + "*" + alleleCall1
+                + " / " + hlaLocus.name() + "*" + alleleCall2 + "] is known by DonorCheck to be Bw4");
           }
-          // Update the appropriate builder flags
-          BwGroup bw =
-              BwSerotypes.getBwGroup(ciwdResultPairs.get(strandIdx).getAntigenCombination());
-          switch (bw) {
-            case Bw4:
-              builder.bw4(true);
-              break;
-            case Bw6:
+          if (assignedBw6) {
+            builder.bw6(true);
+            if (!known6) {
+              // assigned Bw6 but not known to be Bw6
+              builder.addAuditMessage("HLA-B was assigned Bw6 but neither of the assigned alleles [" + hlaLocus.name() + "*" + alleleCall1 + " / "
+                  + hlaLocus.name() + "*" + alleleCall2 + "] are known by DonorCheck to be Bw6");
+            }
+          } else if (known6) {
+            // not assigned Bw6 but known to be Bw6
+            builder.addAuditMessage("HLA-B was not assigned Bw6 but at least one of the assigned alleles [" + hlaLocus.name() + "*" + alleleCall1
+                + " / " + hlaLocus.name() + "*" + alleleCall2 + "] is known by DonorCheck to be Bw6");
+          }
+        } else {
+          for (int strandIdx = 0; strandIdx < ciwdResultPairs.size(); strandIdx++) {
+            // B*47:03 is considered BW6 despite B47 antigen being considered BW4
+            if (ciwdResultPairs.get(strandIdx).alleleCombination.toString().contains("B*47:03")) {
               builder.bw6(true);
               break;
-            default:
-              break;
+            }
+            // Update the appropriate builder flags
+            BwGroup bw = BwSerotypes.getBwGroup(ciwdResultPairs.get(strandIdx).getAntigenCombination());
+            BwGroup bw1 = BwSerotypes.getBwGroup(ciwdResultPairs.get(strandIdx).getAlleleCombination());
+            if (bw != bw1) {
+              // discrepancy between allele status and antigen status
+            }
+            switch (bw) {
+              case Bw4:
+                builder.bw4(true);
+                break;
+              case Bw6:
+                builder.bw6(true);
+                break;
+              default:
+                break;
+            }
           }
         }
       } else if (DPB_HEADER.equals(locus)) {
-        addHaplotypes(builder, resultCombinations.get(selectedResultIndex),
-            identityLocusMap(HLALocus.DPB1), ValidationModelBuilder::dpHaplotype);
+        addHaplotypes(builder, selectedResultCombination, identityLocusMap(HLALocus.DPB1), ValidationModelBuilder::dpHaplotype);
+      }
+
+      // if we don't have both, but we haven't thrown an error, fall back to using the default behavior
+      // we would use if the allele call value wasn't there in the first place
+      if (h1 != null && h2 != null) {
+        String sero1 = null;
+        String sero2 = null;
+        sero1 = convertToSerotype(locus, h1);
+        sero2 = convertToSerotype(locus, h2);
+        metadataMap.get(locus).accept(builder, sero1);
+        metadataMap.get(locus).accept(builder, sero2);
+        if (metadataTypeMap.containsKey(locus)) {
+          metadataTypeMap.get(locus).accept(builder, h1);
+          metadataTypeMap.get(locus).accept(builder, h2);
+        }
+        builder.setLocusAssigned(hlaLocus, h1, h2);
+        return;
       }
 
       // Finally, add the types to the model builder
@@ -530,8 +691,7 @@ public class XmlScore6Parser {
       for (int i = 0; i < ciwdResultPairs.size(); i++) {
         HLAType ciwdAllele = ciwdResultPairs.get(i).alleleCombination;
         if (ciwdAllele.resolution() > 2) {
-          ciwdAllele =
-              new HLAType(ciwdAllele.locus(), ciwdAllele.spec().get(0), ciwdAllele.spec().get(1));
+          ciwdAllele = new HLAType(ciwdAllele.locus(), ciwdAllele.spec().get(0), ciwdAllele.spec().get(1));
         } else if (ciwdAllele.resolution() == 1) {
           // TODO
         }
@@ -542,8 +702,7 @@ public class XmlScore6Parser {
       for (int i = 0; i < firstResultPairs.size(); i++) {
         HLAType firstAllele = firstResultPairs.get(i).alleleCombination;
         if (firstAllele.resolution() > 2) {
-          firstAllele = new HLAType(firstAllele.locus(), firstAllele.spec().get(0),
-              firstAllele.spec().get(1));
+          firstAllele = new HLAType(firstAllele.locus(), firstAllele.spec().get(0), firstAllele.spec().get(1));
         } else if (firstAllele.resolution() == 1) {
           // TODO
         }
@@ -551,8 +710,8 @@ public class XmlScore6Parser {
         firstTypes.add(convertToSerotype(locus, firstAllele));
       }
 
-      boolean hasUnknown = firstResultPairs.stream().map(ResultCombination::getAlleleCombination)
-          .map(CommonWellDocumented::getStatus).filter(c -> c == Status.UNKNOWN).count() > 0;
+      boolean hasUnknown = firstResultPairs.stream().map(ResultCombination::getAlleleCombination).map(CommonWellDocumented::getStatus)
+          .filter(c -> c == Status.UNKNOWN).count() > 0;
 
       if (hasUnknown) {
         if (ValidationModelBuilder.REPORT_SERO.contains(hlaLocus)) {
@@ -622,16 +781,14 @@ public class XmlScore6Parser {
       return loci.iterator().next();
     }
     throw new IllegalStateException(
-        "DRB345 alleles found without locus; interrogation of DRB1 alleles found " + loci.size()
-            + " distinct DRB345 loci");
+        "DRB345 alleles found without locus; interrogation of DRB1 alleles found " + loci.size() + " distinct DRB345 loci");
   }
 
   private static Map<Strand, HLALocus> drb345Map(List<ResultCombination> resultPairs) {
     Builder<Strand, HLALocus> mapBuilder = ImmutableMap.builder();
     int strandIdx = 0;
     for (int combinationIndex = 0; combinationIndex < resultPairs.size(); combinationIndex++) {
-      Optional<HLALocus> locus =
-          DRAssociations.getDRBLocus(resultPairs.get(combinationIndex).getAntigenCombination());
+      Optional<HLALocus> locus = DRAssociations.getDRBLocus(resultPairs.get(combinationIndex).getAntigenCombination());
       if (locus.isPresent()) {
         mapBuilder.put(Strand.values()[strandIdx++], locus.get());
       }
@@ -653,8 +810,7 @@ public class XmlScore6Parser {
    * @return The DRB locus discovered, or null if it is not found
    */
   private static HLALocus parseDRBCombination(String xml) {
-    Set<HLALocus> drbLoci =
-        ImmutableSet.of(HLALocus.DRB1, HLALocus.DRB3, HLALocus.DRB4, HLALocus.DRB5);
+    Set<HLALocus> drbLoci = ImmutableSet.of(HLALocus.DRB1, HLALocus.DRB3, HLALocus.DRB4, HLALocus.DRB5);
 
     for (HLALocus locus : drbLoci) {
       if (xml.contains(locus.toString() + "*")) {
@@ -693,13 +849,10 @@ public class XmlScore6Parser {
     return drCounts;
   }
 
-  private static void parseAlleleCombinations(Element resultCombination, HLALocus locus,
-      AllelePairings allelePairs) {
+  private static void parseAlleleCombinations(Element resultCombination, HLALocus locus, AllelePairings allelePairs) {
 
-    List<String> a1Types =
-        getAllValidTypes(resultCombination.getElementsByTag("alleleList1"), locus);
-    List<String> a2Types =
-        getAllValidTypes(resultCombination.getElementsByTag("alleleList2"), locus);
+    List<String> a1Types = getAllValidTypes(resultCombination.getElementsByTag("alleleList1"), locus);
+    List<String> a2Types = getAllValidTypes(resultCombination.getElementsByTag("alleleList2"), locus);
 
     for (String a1 : a1Types) {
       for (String a2 : a2Types) {
@@ -710,15 +863,13 @@ public class XmlScore6Parser {
   }
 
   /** Parse the allele + antigen pairs from a result combination */
-  private static List<ResultCombination> parseResultCombinations(Element currentCombination,
-      HLALocus locus, boolean requireCWD) {
+  private static List<ResultCombination> parseResultCombinations(Element currentCombination, HLALocus locus, boolean requireCWD) {
     List<ResultCombination> combinations = new ArrayList<>();
     for (int combination = 1; combination <= 4; combination++) {
       ResultCombination nextResult = null;
       try {
-        nextResult = parseCombination(currentCombination, combination, locus,
-            ALLELE_COMBINATION_TAG, requireCWD ? XmlScore6Parser::getFirstValidCWDType
-                : XmlScore6Parser::getFirstValidType);
+        nextResult = parseCombination(currentCombination, combination, locus, ALLELE_COMBINATION_TAG,
+            requireCWD ? XmlScore6Parser::getFirstValidCWDType : XmlScore6Parser::getFirstValidType);
       } catch (Exception e) {
         e.printStackTrace(System.err);
       }
@@ -729,20 +880,63 @@ public class XmlScore6Parser {
     return combinations;
   }
 
+
+  /** Parse the allele + antigen pairs from a result combination */
+  private static boolean testIfAlleleCallPresent(HLAType ac1, HLAType ac2, Element currentCombination, HLALocus locus) {
+    Set<Integer> ac1FoundIn = new HashSet<>();
+    Set<Integer> ac2FoundIn = new HashSet<>();
+
+    for (int combination = 1; combination <= 4; combination++) {
+      try {
+        boolean[] found = testIfAlleleCallPresent(ac1, ac2, currentCombination, combination, ALLELE_COMBINATION_TAG);
+        if (found[0])
+          ac1FoundIn.add(combination);
+        if (found[1])
+          ac2FoundIn.add(combination);
+      } catch (Exception e) {
+        e.printStackTrace(System.err);
+      }
+    }
+
+    // Both alleles need to be found in at least one combination
+    boolean bothFound = !ac1FoundIn.isEmpty() && !ac2FoundIn.isEmpty();
+
+    // Check if they are both found ONLY in the same single combination
+    boolean foundInSameSingleCombinationOnly = ac1FoundIn.equals(ac2FoundIn) && ac1FoundIn.size() == 1;
+
+    // Return true if both alleles are found and they are not exclusively in the same single combination
+    return bothFound && !foundInSameSingleCombinationOnly;
+  }
+
+  private static boolean[] testIfAlleleCallPresent(HLAType ac1, HLAType ac2, Element resultCombinations, int combinationIndex,
+      String alleleComboTag) {
+    List<String> alleles = getAllValidTypes(resultCombinations.getElementsByTag(alleleComboTag + combinationIndex), ac1.locus());
+    boolean foundAC1 = false;
+    boolean foundAC2 = false;
+    for (String s : alleles) {
+      HLAType h = HLAType.valueOf(s);
+      if (HLAType.permissiveEquals(ac1, h)) {
+        foundAC1 = true;
+      }
+      if (HLAType.permissiveEquals(ac2, h)) {
+        foundAC2 = true;
+      }
+      if (foundAC1 && foundAC2) {
+        break;
+      }
+    }
+    return new boolean[] {foundAC1, foundAC2};
+  }
+
   /** Parse a particular allele + antigen pair from a single result combination */
-  private static ResultCombination parseCombination(Element resultCombinations,
-      int combinationIndex, HLALocus locus, String alleleComboTag,
+  private static ResultCombination parseCombination(Element resultCombinations, int combinationIndex, HLALocus locus, String alleleComboTag,
       BiFunction<Elements, HLALocus, String> typeFunction) {
 
-    String alleleString = typeFunction
-        .apply(resultCombinations.getElementsByTag(alleleComboTag + combinationIndex), locus);
-    String antigenString1 = typeFunction
-        .apply(resultCombinations.getElementsByTag(SERO_COMBINATION_TAG + combinationIndex), null);
-    String antigenString =
-        parseSerotype(resultCombinations.getElementsByTag(SERO_COMBINATION_TAG + combinationIndex));
+    String alleleString = typeFunction.apply(resultCombinations.getElementsByTag(alleleComboTag + combinationIndex), locus);
+    String antigenString1 = typeFunction.apply(resultCombinations.getElementsByTag(SERO_COMBINATION_TAG + combinationIndex), null);
+    String antigenString = parseSerotype(resultCombinations.getElementsByTag(SERO_COMBINATION_TAG + combinationIndex));
 
-    if (!hasCombination(resultCombinations, combinationIndex, alleleComboTag)
-        && !DISREGARD_SERO.contains(locus.toString())) {
+    if (!hasCombination(resultCombinations, combinationIndex, alleleComboTag) && !DISREGARD_SERO.contains(locus.toString())) {
       return null;
     }
     if (alleleString != null && alleleString.matches(ValidationModelBuilder.NOT_EXPRESSED)) {
@@ -784,9 +978,8 @@ public class XmlScore6Parser {
       String type = null;
       String[] resultTypes = results.get(0).text().replaceAll("\\s+", "").split(RESULT_SEPARATOR);
 
-      for (int result =
-          0; (Strings.isNullOrEmpty(type) || UNDEFINED_TOKENS.contains(type) || isNullType(type))
-              && result < resultTypes.length; result++) {
+      for (int result = 0; (Strings.isNullOrEmpty(type) || UNDEFINED_TOKENS.contains(type) || isNullType(type))
+          && result < resultTypes.length; result++) {
         String tmp = resultTypes[result];
         if (tmp.isEmpty()) {
           // Sometimes a leading comma can create empty strings - skip these
@@ -812,8 +1005,7 @@ public class XmlScore6Parser {
    * Read all possible alleles in a result combination. These will be used to compute the most
    * probable haplotypes.
    */
-  private static void addHaplotypes(ValidationModelBuilder builder, Element resultCombination,
-      Map<Strand, HLALocus> locusMap,
+  private static void addHaplotypes(ValidationModelBuilder builder, Element resultCombination, Map<Strand, HLALocus> locusMap,
       BiConsumer<ValidationModelBuilder, Multimap<Strand, HLAType>> haplotypeSetter) {
     for (int strandIndex = 1; strandIndex <= Strand.values().length; strandIndex++) {
       Elements results = resultCombination.getElementsByTag(ALLELE_COMBINATION_TAG + strandIndex);
@@ -847,27 +1039,23 @@ public class XmlScore6Parser {
   /**
    * @param reference Base list
    * @param test List to compare to base
-   * @return true if the test list contains a more frequent allele pairing than the reference set.
-   *         If the frequency is the same, the specificity values will be compared - preferring
-   *         lower values.
+   * @return true if the test list contains a more frequent allele pairing than the reference set. If
+   *         the frequency is the same, the specificity values will be compared - preferring lower
+   *         values.
    */
-  private static boolean isTestListPreferred(List<ResultCombination> referenceCombinations,
-      List<ResultCombination> testCombinations) {
+  private static boolean isTestListPreferred(List<ResultCombination> referenceCombinations, List<ResultCombination> testCombinations) {
     if (Objects.isNull(testCombinations) || testCombinations.isEmpty()) {
       return false;
     }
 
-    List<HLAType> reference = referenceCombinations.stream()
-        .map(ResultCombination::getAlleleCombination).collect(Collectors.toList());
-    List<HLAType> test = testCombinations.stream().map(ResultCombination::getAlleleCombination)
-        .collect(Collectors.toList());
+    List<HLAType> reference = referenceCombinations.stream().map(ResultCombination::getAlleleCombination).collect(Collectors.toList());
+    List<HLAType> test = testCombinations.stream().map(ResultCombination::getAlleleCombination).collect(Collectors.toList());
     // If the lists are not equal size return the larger list
     if (reference.size() != test.size()) {
       return reference.size() < test.size();
     }
     // Test if test has higher frequency alleles
-    int diff = Double.compare(CommonWellDocumented.cwdScore(reference),
-        CommonWellDocumented.cwdScore(test));
+    int diff = Double.compare(CommonWellDocumented.cwdScore(reference), CommonWellDocumented.cwdScore(test));
 
     if (diff == 0) {
       // Test if test contains alleles with smaller spec
@@ -885,11 +1073,9 @@ public class XmlScore6Parser {
    */
   private static int compareSpec(List<HLAType> reference, List<HLAType> test) {
     if (!Objects.equals(reference.size(), test.size())) {
-      String refString =
-          reference.stream().map(HLAType::toString).collect(Collectors.joining(", "));
+      String refString = reference.stream().map(HLAType::toString).collect(Collectors.joining(", "));
       String testString = test.stream().map(HLAType::toString).collect(Collectors.joining(", "));
-      throw new IllegalArgumentException(
-          "Found allele combinations with different sizes: " + refString + " - " + testString);
+      throw new IllegalArgumentException("Found allele combinations with different sizes: " + refString + " - " + testString);
     }
 
     List<Integer> refCounts = countSpec(reference);
@@ -928,8 +1114,7 @@ public class XmlScore6Parser {
   }
 
   /** @return true iff the combination XML block contains a result combination of the given index */
-  private static boolean hasCombination(Element resultCombinations, int combinationIndex,
-      String alleleComboTag) {
+  private static boolean hasCombination(Element resultCombinations, int combinationIndex, String alleleComboTag) {
     for (String combinationTag : ImmutableSet.of(alleleComboTag, SERO_COMBINATION_TAG)) {
       Elements results = resultCombinations.getElementsByTag(combinationTag + combinationIndex);
       if (results.isEmpty() || !results.get(0).hasText()) {
@@ -984,8 +1169,8 @@ public class XmlScore6Parser {
 
   /**
    * @return {@code null} if there is no type at this position (homozygous or single DRB345);
-   *         {@link #NULL_TYPE} if the allele is present but not expressed; {@link #UNDEFINED_TYPE}
-   *         if the allele is expressed but has no serological equivalent.
+   *         {@link #NULL_TYPE} if the allele is present but not expressed; {@link #UNDEFINED_TYPE} if
+   *         the allele is expressed but has no serological equivalent.
    */
   private static String getFirstValidType(Elements results, HLALocus locus) {
     String typeText = null;
@@ -1039,8 +1224,8 @@ public class XmlScore6Parser {
 
   /**
    * @return {@code null} if there is no type at this position (homozygous or single DRB345);
-   *         {@link #NULL_TYPE} if the allele is present but not expressed; {@link #UNDEFINED_TYPE}
-   *         if the allele is expressed but has no serological equivalent.
+   *         {@link #NULL_TYPE} if the allele is present but not expressed; {@link #UNDEFINED_TYPE} if
+   *         the allele is expressed but has no serological equivalent.
    */
   private static String getFirstValidCWDType(Elements results, HLALocus locus) {
     Status bestStatus = Objects.isNull(locus) ? Status.COMMON : null;
@@ -1049,9 +1234,9 @@ public class XmlScore6Parser {
       String type = null;
       String[] resultTypes = results.get(0).text().replaceAll("\\s+", "").split(RESULT_SEPARATOR);
 
-      for (int result = 0; (Strings.isNullOrEmpty(type) || UNDEFINED_TYPE.equals(type)
-          || isNullType(type) || !Objects.equals(Status.COMMON, bestStatus))
-          && result < resultTypes.length; result++) {
+      for (int result =
+          0; (Strings.isNullOrEmpty(type) || UNDEFINED_TYPE.equals(type) || isNullType(type) || !Objects.equals(Status.COMMON, bestStatus))
+              && result < resultTypes.length; result++) {
         String tmp = resultTypes[result];
         if (tmp.isEmpty()) {
           // Sometimes a leading comma can create empty strings - skip these
@@ -1087,8 +1272,7 @@ public class XmlScore6Parser {
             }
             // Make sure that this allele has a better CWD status than the last
             Status currentStatus = CommonWellDocumented.getStatus(HLAType.valueOf(tmp));
-            if (Objects.nonNull(bestStatus)
-                && bestStatus.getWeight() >= currentStatus.getWeight()) {
+            if (Objects.nonNull(bestStatus) && bestStatus.getWeight() >= currentStatus.getWeight()) {
               continue;
             }
             bestStatus = currentStatus;
@@ -1139,8 +1323,7 @@ public class XmlScore6Parser {
       StringJoiner sj = new StringJoiner(":");
       sj.add(String.valueOf(hlaType.spec().get(0)));
 
-      if (Objects.equals(HLALocus.DPA1, hlaType.locus())
-          || Objects.equals(HLALocus.DPB1, hlaType.locus())) {
+      if (Objects.equals(HLALocus.DPA1, hlaType.locus()) || Objects.equals(HLALocus.DPB1, hlaType.locus())) {
         // DPA and DPB report two fields
         HLAType t = hlaType;
         if (hlaType.resolution() == 1) {
@@ -1156,16 +1339,15 @@ public class XmlScore6Parser {
   }
 
   /**
-   * Helper class to store paired allele + antigen pairs. Each result combination maps to one of
-   * these pairs, and we may need both for determining which combinations to pick (e.g. we select
-   * the most likely combination based on allele frequency, but report the serotype)
+   * Helper class to store paired allele + antigen pairs. Each result combination maps to one of these
+   * pairs, and we may need both for determining which combinations to pick (e.g. we select the most
+   * likely combination based on allele frequency, but report the serotype)
    */
   private static class ResultCombination {
     private final SeroType antigenCombination;
     private final HLAType alleleCombination;
 
-    public ResultCombination(@Nonnull SeroType antigenCombination,
-        @Nonnull HLAType alleleCombination) {
+    public ResultCombination(@Nonnull SeroType antigenCombination, @Nonnull HLAType alleleCombination) {
       super();
       try {
         Objects.requireNonNull(antigenCombination);
@@ -1180,8 +1362,7 @@ public class XmlScore6Parser {
 
     @Override
     public String toString() {
-      return "ResultCombination [antigenCombination=" + antigenCombination + ", alleleCombination="
-          + alleleCombination + "]";
+      return "ResultCombination [antigenCombination=" + antigenCombination + ", alleleCombination=" + alleleCombination + "]";
     }
 
     public SeroType getAntigenCombination() {

--- a/src/main/java/org/pankratzlab/unet/validation/AlertHelper.java
+++ b/src/main/java/org/pankratzlab/unet/validation/AlertHelper.java
@@ -2,7 +2,6 @@ package org.pankratzlab.unet.validation;
 
 import java.io.File;
 import java.util.Optional;
-
 import javafx.geometry.Pos;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
@@ -14,48 +13,32 @@ import javafx.scene.layout.VBox;
 
 public final class AlertHelper {
 
-  public static void showMessage_ErrorUpdatingTestProperties(
-      ValidationTestFileSet rowValue, Throwable cause) {
-    Alert alert1 =
-        new Alert(
-            AlertType.ERROR,
-            "Error - unable to update test properties for test "
-                + rowValue.id.get()
-                + ". An exception occurred:\n"
-                + cause.getMessage(),
-            ButtonType.CLOSE);
+  public static void showMessage_ErrorUpdatingTestProperties(ValidationTestFileSet rowValue, Throwable cause) {
+    cause.printStackTrace();
+    Alert alert1 = new Alert(AlertType.ERROR,
+        "Error - unable to update test properties for test " + rowValue.id.get() + ". An exception occurred:\n" + cause.getMessage(),
+        ButtonType.CLOSE);
     alert1.setTitle("Failed to update test");
     alert1.setHeaderText("");
     alert1.showAndWait();
   }
 
   public static void showMessage_ErrorUpdatingTestID(String id, String newId, Throwable cause) {
-    Alert alert1 =
-        new Alert(
-            AlertType.ERROR,
-            "Error - unable to rename test from "
-                + id
-                + " to "
-                + newId
-                + ". An exception occurred when moving the directory:\n"
-                + cause.getMessage(),
-            ButtonType.CLOSE);
+    cause.printStackTrace();
+    Alert alert1 = new Alert(AlertType.ERROR,
+        "Error - unable to rename test from " + id + " to " + newId + ". An exception occurred when moving the directory:\n" + cause.getMessage(),
+        ButtonType.CLOSE);
     alert1.setTitle("Failed to rename test");
     alert1.setHeaderText("");
     alert1.showAndWait();
   }
 
   static Optional<ButtonType> showMessage_PII() {
-    Alert alert =
-        new Alert(
-            AlertType.WARNING,
-            "Caution - DonorCheck will retain a copy of the current input files here:\n\n"
-                + ValidationTesting.VALIDATION_DIRECTORY
-                + "\n\nPlease ensure that:\n\n"
-                + "1) The given input files do not contain Personally Identifiable Information (PII), or\n\n"
-                + "2) If the input files do contain PII, that this location is safe to store PII.",
-            ButtonType.OK,
-            ButtonType.CANCEL);
+    Alert alert = new Alert(AlertType.WARNING,
+        "Caution - DonorCheck will retain a copy of the current input files here:\n\n" + ValidationTesting.VALIDATION_DIRECTORY
+            + "\n\nPlease ensure that:\n\n" + "1) The given input files do not contain Personally Identifiable Information (PII), or\n\n"
+            + "2) If the input files do contain PII, that this location is safe to store PII.",
+        ButtonType.OK, ButtonType.CANCEL);
     alert.setTitle("PII warning");
     alert.setHeaderText("");
     Optional<ButtonType> selVal = alert.showAndWait();
@@ -69,9 +52,7 @@ public final class AlertHelper {
     dialog.setHeaderText("A test with the same ID / Label (" + file1.label + ") already exists.");
     String contentText =
         "If this is an error, please remove the test in the DonorCheck Testing Management tool.\n\nOr remove the test manually by deleting this directory:\n\n"
-            + new File(subdir).getAbsolutePath()
-            + File.separator
-            + "\n\nOtherwise, provide a different name for the new test:";
+            + new File(subdir).getAbsolutePath() + File.separator + "\n\nOtherwise, provide a different name for the new test:";
 
     TextField textField = dialog.getEditor();
     Label label = new Label(contentText);
@@ -87,12 +68,8 @@ public final class AlertHelper {
 
   static void showMessage_ErrorCopyingRelFile(String relFile) {
     // notify user, show directory path and cancel operation
-    Alert alert1 =
-        new Alert(
-            AlertType.ERROR,
-            "Error - could not copy serotype lookup file to validation testing directory.\n\nFile: "
-                + relFile,
-            ButtonType.CLOSE);
+    Alert alert1 = new Alert(AlertType.ERROR, "Error - could not copy serotype lookup file to validation testing directory.\n\nFile: " + relFile,
+        ButtonType.CLOSE);
     alert1.setTitle("Failed to add test");
     alert1.setHeaderText("");
     alert1.showAndWait();
@@ -100,12 +77,8 @@ public final class AlertHelper {
 
   static void showMessage_ErrorWritingRemapXMLFile(String remapFile) {
     // notify user, show directory path and cancel operation
-    Alert alert1 =
-        new Alert(
-            AlertType.ERROR,
-            "Error - could not write locus remappings file to validation testing directory.\n\nFile: "
-                + remapFile,
-            ButtonType.CLOSE);
+    Alert alert1 = new Alert(AlertType.ERROR, "Error - could not write locus remappings file to validation testing directory.\n\nFile: " + remapFile,
+        ButtonType.CLOSE);
     alert1.setTitle("Failed to add test");
     alert1.setHeaderText("");
     alert1.showAndWait();
@@ -113,26 +86,16 @@ public final class AlertHelper {
 
   static void showMessage_ErrorWritingPropertiesFile(String propsFile) {
     // notify user, show directory path and cancel operation
-    Alert alert1 =
-        new Alert(
-            AlertType.ERROR,
-            "Error - could not write test properties file to validation testing directory.\n\nFile: "
-                + propsFile,
-            ButtonType.CLOSE);
+    Alert alert1 = new Alert(AlertType.ERROR, "Error - could not write test properties file to validation testing directory.\n\nFile: " + propsFile,
+        ButtonType.CLOSE);
     alert1.setTitle("Failed to add test");
     alert1.setHeaderText("");
     alert1.showAndWait();
   }
 
   static void showMessage_ErrorCopyingInputFile(TestInfo file, String subdir) {
-    Alert alert1 =
-        new Alert(
-            AlertType.ERROR,
-            "Error - could not copy input file to validation testing directory.\n\nFile: "
-                + file.file
-                + "\n\nDirectory: "
-                + subdir,
-            ButtonType.CLOSE);
+    Alert alert1 = new Alert(AlertType.ERROR,
+        "Error - could not copy input file to validation testing directory.\n\nFile: " + file.file + "\n\nDirectory: " + subdir, ButtonType.CLOSE);
     alert1.setTitle("Failed to add test");
     alert1.setHeaderText("");
     alert1.showAndWait();

--- a/src/main/java/org/pankratzlab/unet/validation/AlertHelper.java
+++ b/src/main/java/org/pankratzlab/unet/validation/AlertHelper.java
@@ -1,61 +1,98 @@
 package org.pankratzlab.unet.validation;
 
+import java.io.File;
 import java.util.Optional;
+
+import javafx.geometry.Pos;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.ButtonType;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.control.TextInputDialog;
+import javafx.scene.layout.VBox;
 
 public final class AlertHelper {
 
-  public static void showMessage_ErrorUpdatingTestProperties(ValidationTestFileSet rowValue,
-      Throwable cause) {
-    Alert alert1 = new Alert(AlertType.ERROR, "Error - unable to update test properties for test "
-        + rowValue.id.get() + ". An exception occurred:\n" + cause.getMessage(), ButtonType.CLOSE);
+  public static void showMessage_ErrorUpdatingTestProperties(
+      ValidationTestFileSet rowValue, Throwable cause) {
+    Alert alert1 =
+        new Alert(
+            AlertType.ERROR,
+            "Error - unable to update test properties for test "
+                + rowValue.id.get()
+                + ". An exception occurred:\n"
+                + cause.getMessage(),
+            ButtonType.CLOSE);
     alert1.setTitle("Failed to update test");
     alert1.setHeaderText("");
     alert1.showAndWait();
   }
 
   public static void showMessage_ErrorUpdatingTestID(String id, String newId, Throwable cause) {
-    Alert alert1 = new Alert(AlertType.ERROR,
-        "Error - unable to rename test from " + id + " to " + newId
-            + ". An exception occurred when moving the directory:\n" + cause.getMessage(),
-        ButtonType.CLOSE);
+    Alert alert1 =
+        new Alert(
+            AlertType.ERROR,
+            "Error - unable to rename test from "
+                + id
+                + " to "
+                + newId
+                + ". An exception occurred when moving the directory:\n"
+                + cause.getMessage(),
+            ButtonType.CLOSE);
     alert1.setTitle("Failed to rename test");
     alert1.setHeaderText("");
     alert1.showAndWait();
   }
 
   static Optional<ButtonType> showMessage_PII() {
-    Alert alert = new Alert(AlertType.WARNING,
-        "Caution - DonorCheck will retain a copy of the current input files here:\n\n"
-            + ValidationTesting.VALIDATION_DIRECTORY + "\n\nPlease ensure that:\n\n"
-            + "1) The given input files do not contain Personally Identifiable Information (PII), or\n\n"
-            + "2) If the input files do contain PII, that this location is safe to store PII.",
-        ButtonType.OK, ButtonType.CANCEL);
+    Alert alert =
+        new Alert(
+            AlertType.WARNING,
+            "Caution - DonorCheck will retain a copy of the current input files here:\n\n"
+                + ValidationTesting.VALIDATION_DIRECTORY
+                + "\n\nPlease ensure that:\n\n"
+                + "1) The given input files do not contain Personally Identifiable Information (PII), or\n\n"
+                + "2) If the input files do contain PII, that this location is safe to store PII.",
+            ButtonType.OK,
+            ButtonType.CANCEL);
     alert.setTitle("PII warning");
     alert.setHeaderText("");
     Optional<ButtonType> selVal = alert.showAndWait();
     return selVal;
   }
 
-  static void showMessage_TestAlreadyExists(TestInfo file1, String subdir) {
+  static Optional<String> showMessage_TestAlreadyExists(TestInfo file1, String subdir) {
     // notify user, show directory path and cancel operation
-    Alert alert1 = new Alert(AlertType.ERROR, "Error - a test with the same ID / Label ("
-        + file1.label
-        + ") already exists.\n\nIf this is an error, please remove the test in the DonorCheck Testing Management tool.\n\nOr remove the test manually by deleting this directory:\n\n"
-        + subdir, ButtonType.CLOSE);
-    alert1.setTitle("Failed to add test");
-    alert1.setHeaderText("");
-    alert1.showAndWait();
+    TextInputDialog dialog = new TextInputDialog(file1.label);
+    dialog.setTitle("Test already exists");
+    dialog.setHeaderText("A test with the same ID / Label (" + file1.label + ") already exists.");
+    String contentText =
+        "If this is an error, please remove the test in the DonorCheck Testing Management tool.\n\nOr remove the test manually by deleting this directory:\n\n"
+            + new File(subdir).getAbsolutePath()
+            + File.separator
+            + "\n\nOtherwise, provide a different name for the new test:";
+
+    TextField textField = dialog.getEditor();
+    Label label = new Label(contentText);
+
+    VBox vBox = new VBox(label, textField);
+    vBox.setAlignment(Pos.CENTER_LEFT);
+    vBox.setSpacing(10);
+
+    dialog.getDialogPane().setContent(vBox);
+    Optional<String> result = dialog.showAndWait();
+    return result;
   }
 
   static void showMessage_ErrorCopyingRelFile(String relFile) {
     // notify user, show directory path and cancel operation
-    Alert alert1 = new Alert(AlertType.ERROR,
-        "Error - could not copy serotype lookup file to validation testing directory.\n\nFile: "
-            + relFile,
-        ButtonType.CLOSE);
+    Alert alert1 =
+        new Alert(
+            AlertType.ERROR,
+            "Error - could not copy serotype lookup file to validation testing directory.\n\nFile: "
+                + relFile,
+            ButtonType.CLOSE);
     alert1.setTitle("Failed to add test");
     alert1.setHeaderText("");
     alert1.showAndWait();
@@ -63,10 +100,12 @@ public final class AlertHelper {
 
   static void showMessage_ErrorWritingRemapXMLFile(String remapFile) {
     // notify user, show directory path and cancel operation
-    Alert alert1 = new Alert(AlertType.ERROR,
-        "Error - could not write locus remappings file to validation testing directory.\n\nFile: "
-            + remapFile,
-        ButtonType.CLOSE);
+    Alert alert1 =
+        new Alert(
+            AlertType.ERROR,
+            "Error - could not write locus remappings file to validation testing directory.\n\nFile: "
+                + remapFile,
+            ButtonType.CLOSE);
     alert1.setTitle("Failed to add test");
     alert1.setHeaderText("");
     alert1.showAndWait();
@@ -74,23 +113,28 @@ public final class AlertHelper {
 
   static void showMessage_ErrorWritingPropertiesFile(String propsFile) {
     // notify user, show directory path and cancel operation
-    Alert alert1 = new Alert(AlertType.ERROR,
-        "Error - could not write test properties file to validation testing directory.\n\nFile: "
-            + propsFile,
-        ButtonType.CLOSE);
+    Alert alert1 =
+        new Alert(
+            AlertType.ERROR,
+            "Error - could not write test properties file to validation testing directory.\n\nFile: "
+                + propsFile,
+            ButtonType.CLOSE);
     alert1.setTitle("Failed to add test");
     alert1.setHeaderText("");
     alert1.showAndWait();
   }
 
   static void showMessage_ErrorCopyingInputFile(TestInfo file, String subdir) {
-    Alert alert1 = new Alert(AlertType.ERROR,
-        "Error - could not copy input file to validation testing directory.\n\nFile: " + file.file
-            + "\n\nDirectory: " + subdir,
-        ButtonType.CLOSE);
+    Alert alert1 =
+        new Alert(
+            AlertType.ERROR,
+            "Error - could not copy input file to validation testing directory.\n\nFile: "
+                + file.file
+                + "\n\nDirectory: "
+                + subdir,
+            ButtonType.CLOSE);
     alert1.setTitle("Failed to add test");
     alert1.setHeaderText("");
     alert1.showAndWait();
   }
-
 }

--- a/src/main/java/org/pankratzlab/unet/validation/TestResultWithMultiData.java
+++ b/src/main/java/org/pankratzlab/unet/validation/TestResultWithMultiData.java
@@ -1,0 +1,57 @@
+package org.pankratzlab.unet.validation;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.pankratzlab.unet.model.ModelData;
+
+class TestResultWithMultiData {
+
+  TEST_RESULT result;
+
+  Map<String, Exception> errorFiles = new HashMap<>();
+  Map<String, ModelData> invalidRemapFiles = new HashMap<>();
+  Map<String, ModelData> invalidModels = new HashMap<>();
+  Map<String, ModelData> validModels = new HashMap<>();
+
+  boolean missingRemapFile = false;
+  Optional<Exception> remapException = Optional.empty();
+
+  public TestResultWithMultiData(TEST_RESULT result) {
+    this.result = result;
+  }
+
+  public TestResultWithMultiData(TEST_RESULT result, Map<String, ModelData> validModels) {
+    this.result = result;
+    this.validModels = validModels;
+  }
+
+  public TestResultWithMultiData(TEST_RESULT result, Map<String, Exception> errorFiles, Map<String, ModelData> invalidRemapFiles,
+      Map<String, ModelData> invalidModels, Map<String, ModelData> validModels, boolean missingRemapFile, Optional<Exception> remapException) {
+    this.result = result;
+    this.errorFiles = errorFiles;
+    this.invalidRemapFiles = invalidRemapFiles;
+    this.invalidModels = invalidModels;
+    this.validModels = validModels;
+    this.missingRemapFile = missingRemapFile;
+    this.remapException = remapException;
+  }
+
+  public TEST_RESULT testResult() {
+    return result;
+  }
+
+  public Optional<Exception> getException() {
+    if (remapException.isPresent())
+      return remapException;
+    if (!errorFiles.isEmpty()) {
+      return Optional.of(errorFiles.values().iterator().next());
+    }
+    return Optional.empty();
+  }
+
+  public Map<String, ModelData> getValidModels() {
+    return validModels;
+  }
+
+}

--- a/src/main/java/org/pankratzlab/unet/validation/TestRun.java
+++ b/src/main/java/org/pankratzlab/unet/validation/TestRun.java
@@ -1,20 +1,31 @@
 package org.pankratzlab.unet.validation;
 
 import java.util.Date;
+import java.util.Map;
 import java.util.Optional;
-import org.pankratzlab.unet.model.ValidationTable.TableData;
+import org.pankratzlab.unet.model.ModelData;
 
 public class TestRun {
-  public final ValidationTestFileSet testFileSet;
-  public final TEST_RESULT result;
-  public final Date runTime;
-  public final Optional<Exception> error;
-  public final Optional<TableData> data;
 
-  public TestRun(ValidationTestFileSet testFileSet, TEST_RESULT result, Date runTime, Optional<Exception> error, Optional<TableData> data) {
+  public static class TestRunMetadata {
+    public final TEST_RESULT result;
+    public final Date runTime;
+
+    public TestRunMetadata(TEST_RESULT result, Date runTime) {
+      this.result = result;
+      this.runTime = runTime;
+    }
+  }
+
+  public final ValidationTestFileSet testFileSet;
+  public final TestRunMetadata testRunMetadata;
+  public final Optional<Exception> error;
+
+  public final Map<String, ModelData> data;
+
+  public TestRun(ValidationTestFileSet testFileSet, TEST_RESULT result, Date runTime, Optional<Exception> error, Map<String, ModelData> data) {
     this.testFileSet = testFileSet;
-    this.result = result;
-    this.runTime = runTime;
+    this.testRunMetadata = new TestRunMetadata(result, runTime);
     this.error = error;
     this.data = data;
   }

--- a/src/main/java/org/pankratzlab/unet/validation/TestRun.java
+++ b/src/main/java/org/pankratzlab/unet/validation/TestRun.java
@@ -2,19 +2,21 @@ package org.pankratzlab.unet.validation;
 
 import java.util.Date;
 import java.util.Optional;
+import org.pankratzlab.unet.model.ValidationTable.TableData;
 
 public class TestRun {
   public final ValidationTestFileSet testFileSet;
   public final TEST_RESULT result;
   public final Date runTime;
   public final Optional<Exception> error;
+  public final Optional<TableData> data;
 
-  public TestRun(ValidationTestFileSet testFileSet, TEST_RESULT result, Date runTime,
-      Optional<Exception> error) {
+  public TestRun(ValidationTestFileSet testFileSet, TEST_RESULT result, Date runTime, Optional<Exception> error, Optional<TableData> data) {
     this.testFileSet = testFileSet;
     this.result = result;
     this.runTime = runTime;
     this.error = error;
+    this.data = data;
   }
 
 }

--- a/src/main/java/org/pankratzlab/unet/validation/ValidationTestFileSet.java
+++ b/src/main/java/org/pankratzlab/unet/validation/ValidationTestFileSet.java
@@ -2,8 +2,10 @@ package org.pankratzlab.unet.validation;
 
 import java.io.File;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.pankratzlab.unet.deprecated.hla.HLALocus;
@@ -51,6 +53,8 @@ public class ValidationTestFileSet {
 
   public final ObjectProperty<TEST_RESULT> lastTestResult;
 
+  public final Map<String, String> dcProperties;
+
   public static class ValidationTestFileSetBuilder {
     private String id;
     private String comment;
@@ -63,6 +67,7 @@ public class ValidationTestFileSet {
     private String donorCheckVersion;
     private Date lastRunDate;
     private TEST_RESULT lastPassingResult;
+    private Map<String, String> dcProperties;
 
     public ValidationTestFileSetBuilder id(String id) {
       this.id = id;
@@ -122,10 +127,15 @@ public class ValidationTestFileSet {
       return this;
     }
 
+    public ValidationTestFileSetBuilder setDonorCheckProperty(String key, String value) {
+      dcProperties = dcProperties == null ? new HashMap<>() : dcProperties;
+      dcProperties.put(key, value);
+      return this;
+    }
+
     public ValidationTestFileSet build() {
-      return new ValidationTestFileSet(id, comment, expectedResult, filePaths, remapFile,
-          remappedLoci, cwdSource, relDnaSerFile, donorCheckVersion, lastRunDate,
-          lastPassingResult);
+      return new ValidationTestFileSet(id, comment, expectedResult, filePaths, remapFile, remappedLoci, cwdSource, relDnaSerFile, donorCheckVersion,
+          lastRunDate, lastPassingResult, dcProperties);
     }
 
   }
@@ -134,23 +144,21 @@ public class ValidationTestFileSet {
     return new ValidationTestFileSetBuilder();
   }
 
-  private ValidationTestFileSet(String id, String comment, TEST_EXPECTATION expectedResult,
-      List<String> filePaths, String remapFile, Set<HLALocus> remappedLoci,
-      CommonWellDocumented.SOURCE cwdSource, String relDnaSerFile, String donorCheckVersion,
-      Date lastRunDate, TEST_RESULT lastTestResult) {
+  private ValidationTestFileSet(String id, String comment, TEST_EXPECTATION expectedResult, List<String> filePaths, String remapFile,
+      Set<HLALocus> remappedLoci, CommonWellDocumented.SOURCE cwdSource, String relDnaSerFile, String donorCheckVersion, Date lastRunDate,
+      TEST_RESULT lastTestResult, Map<String, String> dcProps) {
     this.id = new SimpleStringProperty(id);
     this.comment = new SimpleStringProperty(comment);
     this.expectedResult = new SimpleObjectProperty<>(expectedResult);
     this.filePaths = new ReadOnlyListWrapper<>(FXCollections.observableList(filePaths));
-    final ObservableSet<SourceType> observableSet =
-        FXCollections.observableSet(filePaths.stream().map(s -> {
-          try {
-            return SourceType.parseType(new File(s));
-          } catch (IllegalArgumentException e) {
-            // TODO should deal with nulls somehow?
-            return null;
-          }
-        }).collect(Collectors.toSet()));
+    final ObservableSet<SourceType> observableSet = FXCollections.observableSet(filePaths.stream().map(s -> {
+      try {
+        return SourceType.parseType(new File(s));
+      } catch (IllegalArgumentException e) {
+        // TODO should deal with nulls somehow?
+        return null;
+      }
+    }).collect(Collectors.toSet()));
     this.sourceTypes = new ReadOnlySetWrapper<>(observableSet);
     this.remapFile = new ReadOnlyStringWrapper(remapFile);
     this.remappedLoci = new ReadOnlySetWrapper<>(FXCollections.observableSet(remappedLoci));
@@ -159,6 +167,7 @@ public class ValidationTestFileSet {
     this.donorCheckVersion = new SimpleStringProperty(donorCheckVersion);
     this.lastRunDate = new SimpleObjectProperty<>(lastRunDate);
     this.lastTestResult = new SimpleObjectProperty<>(lastTestResult);
+    this.dcProperties = dcProps == null ? new HashMap<>() : dcProps;
   }
 
 }

--- a/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
+++ b/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
@@ -552,7 +552,9 @@ public class ValidationTesting {
     cell0.setCellValue("Last validated on:");
     cell1.setCellValue(format.format(t.lastRunDate.getValue()));
 
-
+    sheet.autoSizeColumn(0);
+    sheet.autoSizeColumn(1);
+    sheet.autoSizeColumn(2);
   }
 
   public static void updateTestResults(Map<ValidationTestFileSet, TestRun> newResults) {

--- a/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
+++ b/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
@@ -33,7 +33,7 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.parser.Parser;
 import org.pankratzlab.unet.deprecated.hla.AntigenDictionary;
-import org.pankratzlab.unet.deprecated.hla.HLAProperties;
+import org.pankratzlab.unet.deprecated.hla.DonorCheckProperties;
 import org.pankratzlab.unet.deprecated.hla.Info;
 import org.pankratzlab.unet.deprecated.hla.SourceType;
 import org.pankratzlab.unet.deprecated.jfx.JFXUtilHelper;
@@ -66,9 +66,9 @@ public class ValidationTesting {
   private static final String TEST_PROPERTIES = "test.properties";
   private static final String TEST_LOG = "test.log";
 
-  public static final String REL_DIRECTORY = Info.HLA_HOME + "rel_dna_ser_files/";
+  public static final String REL_DIRECTORY = Info.DONOR_CHECK_HOME + "rel_dna_ser_files/";
   public static final String VALIDATION_DIRECTORY =
-      new File(Info.HLA_HOME + "validation/").getAbsolutePath() + File.separator;
+      new File(Info.DONOR_CHECK_HOME + "validation/").getAbsolutePath() + File.separator;
 
   private static final String CWD_PROP = "cwd";
   private static final String REL = "rel";
@@ -141,7 +141,7 @@ public class ValidationTesting {
       relDirFile.mkdir();
     }
 
-    String relDnaSerFile = HLAProperties.get().getProperty(AntigenDictionary.REL_DNA_SER_PROP);
+    String relDnaSerFile = DonorCheckProperties.get().getProperty(AntigenDictionary.REL_DNA_SER_PROP);
     String newRelFileName;
     String newRelDnaSerFile;
     if (!Strings.isNullOrEmpty(relDnaSerFile) && new File(relDnaSerFile).exists()) {
@@ -462,7 +462,7 @@ public class ValidationTesting {
 
   private static TestRun runTest(ValidationTestFileSet test) {
     SOURCE current = CommonWellDocumented.loadPropertyCWDSource();
-    String currentRel = HLAProperties.get().getProperty(AntigenDictionary.REL_DNA_SER_PROP);
+    String currentRel = DonorCheckProperties.get().getProperty(AntigenDictionary.REL_DNA_SER_PROP);
 
     SOURCE source = test.cwdSource.get();
     String rel = test.relDnaSerFile.get();
@@ -474,7 +474,7 @@ public class ValidationTesting {
       changedCWID = true;
     }
     if (!new File(currentRel).equals(new File(rel))) {
-      HLAProperties.get().setProperty(AntigenDictionary.REL_DNA_SER_PROP, rel);
+      DonorCheckProperties.get().setProperty(AntigenDictionary.REL_DNA_SER_PROP, rel);
       AntigenDictionary.clearCache();
       changedRel = true;
     }
@@ -493,7 +493,7 @@ public class ValidationTesting {
       CommonWellDocumented.loadCIWDVersion(current);
     }
     if (changedRel) {
-      HLAProperties.get().setProperty(AntigenDictionary.REL_DNA_SER_PROP, currentRel);
+      DonorCheckProperties.get().setProperty(AntigenDictionary.REL_DNA_SER_PROP, currentRel);
       AntigenDictionary.clearCache();
     }
 

--- a/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
+++ b/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
@@ -98,7 +98,7 @@ public class ValidationTesting {
   private static final String DC_VER_PROP = "version";
   private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
-  private static final String EXPECTED_PASS = "Expected Pass";
+  private static final String EXPECTED_PASS = "Expected pass";
   private static final String EXPECTED_FAILURE = "Expected failure";
   private static final String UNEXPECTED_PASS = "Unexpected pass";
   private static final String UNEXPECTED_FAILURE = "Unexpected failure";
@@ -474,7 +474,11 @@ public class ValidationTesting {
     sheet.createRow(rowNum++);
     XSSFRow row = sheet.createRow(rowNum++);
     XSSFCell cell0 = row.createCell(0);
-    cell0.setCellValue(result.isPassing ? "Validation Succeeded" : "Validation Failed");
+    if (e != null) {
+      cell0.setCellValue("Validation could not be attempted due to the following error: " + convert(result.name()));
+    } else {
+      cell0.setCellValue(result.isPassing ? "Validation Succeeded" : "Validation Failed");
+    }
 
     sheet.autoSizeColumn(0);
     sheet.autoSizeColumn(1);

--- a/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
+++ b/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
@@ -374,10 +374,12 @@ public class ValidationTesting {
     // Write the output
     try (OutputStream output = new BufferedOutputStream(new FileOutputStream(fileOut)); XSSFWorkbook wb = new XSSFWorkbook();) {
 
+      int index = 0;
       for (ValidationTestFileSet t : tests) {
+        index++;
         TableData data = dataResults.get(t);
         Exception e = exceptionTests.get(t);
-        writeSheet(config, wb, t, data, e);
+        writeSheet(index, config, wb, t, data, e);
       }
 
       wb.write(output);
@@ -391,8 +393,8 @@ public class ValidationTesting {
 
   }
 
-  private static void writeSheet(OutputConfig config, XSSFWorkbook wb, ValidationTestFileSet t, TableData data, Exception e) {
-    XSSFSheet sheet = wb.createSheet(t.id.get());
+  private static void writeSheet(int donorIndex, OutputConfig config, XSSFWorkbook wb, ValidationTestFileSet t, TableData data, Exception e) {
+    XSSFSheet sheet = wb.createSheet(!config.includeID() || config.maskID() ? "Donor_" + donorIndex : t.id.get());
     int rowNum = 0;
 
     // TODO create header row?

--- a/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
+++ b/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
@@ -781,7 +781,12 @@ public class ValidationTesting {
       } else if (testFile.getName().equals(TEST_LOG)) {
         // skip
       } else {
-        inputFilesBuilder.add(testFile.getAbsolutePath());
+        try {
+          SourceType.parseType(testFile);
+          inputFilesBuilder.add(testFile.getAbsolutePath());
+        } catch (IllegalArgumentException e) {
+          // not a valid source file
+        }
       }
     }
     builder.filePaths(inputFilesBuilder.build());

--- a/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
+++ b/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
@@ -480,10 +480,6 @@ public class ValidationTesting {
       cell0.setCellValue(result.isPassing ? "Validation Succeeded" : "Validation Failed");
     }
 
-    sheet.autoSizeColumn(0);
-    sheet.autoSizeColumn(1);
-    sheet.autoSizeColumn(2);
-
     if (data != null && !data.isEmpty()) {
       sheet.createRow(rowNum++);
 
@@ -604,6 +600,10 @@ public class ValidationTesting {
       }
     }
 
+    sheet.setColumnWidth(0, 24 * 256);
+    sheet.setColumnWidth(1, 21 * 256);
+    sheet.setColumnWidth(2, 21 * 256);
+    sheet.setColumnWidth(3, 12 * 256);
 
   }
 

--- a/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
+++ b/src/main/java/org/pankratzlab/unet/validation/ValidationTesting.java
@@ -91,7 +91,9 @@ public class ValidationTesting {
         .collect(Collectors.toList());
   }
 
-  public static boolean addToValidationSet(TestInfo file1, TestInfo file2) {
+  public static boolean addToValidationSet(TestInfo file11, TestInfo file21) {
+    TestInfo file1 = file11;
+    TestInfo file2 = file21;
     // Tests can only be added from the validation results screen, which
     // means that we know the test set has exactly two files, and therefore
     // we don't have to check that the ID's match (if they don't match, the result
@@ -105,12 +107,19 @@ public class ValidationTesting {
     String reldir = REL_DIRECTORY;
     String subdir = getTestDirectory(file1.label);
 
-    final File testDir = new File(subdir);
+    File testDir = new File(subdir);
 
     // first check if test already exists
     if (testDir.exists()) {
-      AlertHelper.showMessage_TestAlreadyExists(file1, subdir);
-      return false;
+      Optional<String> newLbl = AlertHelper.showMessage_TestAlreadyExists(file1, subdir);
+      if (newLbl.isEmpty()) {
+        return false;
+      } else {
+        file1 = new TestInfo(newLbl.get(), file1.file, file1.remappings, file1.sourceType);
+        file2 = new TestInfo(newLbl.get(), file2.file, file2.remappings, file2.sourceType);
+        subdir = getTestDirectory(file1.label);
+        testDir = new File(subdir);
+      }
     }
 
     // show dialog with warning about avoiding PII

--- a/src/main/resources/TypeValidationLanding.fxml
+++ b/src/main/resources/TypeValidationLanding.fxml
@@ -170,6 +170,7 @@
               <menus>
                 <Menu mnemonicParsing="false" text="File">
                   <items>
+                    <MenuItem mnemonicParsing="false" onAction="#editPreferences" text="Preferences" />
                     <MenuItem mnemonicParsing="false" onAction="#fileQuitAction" text="Quit" />
                   </items>
                 </Menu>

--- a/src/main/resources/ValidationResults.fxml
+++ b/src/main/resources/ValidationResults.fxml
@@ -31,12 +31,12 @@
 						<Menu mnemonicParsing="false" text="File">
 							<items>
 								<MenuItem fx:id="saveOption" mnemonicParsing="false"
-									onAction="#savePNGResults" text="Save to Image" />
+									onAction="#savePNGResults" text="Save to image" />
 								<MenuItem fx:id="saveCSVOption" mnemonicParsing="false"
 									onAction="#saveCSVResults" text="Save to CSV" />
 								<MenuItem fx:id="addToValidationOption"
 									mnemonicParsing="false" onAction="#addInputsToValidationSet"
-									text="Add Input Files to Testing Suite" />
+									text="Add input files to testing suite" />
 								<MenuItem fx:id="printOption" mnemonicParsing="false"
 									onAction="#printResults" text="Print..." />
 							</items>

--- a/src/main/resources/ValidationResults.fxml
+++ b/src/main/resources/ValidationResults.fxml
@@ -13,10 +13,12 @@
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
+<?import javafx.scene.text.Text?>
 <?import org.pankratzlab.unet.jfx.wizard.ValidatingWizardPane?>
 <?import javafx.scene.layout.StackPane?>
 
@@ -101,12 +103,17 @@
 								<Insets top="15.0" />
 							</VBox.margin>
 						</Label>
-						<Label fx:id="auditLog" minWidth="200" wrapText="false"
-							focusTraversable="false" GridPane.columnIndex="0"
+						<ScrollPane fitToHeight="true" fitToWidth="true" prefHeight="200.0" prefWidth="200.0" GridPane.columnIndex="0"
 							GridPane.rowIndex="2" GridPane.columnSpan="1"
 							GridPane.halignment="CENTER" GridPane.valignment="TOP"
-							GridPane.fillHeight="true" GridPane.vgrow="ALWAYS"
-							VBox.vgrow="ALWAYS" />
+							GridPane.fillHeight="true" GridPane.vgrow="ALWAYS" VBox.vgrow="ALWAYS">
+						<Text fx:id="auditLog" 
+							focusTraversable="false" 
+							VBox.vgrow="ALWAYS" /><!-- minWidth="200" GridPane.columnIndex="0" wrapText="false"
+							GridPane.rowIndex="2" GridPane.columnSpan="1"
+							GridPane.halignment="CENTER" GridPane.valignment="TOP"
+							GridPane.fillHeight="true" GridPane.vgrow="ALWAYS" -->
+						</ScrollPane>
 					</children>
 				</GridPane>
 				<GridPane GridPane.fillHeight="true"

--- a/src/main/resources/ValidationTestMgmt.fxml
+++ b/src/main/resources/ValidationTestMgmt.fxml
@@ -27,10 +27,12 @@
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.control.TableColumn?>
 <?import javafx.scene.control.TableView?>
-<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox prefHeight="600.0" prefWidth="1200.0" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
+<VBox fx:id="rootPane" prefHeight="600.0" prefWidth="1210.0" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
 	<children>
 		<ScrollPane fitToHeight="true" fitToWidth="true" prefHeight="200.0" prefWidth="200.0" VBox.vgrow="ALWAYS">
 			<content>
@@ -49,17 +51,29 @@
 				</TableView>
 			</content>
 		</ScrollPane>
-		<HBox alignment="CENTER" spacing="10.0">
-			<VBox.margin>
-				<Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-			</VBox.margin>
-			<children>
-            	<Button fx:id="openDirectoryButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#openTestDirectory" prefWidth="150.0" text="Open directory" />
-            	<Button fx:id="openTestButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#openSelectedTest" prefWidth="150.0" text="Open test" />
-           		<Button fx:id="removeSelectedButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#removeSelected" prefWidth="150.0" text="Remove selected test(s)" />
-				<Button fx:id="runSelectedButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#runSelected" prefWidth="150.0" text="Run selected test(s)" />
-				<Button fx:id="runAllButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#runAll" prefWidth="150.0" text="Run all tests" />
-			</children>
-		</HBox>
+      <GridPane hgap="10.0">
+         <VBox.margin>
+            <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+         </VBox.margin>
+         <columnConstraints>
+            <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" />
+            <ColumnConstraints hgrow="NEVER" minWidth="10.0" />
+            <ColumnConstraints hgrow="NEVER" minWidth="10.0" />
+            <ColumnConstraints hgrow="NEVER" minWidth="10.0" />
+            <ColumnConstraints hgrow="NEVER" minWidth="10.0" />
+            <ColumnConstraints hgrow="NEVER" minWidth="10.0" />
+            <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" />
+         </columnConstraints>
+         <rowConstraints>
+            <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
+         </rowConstraints>
+         <children>
+            	<Button fx:id="openDirectoryButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#openTestDirectory" prefWidth="150.0" text="Open directory" GridPane.columnIndex="1" />
+            	<Button fx:id="openTestButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#openSelectedTest" prefWidth="150.0" text="Open test" GridPane.columnIndex="2" />
+           		<Button fx:id="removeSelectedButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#removeSelected" prefWidth="150.0" text="Remove selected test(s)" GridPane.columnIndex="3" />
+				<Button fx:id="runSelectedButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#runSelected" prefWidth="150.0" text="Run selected test(s)" GridPane.columnIndex="4" />
+				<Button fx:id="runAllButton" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#runAll" prefWidth="150.0" text="Run all tests" GridPane.columnIndex="5" />
+         </children>
+      </GridPane>
 	</children>
 </VBox>

--- a/src/main/resources/csvConfig.fxml
+++ b/src/main/resources/csvConfig.fxml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.RowConstraints?>
+
+<GridPane hgap="10.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="94.0" prefWidth="538.0" xmlns:fx="http://javafx.com/fxml/1" xmlns="http://javafx.com/javafx/21">
+  <columnConstraints>
+    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+    <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" prefWidth="100.0" />
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+  </columnConstraints>
+  <rowConstraints>
+    <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
+    <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
+    <RowConstraints minHeight="0.0" prefHeight="0.0" vgrow="SOMETIMES" />
+  </rowConstraints>
+   <children>
+      <TextField fx:id="outputFileField" GridPane.columnIndex="1" />
+      <Label text="Output File:" GridPane.halignment="RIGHT" />
+      <Button fx:id="selectFileBtn" mnemonicParsing="false" text="Select File" GridPane.columnIndex="2" />
+      <CheckBox fx:id="includeIDs" mnemonicParsing="false" text="Include Donor IDs" GridPane.columnIndex="1" GridPane.halignment="LEFT" GridPane.rowIndex="1">
+         <GridPane.margin>
+            <Insets left="20.0" />
+         </GridPane.margin>
+      </CheckBox>
+      <CheckBox fx:id="maskIDs" mnemonicParsing="false" text="Mask Donor IDs" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="1">
+         <GridPane.margin>
+            <Insets right="20.0" />
+         </GridPane.margin>
+      </CheckBox>
+   </children>
+   <padding>
+      <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+   </padding>
+</GridPane>

--- a/src/main/resources/csvConfig.fxml
+++ b/src/main/resources/csvConfig.fxml
@@ -22,14 +22,14 @@
   </rowConstraints>
    <children>
       <TextField fx:id="outputFileField" GridPane.columnIndex="1" />
-      <Label text="Output File:" GridPane.halignment="RIGHT" />
-      <Button fx:id="selectFileBtn" mnemonicParsing="false" text="Select File" GridPane.columnIndex="2" />
-      <CheckBox fx:id="includeIDs" mnemonicParsing="false" text="Include Donor IDs" GridPane.columnIndex="1" GridPane.halignment="LEFT" GridPane.rowIndex="1">
+      <Label text="Output file:" GridPane.halignment="RIGHT" />
+      <Button fx:id="selectFileBtn" mnemonicParsing="false" text="Select file" GridPane.columnIndex="2" />
+      <CheckBox fx:id="includeIDs" mnemonicParsing="false" text="Include donor ids" GridPane.columnIndex="1" GridPane.halignment="LEFT" GridPane.rowIndex="1">
          <GridPane.margin>
             <Insets left="20.0" />
          </GridPane.margin>
       </CheckBox>
-      <CheckBox fx:id="maskIDs" mnemonicParsing="false" text="Mask Donor IDs" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="1">
+      <CheckBox fx:id="maskIDs" mnemonicParsing="false" text="Mask donor ids" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="1">
          <GridPane.margin>
             <Insets right="20.0" />
          </GridPane.margin>

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -1,1 +1,1 @@
-version = 1.2.5
+version = 1.2.6

--- a/src/test/java/org/pankratzlab/unet/integration/PdfSureTyperParserTest.java
+++ b/src/test/java/org/pankratzlab/unet/integration/PdfSureTyperParserTest.java
@@ -1,9 +1,11 @@
 package org.pankratzlab.unet.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.stream.Stream;
+
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.junit.jupiter.api.BeforeAll;
@@ -20,6 +22,7 @@ import org.pankratzlab.unet.hapstats.RaceGroup;
 import org.pankratzlab.unet.model.ValidationModel;
 import org.pankratzlab.unet.model.ValidationModelBuilder;
 import org.pankratzlab.unet.parser.util.PdfSureTyperParser;
+
 import com.google.common.collect.SetMultimap;
 
 public class PdfSureTyperParserTest {
@@ -46,10 +49,19 @@ public class PdfSureTyperParserTest {
   // create parameters to be used as CSV source for checking Donor ID parsing
   @DisplayName("Donor ID parsing")
   @ParameterizedTest(name = "{0}")
-  @CsvSource({Test_File1 + ", AFJQ146", Test_File2 + ", AFLE337", Test_File3 + ", AFK3449",
-      Test_File4 + ", AFK3166", Test_File5 + ", AGEZ412", Test_File6 + ", AGD4110",
-      Test_File7 + ", AGDX065", Test_File8 + ", AGEA128", Test_File9 + ", SABR",
-      Test_File10 + ", AGID359", Test_File11 + ", AGJG190"})
+  @CsvSource({
+    Test_File1 + ", AFJQ146",
+    Test_File2 + ", AFLE337",
+    Test_File3 + ", AFK3449",
+    Test_File4 + ", AFK3166",
+    Test_File5 + ", AGEZ412",
+    Test_File6 + ", AGD4110",
+    Test_File7 + ", AGDX065",
+    Test_File8 + ", AGEA128",
+    Test_File9 + ", SABR",
+    Test_File10 + ", AGID359",
+    Test_File11 + ", AGJG190"
+  })
   /**
    * @param fileName String file name for test file being passed to createModel
    * @param donorId expected Donor ID for each respective donor file
@@ -61,32 +73,94 @@ public class PdfSureTyperParserTest {
   // create the parameters to be used as a method source for the allele parser to run through
   private static Stream<Arguments> testGetABC() {
     return Stream.of(
-        Arguments.of(Test_File1, new SeroType("A", 30), new SeroType("A", 36),
-            new SeroType("B", 07), new SeroType("B", 49), new SeroType("C", 07), null),
-        Arguments.of(Test_File2, new SeroType("A", 2), new SeroType("A", 33), new SeroType("B", 45),
-            new SeroType("B", 53), new SeroType("C", 04), new SeroType("C", 16)),
-        Arguments.of(Test_File3, new SeroType("A", 2), new SeroType("A", 3), new SeroType("B", 57),
-            new SeroType("B", 65), new SeroType("C", 06), new SeroType("C", 8)),
-        Arguments.of(Test_File4, new SeroType("A", 3), new SeroType("A", 24), new SeroType("B", 27),
-            new SeroType("B", 35), new SeroType("C", 02), new SeroType("C", 04)),
-        Arguments.of(Test_File5, new SeroType("A", 2), new SeroType("A", 24), new SeroType("B", 18),
-            new SeroType("B", 35), new SeroType("C", 04), new SeroType("C", 07)),
-        Arguments.of(Test_File6, new SeroType("A", 02), new SeroType("A", 29),
-            new SeroType("B", 57), new SeroType("B", 58), new SeroType("C", 06),
+        Arguments.of(
+            Test_File1,
+            new SeroType("A", 30),
+            new SeroType("A", 36),
+            new SeroType("B", 07),
+            new SeroType("B", 49),
+            new SeroType("C", 07),
+            null),
+        Arguments.of(
+            Test_File2,
+            new SeroType("A", 2),
+            new SeroType("A", 33),
+            new SeroType("B", 45),
+            new SeroType("B", 53),
+            new SeroType("C", 04),
+            new SeroType("C", 16)),
+        Arguments.of(
+            Test_File3,
+            new SeroType("A", 2),
+            new SeroType("A", 3),
+            new SeroType("B", 57),
+            new SeroType("B", 65),
+            new SeroType("C", 06),
+            new SeroType("C", 8)),
+        Arguments.of(
+            Test_File4,
+            new SeroType("A", 3),
+            new SeroType("A", 24),
+            new SeroType("B", 27),
+            new SeroType("B", 35),
+            new SeroType("C", 02),
+            new SeroType("C", 04)),
+        Arguments.of(
+            Test_File5,
+            new SeroType("A", 2),
+            new SeroType("A", 24),
+            new SeroType("B", 18),
+            new SeroType("B", 35),
+            new SeroType("C", 04),
             new SeroType("C", 07)),
-        Arguments.of(Test_File7, new SeroType("A", 02), new SeroType("A", 24),
-            new SeroType("B", 62), new SeroType("B", 72), new SeroType("C", 02),
+        Arguments.of(
+            Test_File6,
+            new SeroType("A", 02),
+            new SeroType("A", 29),
+            new SeroType("B", 57),
+            new SeroType("B", 58),
+            new SeroType("C", 06),
+            new SeroType("C", 07)),
+        Arguments.of(
+            Test_File7,
+            new SeroType("A", 02),
+            new SeroType("A", 24),
+            new SeroType("B", 62),
+            new SeroType("B", 72),
+            new SeroType("C", 02),
             new SeroType("C", 9)),
-        Arguments.of(Test_File8, new SeroType("A", 02), new SeroType("A", 68),
-            new SeroType("B", 44), new SeroType("B", 65), new SeroType("C", 5),
+        Arguments.of(
+            Test_File8,
+            new SeroType("A", 02),
+            new SeroType("A", 68),
+            new SeroType("B", 44),
+            new SeroType("B", 65),
+            new SeroType("C", 5),
             new SeroType("C", 8)),
-        Arguments.of(Test_File9, new SeroType("A", 23), new SeroType("A", 33),
-            new SeroType("B", 45), new SeroType("B", 65), new SeroType("C", 6),
+        Arguments.of(
+            Test_File9,
+            new SeroType("A", 23),
+            new SeroType("A", 33),
+            new SeroType("B", 45),
+            new SeroType("B", 65),
+            new SeroType("C", 6),
             new SeroType("C", 8)),
-        Arguments.of(Test_File10, new SeroType("A", 1), new SeroType("A", 31), new SeroType("B", 8),
-            new SeroType("B", 60), new SeroType("C", 7), new SeroType("C", 10)),
-        Arguments.of(Test_File11, new SeroType("A", 1), new SeroType("A", 3), new SeroType("B", 7),
-            new SeroType("B", 8), new SeroType("C", 7), null));
+        Arguments.of(
+            Test_File10,
+            new SeroType("A", 1),
+            new SeroType("A", 31),
+            new SeroType("B", 8),
+            new SeroType("B", 60),
+            new SeroType("C", 7),
+            new SeroType("C", 10)),
+        Arguments.of(
+            Test_File11,
+            new SeroType("A", 1),
+            new SeroType("A", 3),
+            new SeroType("B", 7),
+            new SeroType("B", 8),
+            new SeroType("C", 7),
+            null));
   }
 
   /**
@@ -101,8 +175,14 @@ public class PdfSureTyperParserTest {
   @DisplayName("Allele A, B and C parsing")
   @ParameterizedTest(name = "{0}")
   @MethodSource("testGetABC")
-  public void PdfSureTyperTest_getABC(String fileName, SeroType A1, SeroType A2, SeroType B1,
-      SeroType B2, SeroType C1, SeroType C2) {
+  public void PdfSureTyperTest_getABC(
+      String fileName,
+      SeroType A1,
+      SeroType A2,
+      SeroType B1,
+      SeroType B2,
+      SeroType C1,
+      SeroType C2) {
     ValidationModel model = createModel(fileName);
     assertEquals(A1, model.getA1());
     assertEquals(A2, model.getA2());
@@ -115,12 +195,19 @@ public class PdfSureTyperParserTest {
   // create parameters to be used as CSV source for checking Bw4 and Bw6 parsing
   @DisplayName("Bw4 and Bw6 parsing")
   @ParameterizedTest(name = "{0}")
-  @CsvSource({Test_File1 + ", Positive, Positive", Test_File2 + ", Positive, Positive",
-      Test_File3 + ", Positive, Positive", Test_File4 + ", Negative, Positive",
-      Test_File5 + ", Negative, Positive", Test_File6 + ", Positive, Negative",
-      Test_File7 + ", Negative, Positive", Test_File8 + ", Positive, Positive",
-      Test_File9 + ", Negative, Positive", Test_File10 + ", Negative, Positive",
-      Test_File11 + ", Negative, Positive"})
+  @CsvSource({
+    Test_File1 + ", Positive, Positive",
+    Test_File2 + ", Positive, Positive",
+    Test_File3 + ", Positive, Positive",
+    Test_File4 + ", Negative, Positive",
+    Test_File5 + ", Negative, Positive",
+    Test_File6 + ", Positive, Negative",
+    Test_File7 + ", Negative, Positive",
+    Test_File8 + ", Positive, Positive",
+    Test_File9 + ", Negative, Positive",
+    Test_File10 + ", Negative, Positive",
+    Test_File11 + ", Negative, Positive"
+  })
   /**
    * @param fileName String file name for test file being passed to createModel
    * @param Bw4Result expected Bw4 result(Positive or Negative)
@@ -134,24 +221,25 @@ public class PdfSureTyperParserTest {
 
   // create parameters to be used as a method source for checking the DRB345 parser
   private static Stream<Arguments> testGetDRB() {
-    return Stream.of(Arguments.of(Test_File1, null, null, new HLAType("DRB3", 2), null, null, null),
-        Arguments
-            .of(Test_File2, new HLAType("DRB5", 1), null, new HLAType("DRB3", 2), null, null, null),
+    return Stream.of(
+        Arguments.of(Test_File1, null, null, new HLAType("DRB3", 2), null, null, null),
+        Arguments.of(
+            Test_File2, new HLAType("DRB5", 1), null, new HLAType("DRB3", 2), null, null, null),
         Arguments.of(Test_File3, null, null, new HLAType("DRB3", 3), null, null, null),
-        Arguments.of(Test_File4, null, null, null, null, new HLAType("DRB4", 1),
-            new HLAType("DRB4", 1)),
+        Arguments.of(
+            Test_File4, null, null, null, null, new HLAType("DRB4", 1), new HLAType("DRB4", 1)),
         Arguments.of(Test_File5, null, null, null, null, new HLAType("DRB4", 1), null),
         Arguments.of(Test_File6, null, null, null, null, null, null),
-        Arguments.of(Test_File7, null, null, new HLAType("DRB3", 1), new HLAType("DRB3", 3), null,
-            null),
-        Arguments.of(Test_File8, null, null, new HLAType("DRB3", 2), null, new HLAType("DRB4", 1),
-            null),
-        Arguments.of(Test_File9, null, null, new HLAType("DRB3", 2), null, new HLAType("DRB4", 1),
-            null),
-        Arguments.of(Test_File10, null, null, new HLAType("DRB3", 2), null, new HLAType("DRB4", 1),
-            null),
-        Arguments.of(Test_File11, null, null, new HLAType("DRB3", 1), new HLAType("DRB3", 1), null,
-            null));
+        Arguments.of(
+            Test_File7, null, null, new HLAType("DRB3", 1), new HLAType("DRB3", 3), null, null),
+        Arguments.of(
+            Test_File8, null, null, new HLAType("DRB3", 2), null, new HLAType("DRB4", 1), null),
+        Arguments.of(
+            Test_File9, null, null, new HLAType("DRB3", 2), null, new HLAType("DRB4", 1), null),
+        Arguments.of(
+            Test_File10, null, null, new HLAType("DRB3", 2), null, new HLAType("DRB4", 1), null),
+        Arguments.of(
+            Test_File11, null, null, new HLAType("DRB3", 1), new HLAType("DRB3", 1), null, null));
   }
 
   /**
@@ -166,8 +254,14 @@ public class PdfSureTyperParserTest {
   @DisplayName("DRB345 parsing")
   @ParameterizedTest(name = "{0}")
   @MethodSource("testGetDRB")
-  public void PdfSureTyperTest_getDRB(String fileName, HLAType DR51_1, HLAType DR51_2,
-      HLAType DR52_1, HLAType DR52_2, HLAType DR53_1, HLAType DR53_2) {
+  public void PdfSureTyperTest_getDRB(
+      String fileName,
+      HLAType DR51_1,
+      HLAType DR51_2,
+      HLAType DR52_1,
+      HLAType DR52_2,
+      HLAType DR53_1,
+      HLAType DR53_2) {
     ValidationModel model = createModel(fileName);
     assertEquals(DR51_1, model.getDR51_1());
     assertEquals(DR51_2, model.getDR51_2());
@@ -180,41 +274,53 @@ public class PdfSureTyperParserTest {
   // create the parameters to be used as a method source for the haplotype allele parser to run
   // through
   private static Stream<Arguments> testHaplotype() {
-    return Stream.of(Arguments.of(Test_File1,
-        "\n\tCAU\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\n\tAFA\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\n\tAPI\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\n\tHIS\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\n\tNAM\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tAFA\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tAPI\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tHIS\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tNAM\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]"),
-        Arguments.of(Test_File2,
+    return Stream.of(
+        Arguments.of(
+            Test_File1,
+            "\n\tCAU\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\n\tAFA\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\n\tAPI\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\n\tHIS\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\n\tNAM\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tAFA\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tAPI\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tHIS\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tNAM\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]"),
+        Arguments.of(
+            Test_File2,
             "\n\tCAU\n\tHaplotype [types=[B*45:01:01, C*16:01:01]]\n\tHaplotype [types=[B*53:01:01, C*04:01:01]]\n\tAFA\n\tHaplotype [types=[B*45:01:01, C*16:01:01]]\n\tHaplotype [types=[B*53:01:01, C*04:01:01]]\n\tAPI\n\tHaplotype [types=[B*45:01:01, C*16:01:01]]\n\tHaplotype [types=[B*53:01:01, C*04:01:01]]\n\tHIS\n\tHaplotype [types=[B*45:01:01, C*16:01:01]]\n\tHaplotype [types=[B*53:01:01, C*04:01:01]]\n\tNAM\n\tHaplotype [types=[B*45:01:01, C*16:01:01]]\n\tHaplotype [types=[B*53:01:01, C*04:01:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*03:01:01, DRB3*01:01:02, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*15:01:01, DRB5*01:01:01, DQB1*06:02:01]]\n\tAFA\n\tHaplotype [types=[DRB1*03:01:01, DRB3*02:02:01, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*15:03:01, DRB5*01:01:01, DQB1*06:02:01]]\n\tAPI\n\tHaplotype [types=[DRB1*03:01:01, DRB3*02:02:01, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*15:01:01, DRB5*01:01:01, DQB1*06:02:01]]\n\tHIS\n\tHaplotype [types=[DRB1*03:01:01, DRB3*02:02:01, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*15:01:01, DRB5*01:01:01, DQB1*06:02:01]]\n\tNAM\n\tHaplotype [types=[DRB1*03:01:01, DRB3*01:01:02, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*15:01:01, DRB5*01:01:01, DQB1*06:02:01]]"),
-        Arguments.of(Test_File3,
+        Arguments.of(
+            Test_File3,
             "\n\tCAU\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tAFA\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tAPI\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tHIS\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tNAM\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:04:01]]\n\tAFA\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:09:01]]\n\tAPI\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:04:01]]\n\tHIS\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:04:01]]\n\tNAM\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:04:01]]"),
-        Arguments.of(Test_File4,
+        Arguments.of(
+            Test_File4,
             "\n\tCAU\n\tHaplotype [types=[B*27:08, C*02:10:01]]\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\n\tAFA\n\tHaplotype [types=[B*27:08, C*02:10:01]]\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\n\tAPI\n\tHaplotype [types=[B*27:08, C*02:10:01]]\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\n\tHIS\n\tHaplotype [types=[B*27:08, C*02:10:01]]\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\n\tNAM\n\tHaplotype [types=[B*27:08, C*02:10:01]]\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*04:01:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]\n\tAFA\n\tHaplotype [types=[DRB1*04:05:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]\n\tAPI\n\tHaplotype [types=[DRB1*04:03:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]\n\tHIS\n\tHaplotype [types=[DRB1*04:07:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]\n\tNAM\n\tHaplotype [types=[DRB1*04:04:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]"),
-        Arguments.of(Test_File5,
+        Arguments.of(
+            Test_File5,
             "\n\tCAU\n\tHaplotype [types=[B*18:01:01, C*07:01:01]]\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\n\tAFA\n\tHaplotype [types=[B*18:01:01, C*07:04:01]]\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\n\tAPI\n\tHaplotype [types=[B*18:01:01, C*07:01:01]]\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\n\tHIS\n\tHaplotype [types=[B*18:01:01, C*07:01:01]]\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\n\tNAM\n\tHaplotype [types=[B*18:01:01, C*07:01:01]]\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*01:01:02, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]\n\tAFA\n\tHaplotype [types=[DRB1*01:02:01, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]\n\tAPI\n\tHaplotype [types=[DRB1*01:01:02, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]\n\tHIS\n\tHaplotype [types=[DRB1*01:01:02, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]\n\tNAM\n\tHaplotype [types=[DRB1*01:01:02, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]"),
-        Arguments.of(Test_File6,
+        Arguments.of(
+            Test_File6,
             "\n\tCAU\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tHaplotype [types=[B*58:01:01, C*07:01:01]]\n\tAFA\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tHaplotype [types=[B*58:01:01, C*07:01:01]]\n\tAPI\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tHaplotype [types=[B*58:01:01, C*07:01:01]]\n\tHIS\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tHaplotype [types=[B*58:01:01, C*07:01:01]]\n\tNAM\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tHaplotype [types=[B*58:01:01, C*07:01:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*04:02:01]]\n\tAFA\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*04:02:01]]\n\tAPI\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*08:02, DRB3*00:00N, DQB1*04:02:01]]\n\tHIS\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*08:02, DRB3*00:00N, DQB1*04:02:01]]\n\tNAM\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*04:02:01]]"),
-        Arguments.of(Test_File7,
+        Arguments.of(
+            Test_File7,
             "\n\tCAU\n\tHaplotype [types=[B*15:01:01, C*03:03:04]]\n\tHaplotype [types=[B*15:03:01, C*02:02:02]]\n\tAFA\n\tHaplotype [types=[B*15:01:01, C*03:03:04]]\n\tHaplotype [types=[B*15:03:01, C*02:02:02]]\n\tAPI\n\tHaplotype [types=[B*15:01:01, C*03:03:04]]\n\tHaplotype [types=[B*15:03:01, C*02:02:02]]\n\tHIS\n\tHaplotype [types=[B*15:01:01, C*03:03:04]]\n\tHaplotype [types=[B*15:03:01, C*02:02:02]]\n\tNAM\n\tHaplotype [types=[B*15:01:01, C*03:03:04]]\n\tHaplotype [types=[B*15:03:01, C*02:02:02]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*13:01:01, DRB3*01:01:02, DQB1*06:03:01]]\n\tHaplotype [types=[DRB1*13:03:01, DRB3*01:01:02, DQB1*03:01:01]]\n\tAFA\n\tHaplotype [types=[DRB1*13:01:01, DRB3*01:01:02, DQB1*06:03:01]]\n\tHaplotype [types=[DRB1*13:03:01, DRB3*01:01:02, DQB1*03:01:01]]\n\tAPI\n\tHaplotype [types=[DRB1*13:01:01, DRB3*01:01:02, DQB1*06:03:01]]\n\tHaplotype [types=[DRB1*13:03:01, DRB3*01:01:02, DQB1*03:01:01]]\n\tHIS\n\tHaplotype [types=[DRB1*13:01:01, DRB3*01:01:02, DQB1*06:03:01]]\n\tHaplotype [types=[DRB1*13:03:01, DRB3*01:01:02, DQB1*03:01:01]]\n\tNAM\n\tHaplotype [types=[DRB1*13:01:01, DRB3*01:01:02, DQB1*06:03:01]]\n\tHaplotype [types=[DRB1*13:03:01, DRB3*01:01:02, DQB1*03:01:01]]"),
-        Arguments.of(Test_File8,
+        Arguments.of(
+            Test_File8,
             "\n\tCAU\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*44:02:01, C*05:01:01]]\n\tAFA\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*44:02:01, C*05:01:01]]\n\tAPI\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*44:02:01, C*05:01:01]]\n\tHIS\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*44:02:01, C*05:01:01]]\n\tNAM\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*44:02:01, C*05:01:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*03:01:01, DRB3*01:01:02, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*04:01:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tAFA\n\tHaplotype [types=[DRB1*03:01:01, DRB3*02:02:01, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*04:05:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tAPI\n\tHaplotype [types=[DRB1*03:01:01, DRB3*02:02:01, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*04:03:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHIS\n\tHaplotype [types=[DRB1*03:01:01, DRB3*02:02:01, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*04:07:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tNAM\n\tHaplotype [types=[DRB1*03:01:01, DRB3*01:01:02, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*04:04:01, DRB4*01:01:01, DQB1*03:02:01]]"),
-        Arguments.of(Test_File9,
+        Arguments.of(
+            Test_File9,
             "\n\tCAU\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*45:01:01, C*06:02:01]]\n\tAFA\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*45:01:01, C*06:02:01]]\n\tAPI\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*45:01:01, C*06:02:01]]\n\tHIS\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*45:01:01, C*06:02:01]]\n\tNAM\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*45:01:01, C*06:02:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*09:01:02, DRB4*01:01:01, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*11:01:02, DRB3*02:02:01, DQB1*06:02:01]]\n\tAFA\n\tHaplotype [types=[DRB1*09:01:02, DRB4*01:01:01, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*11:01:02, DRB3*02:02:01, DQB1*06:02:01]]\n\tAPI\n\tHaplotype [types=[DRB1*09:01:02, DRB4*01:01:01, DQB1*06:02:01]]\n\tHaplotype [types=[DRB1*11:19:01, DRB3*02:02:01, DQB1*02:01:01]]\n\tHIS\n\tHaplotype [types=[DRB1*09:01:02, DRB4*01:01:01, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*11:01:02, DRB3*02:02:01, DQB1*06:02:01]]\n\tNAM\n\tHaplotype [types=[DRB1*09:01:02, DRB4*01:01:01, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*11:01:02, DRB3*02:02:01, DQB1*06:02:01]]"),
-        Arguments.of(Test_File10,
+        Arguments.of(
+            Test_File10,
             "\n\tCAU\n\tHaplotype [types=[B*08:01:01, C*07:01:01]]\n\tHaplotype [types=[B*40:01:01, C*03:04:02]]\n\tAFA\n\tHaplotype [types=[B*08:01:01, C*07:01:01]]\n\tHaplotype [types=[B*40:01:01, C*03:04:02]]\n\tAPI\n\tHaplotype [types=[B*08:01:01, C*07:02:01]]\n\tHaplotype [types=[B*40:01:01, C*03:04:02]]\n\tHIS\n\tHaplotype [types=[B*08:01:01, C*07:01:01]]\n\tHaplotype [types=[B*40:01:01, C*03:04:02]]\n\tNAM\n\tHaplotype [types=[B*08:01:01, C*07:01:01]]\n\tHaplotype [types=[B*40:01:01, C*03:04:02]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*04:01:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*13:01:01, DRB3*01:01:02, DQB1*06:03:01]]\n\tAFA\n\tHaplotype [types=[DRB1*04:05:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*13:01:01, DRB3*01:01:02, DQB1*06:03:01]]\n\tAPI\n\tHaplotype [types=[DRB1*04:03:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*13:01:01, DRB3*01:01:02, DQB1*06:03:01]]\n\tHIS\n\tHaplotype [types=[DRB1*04:07:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*13:01:01, DRB3*01:01:02, DQB1*06:03:01]]\n\tNAM\n\tHaplotype [types=[DRB1*04:04:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*13:01:01, DRB3*01:01:02, DQB1*06:03:01]]"),
-        Arguments.of(Test_File11,
+        Arguments.of(
+            Test_File11,
             "\n\tCAU\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*08:01:01, C*07:01:01]]\n\tAFA\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*08:01:01, C*07:01:01]]\n\tAPI\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*08:01:01, C*07:02:01]]\n\tHIS\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*08:01:01, C*07:01:01]]\n\tNAM\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*08:01:01, C*07:01:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*03:01:01, DRB3*01:01:02, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*03:01:01, DRB3*01:01:02, DQB1*02:01:01]]\n\tAFA\n\tHaplotype [types=[DRB1*03:01:01, DRB3*01:01:02, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*03:01:01, DRB3*01:01:02, DQB1*02:01:01]]\n\tAPI\n\tHaplotype [types=[DRB1*03:01:01, DRB3*01:01:02, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*03:01:01, DRB3*01:01:02, DQB1*02:01:01]]\n\tHIS\n\tHaplotype [types=[DRB1*03:01:01, DRB3*01:01:02, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*03:01:01, DRB3*01:01:02, DQB1*02:01:01]]\n\tNAM\n\tHaplotype [types=[DRB1*03:01:01, DRB3*01:01:02, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*03:01:01, DRB3*01:01:02, DQB1*02:01:01]]"));
   }
 
   /**
    * @param fileName String file name for test file being passed to createModel
-   * @param expectedHaplotype string expected as the output of the string version of
-   *        {@link ValidationModel} when split to just be haplotype section
+   * @param expectedHaplotype string expected as the output of the string version of {@link
+   *     ValidationModel} when split to just be haplotype section
    */
   @DisplayName("Haplotype Alleles parsing")
   @ParameterizedTest(name = "{0}")
   @MethodSource("testHaplotype")
   public void PDFSureTyperParserTest_haplotype(String fileName, String expectedHaplotype) {
     ValidationModel model = createModel(fileName);
-    if (HaplotypeFrequencies.successfullyInitialized()) {
+    if (HaplotypeFrequencies.successfullyInitialized().get()) {
       assertEquals(expectedHaplotype, model.toString().split("B-C Haplotype")[1]);
     } else {
       System.err.println("Error: Frequency files not loaded in");
@@ -225,29 +331,40 @@ public class PdfSureTyperParserTest {
   // through
   // Expected results frequencies in CAU, AFA, API, HIS, NAM order
   private static Stream<Arguments> testBCHaplotypeFrequency() {
-    double[] freq1 =
-        {0.01611, 0.123, 0.02804, 0.05984, 0.00287, 0.02923, 0.02362, 0.05652, 0.01377, 0.09628};
-    double[] freq2 =
-        {0.00072, 0.00363, 0.03735, 0.1079, 0.00041, 0.00079, 0.0092, 0.0153, 0.00285, 0.00804};
-    double[] freq3 =
-        {0.02719, 0.03371, 0.00664, 0.02134, 0.00155, 0.03078, 0.01043, 0.04161, 0.0207, 0.02662};
+    double[] freq1 = {
+      0.01611, 0.123, 0.02804, 0.05984, 0.00287, 0.02923, 0.02362, 0.05652, 0.01377, 0.09628
+    };
+    double[] freq2 = {
+      0.00072, 0.00363, 0.03735, 0.1079, 0.00041, 0.00079, 0.0092, 0.0153, 0.00285, 0.00804
+    };
+    double[] freq3 = {
+      0.02719, 0.03371, 0.00664, 0.02134, 0.00155, 0.03078, 0.01043, 0.04161, 0.0207, 0.02662
+    };
     double[] freq4 = {0, 0.05588, 0, 0.05482, 0, 0.03018, 0, 0.06563, 0, 0.08644};
-    double[] freq5 =
-        {0.01992, 0.05588, 0.00405, 0.05482, 0.00553, 0.03018, 0.00972, 0.06563, 0.01258, 0.08644};
-    double[] freq6 =
-        {0.00522, 0.03371, 0.00664, 0.0234, 0.00009, 0.03078, 0.00906, 0.01043, 0.00429, 0.02662};
-    double[] freq7 =
-        {0.00076, 0.03177, 0.00579, 0.06076, 0.00012, 0.01548, 0.01129, 0.01458, 0.00329, 0.02668};
-    double[] freq8 =
-        {0.02719, 0.07064, 0.0176, 0.02134, 0.00155, 0.00729, 0.0381, 0.04161, 0.0207, 0.06176};
-    double[] freq9 =
-        {0.00459, 0.02719, 0.01064, 0.02134, 0.00064, 0.00155, 0.00796, 0.04161, 0.00413, 0.0207};
-    double[] freq10 =
-        {0.0492, 0.10394, 0.01131, 0.02734, 0.01588, 0.03027, 0.01481, 0.03867, 0.04881, 0.07723};
-    double[] freq11 =
-        {0.123, 0.10394, 0.02734, 0.05984, 0.01588, 0.02923, 0.05652, 0.03867, 0.09628, 0.07723};
+    double[] freq5 = {
+      0.01992, 0.05588, 0.00405, 0.05482, 0.00553, 0.03018, 0.00972, 0.06563, 0.01258, 0.08644
+    };
+    double[] freq6 = {
+      0.00522, 0.03371, 0.00664, 0.0234, 0.00009, 0.03078, 0.00906, 0.01043, 0.00429, 0.02662
+    };
+    double[] freq7 = {
+      0.00076, 0.03177, 0.00579, 0.06076, 0.00012, 0.01548, 0.01129, 0.01458, 0.00329, 0.02668
+    };
+    double[] freq8 = {
+      0.02719, 0.07064, 0.0176, 0.02134, 0.00155, 0.00729, 0.0381, 0.04161, 0.0207, 0.06176
+    };
+    double[] freq9 = {
+      0.00459, 0.02719, 0.01064, 0.02134, 0.00064, 0.00155, 0.00796, 0.04161, 0.00413, 0.0207
+    };
+    double[] freq10 = {
+      0.0492, 0.10394, 0.01131, 0.02734, 0.01588, 0.03027, 0.01481, 0.03867, 0.04881, 0.07723
+    };
+    double[] freq11 = {
+      0.123, 0.10394, 0.02734, 0.05984, 0.01588, 0.02923, 0.05652, 0.03867, 0.09628, 0.07723
+    };
 
-    return Stream.of(Arguments.of(Test_File1, HaplotypeTestingUtils.createTestMultimap(freq1)),
+    return Stream.of(
+        Arguments.of(Test_File1, HaplotypeTestingUtils.createTestMultimap(freq1)),
         Arguments.of(Test_File2, HaplotypeTestingUtils.createTestMultimap(freq2)),
         Arguments.of(Test_File3, HaplotypeTestingUtils.createTestMultimap(freq3)),
         Arguments.of(Test_File4, HaplotypeTestingUtils.createTestMultimap(freq4)),
@@ -263,14 +380,14 @@ public class PdfSureTyperParserTest {
   /**
    * @param fileName String file name for test file being passed to createModel
    * @param expectedBCMultimap a multimap of RaceGroup ethnicities with BigDecimal expected
-   *        frequencies
+   *     frequencies
    */
   @DisplayName("Haplotype BC Frequency parsing")
   @ParameterizedTest(name = "{0}")
   @MethodSource("testBCHaplotypeFrequency")
-  public void PDFSureTyperParserTest_BCHaplotypeFrequency(String fileName,
-      SetMultimap<RaceGroup, BigDecimal> expectedBCMultimap) {
-    if (HaplotypeFrequencies.successfullyInitialized()) {
+  public void PDFSureTyperParserTest_BCHaplotypeFrequency(
+      String fileName, SetMultimap<RaceGroup, BigDecimal> expectedBCMultimap) {
+    if (HaplotypeFrequencies.successfullyInitialized().get()) {
       ValidationModel model = createModel(fileName);
       assertEquals(
           "Difference between generated and expected: {}Difference between expected and generated: {}",
@@ -285,29 +402,40 @@ public class PdfSureTyperParserTest {
   // run through
   // Expected results frequencies in CAU, AFA, API, HIS, NAM order
   private static Stream<Arguments> testDRDQHaplotypeFrequency() {
-    double[] freq1 =
-        {0.00078, 0.00282, 0.03548, 0.05223, 0.00012, 0.00016, 0.00497, 0.01253, 0.00372, 0.00474};
-    double[] freq2 =
-        {0.09431, 0.12689, 0.05172, 0.11672, 0.03514, 0.05492, 0.03637, 0.06023, 0.0707, 0.10037};
-    double[] freq3 =
-        {0.03364, 0.03741, 0.00295, 0.03757, 0.01847, 0.02507, 0.01206, 0.02784, 0.02339, 0.02771};
-    double[] freq4 =
-        {0.04557, 0.09595, 0.01512, 0.09746, 0.03671, 0.07397, 0.06337, 0.09536, 0.04735, 0.07928};
-    double[] freq5 =
-        {0.08444, 0.09595, 0.04014, 0.09746, 0.02642, 0.07397, 0.04482, 0.09536, 0.06747, 0.07928};
-    double[] freq6 =
-        {0.00177, 0.03364, 0.00226, 0.00295, 0.00583, 0.02507, 0.01206, 0.06882, 0.02302, 0.02339};
-    double[] freq7 =
-        {0.01192, 0.03588, 0.01657, 0.0194, 0.00072, 0.02211, 0.0121, 0.0276, 0.00867, 0.024};
-    double[] freq8 =
-        {0.04557, 0.09431, 0.01512, 0.05172, 0.03671, 0.05492, 0.03637, 0.06337, 0.04735, 0.0707};
+    double[] freq1 = {
+      0.00078, 0.00282, 0.03548, 0.05223, 0.00012, 0.00016, 0.00497, 0.01253, 0.00372, 0.00474
+    };
+    double[] freq2 = {
+      0.09431, 0.12689, 0.05172, 0.11672, 0.03514, 0.05492, 0.03637, 0.06023, 0.0707, 0.10037
+    };
+    double[] freq3 = {
+      0.03364, 0.03741, 0.00295, 0.03757, 0.01847, 0.02507, 0.01206, 0.02784, 0.02339, 0.02771
+    };
+    double[] freq4 = {
+      0.04557, 0.09595, 0.01512, 0.09746, 0.03671, 0.07397, 0.06337, 0.09536, 0.04735, 0.07928
+    };
+    double[] freq5 = {
+      0.08444, 0.09595, 0.04014, 0.09746, 0.02642, 0.07397, 0.04482, 0.09536, 0.06747, 0.07928
+    };
+    double[] freq6 = {
+      0.00177, 0.03364, 0.00226, 0.00295, 0.00583, 0.02507, 0.01206, 0.06882, 0.02302, 0.02339
+    };
+    double[] freq7 = {
+      0.01192, 0.03588, 0.01657, 0.0194, 0.00072, 0.02211, 0.0121, 0.0276, 0.00867, 0.024
+    };
+    double[] freq8 = {
+      0.04557, 0.09431, 0.01512, 0.05172, 0.03671, 0.05492, 0.03637, 0.06337, 0.04735, 0.0707
+    };
     double[] freq9 = {0.00001, 0.00039, 0.02864, 0.03893, 0, 0, 0.00259, 0.00534, 0.00112, 0.00125};
-    double[] freq10 =
-        {0.03588, 0.04557, 0.01512, 0.0194, 0.02211, 0.03671, 0.0276, 0.06337, 0.024, 0.04735};
-    double[] freq11 =
-        {.09431, 0.09431, 0.0175, 0.0175, 0.0014, 0.0014, 0.03374, 0.03374, 0.0707, 0.0707};
+    double[] freq10 = {
+      0.03588, 0.04557, 0.01512, 0.0194, 0.02211, 0.03671, 0.0276, 0.06337, 0.024, 0.04735
+    };
+    double[] freq11 = {
+      .09431, 0.09431, 0.0175, 0.0175, 0.0014, 0.0014, 0.03374, 0.03374, 0.0707, 0.0707
+    };
 
-    return Stream.of(Arguments.of(Test_File1, HaplotypeTestingUtils.createTestMultimap(freq1)),
+    return Stream.of(
+        Arguments.of(Test_File1, HaplotypeTestingUtils.createTestMultimap(freq1)),
         Arguments.of(Test_File2, HaplotypeTestingUtils.createTestMultimap(freq2)),
         Arguments.of(Test_File3, HaplotypeTestingUtils.createTestMultimap(freq3)),
         Arguments.of(Test_File4, HaplotypeTestingUtils.createTestMultimap(freq4)),
@@ -323,14 +451,14 @@ public class PdfSureTyperParserTest {
   /**
    * @param fileName String file name for test file being passed to createModel
    * @param expectedDRDQMultimap a multimap of RaceGroup ethnicities with BigDecimal expected
-   *        frequencies
+   *     frequencies
    */
   @DisplayName("Haplotype DRDQ Frequency parsing")
   @ParameterizedTest(name = "{0}")
   @MethodSource("testDRDQHaplotypeFrequency")
-  public void PDFSureTyperParserTest_DRDQHaplotypeFrequency(String fileName,
-      SetMultimap<RaceGroup, BigDecimal> expectedDRDQMultimap) {
-    if (HaplotypeFrequencies.successfullyInitialized()) {
+  public void PDFSureTyperParserTest_DRDQHaplotypeFrequency(
+      String fileName, SetMultimap<RaceGroup, BigDecimal> expectedDRDQMultimap) {
+    if (HaplotypeFrequencies.successfullyInitialized().get()) {
       ValidationModel model = createModel(fileName);
       assertEquals(
           "Difference between generated and expected: {}Difference between expected and generated: {}",

--- a/src/test/java/org/pankratzlab/unet/integration/XMLScore6ParserTest.java
+++ b/src/test/java/org/pankratzlab/unet/integration/XMLScore6ParserTest.java
@@ -1,10 +1,12 @@
 package org.pankratzlab.unet.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.util.stream.Stream;
+
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.BeforeAll;
@@ -21,6 +23,7 @@ import org.pankratzlab.unet.hapstats.RaceGroup;
 import org.pankratzlab.unet.model.ValidationModel;
 import org.pankratzlab.unet.model.ValidationModelBuilder;
 import org.pankratzlab.unet.parser.util.XmlScore6Parser;
+
 import com.google.common.collect.SetMultimap;
 
 public class XMLScore6ParserTest {
@@ -44,9 +47,16 @@ public class XMLScore6ParserTest {
   // create parameters to be used as CSV source for checking Donor ID parsing
   @DisplayName("Donor ID parsing")
   @ParameterizedTest(name = "{0}")
-  @CsvSource({Test_File1 + ", AFJQ146", Test_File2 + ", AFLG047", Test_File3 + ", AFK3387",
-      Test_File4 + ", AFLK097", Test_File5 + ", AGFJ449", Test_File6 + ", AFK3449",
-      Test_File7 + ", AGJS214", Test_File8 + ", AGJF127"})
+  @CsvSource({
+    Test_File1 + ", AFJQ146",
+    Test_File2 + ", AFLG047",
+    Test_File3 + ", AFK3387",
+    Test_File4 + ", AFLK097",
+    Test_File5 + ", AGFJ449",
+    Test_File6 + ", AFK3449",
+    Test_File7 + ", AGJS214",
+    Test_File8 + ", AGJF127"
+  })
   /**
    * @param fileName String file name for test file being passed to createModel
    * @param donorId expected Donor ID for each respective donor file
@@ -58,22 +68,70 @@ public class XMLScore6ParserTest {
   // create the parameters to be used as a method source for the allele parser to run through
   private static Stream<Arguments> testGetABC() {
     return Stream.of(
-        Arguments.of(Test_File1, new SeroType("A", 30), new SeroType("A", 36),
-            new SeroType("B", 07), new SeroType("B", 49), new SeroType("C", 07), null),
-        Arguments.of(Test_File2, new SeroType("A", 3), new SeroType("A", 32), new SeroType("B", 35),
-            new SeroType("B", 61), new SeroType("C", 2), new SeroType("C", 4)),
-        Arguments.of(Test_File3, new SeroType("A", 1), new SeroType("A", 2), new SeroType("B", 27),
-            new SeroType("B", 44), new SeroType("C", 2), null),
-        Arguments.of(Test_File4, new SeroType("A", 2), new SeroType("A", 29), new SeroType("B", 44),
-            new SeroType("B", 51), new SeroType("C", 15), new SeroType("C", 16)),
-        Arguments.of(Test_File5, new SeroType("A", 2), new SeroType("A", 3), new SeroType("B", 44),
-            new SeroType("B", 62), new SeroType("C", 7), new SeroType("C", 9)),
-        Arguments.of(Test_File6, new SeroType("A", 2), new SeroType("A", 3), new SeroType("B", 57),
-            new SeroType("B", 65), new SeroType("C", 6), new SeroType("C", 8)),
-        Arguments.of(Test_File7, new SeroType("A", 1), new SeroType("A", 24), new SeroType("B", 35),
-            new SeroType("B", 57), new SeroType("C", 6), new SeroType("C", 9)),
-        Arguments.of(Test_File8, new SeroType("A", 2), new SeroType("A", 3), new SeroType("B", 44),
-            new SeroType("B", 62), new SeroType("C", 5), new SeroType("C", 9)));
+        Arguments.of(
+            Test_File1,
+            new SeroType("A", 30),
+            new SeroType("A", 36),
+            new SeroType("B", 07),
+            new SeroType("B", 49),
+            new SeroType("C", 07),
+            null),
+        Arguments.of(
+            Test_File2,
+            new SeroType("A", 3),
+            new SeroType("A", 32),
+            new SeroType("B", 35),
+            new SeroType("B", 61),
+            new SeroType("C", 2),
+            new SeroType("C", 4)),
+        Arguments.of(
+            Test_File3,
+            new SeroType("A", 1),
+            new SeroType("A", 2),
+            new SeroType("B", 27),
+            new SeroType("B", 44),
+            new SeroType("C", 2),
+            null),
+        Arguments.of(
+            Test_File4,
+            new SeroType("A", 2),
+            new SeroType("A", 29),
+            new SeroType("B", 44),
+            new SeroType("B", 51),
+            new SeroType("C", 15),
+            new SeroType("C", 16)),
+        Arguments.of(
+            Test_File5,
+            new SeroType("A", 2),
+            new SeroType("A", 3),
+            new SeroType("B", 44),
+            new SeroType("B", 62),
+            new SeroType("C", 7),
+            new SeroType("C", 9)),
+        Arguments.of(
+            Test_File6,
+            new SeroType("A", 2),
+            new SeroType("A", 3),
+            new SeroType("B", 57),
+            new SeroType("B", 65),
+            new SeroType("C", 6),
+            new SeroType("C", 8)),
+        Arguments.of(
+            Test_File7,
+            new SeroType("A", 1),
+            new SeroType("A", 24),
+            new SeroType("B", 35),
+            new SeroType("B", 57),
+            new SeroType("C", 6),
+            new SeroType("C", 9)),
+        Arguments.of(
+            Test_File8,
+            new SeroType("A", 2),
+            new SeroType("A", 3),
+            new SeroType("B", 44),
+            new SeroType("B", 62),
+            new SeroType("C", 5),
+            new SeroType("C", 9)));
   }
 
   /**
@@ -88,8 +146,14 @@ public class XMLScore6ParserTest {
   @DisplayName("Allele A, B and C parsing")
   @ParameterizedTest(name = "{0}")
   @MethodSource("testGetABC")
-  public void XMLScore6ParserTest_getABC(String fileName, SeroType A1, SeroType A2, SeroType B1,
-      SeroType B2, SeroType C1, SeroType C2) {
+  public void XMLScore6ParserTest_getABC(
+      String fileName,
+      SeroType A1,
+      SeroType A2,
+      SeroType B1,
+      SeroType B2,
+      SeroType C1,
+      SeroType C2) {
     ValidationModel model = createModel(fileName);
     assertEquals(A1, model.getA1());
     assertEquals(A2, model.getA2());
@@ -102,10 +166,16 @@ public class XMLScore6ParserTest {
   // create parameters to be used as CSV source for checking Bw4 and Bw6 parsing
   @DisplayName("Bw4 and Bw6 parsing")
   @ParameterizedTest(name = "{0}")
-  @CsvSource({Test_File1 + ", Positive, Positive", Test_File2 + ", Negative, Positive",
-      Test_File3 + ", Positive, Negative", Test_File4 + ", Positive, Negative",
-      Test_File5 + ", Positive, Positive", Test_File6 + ", Positive, Positive",
-      Test_File7 + ", Positive, Positive", Test_File8 + ", Positive, Positive"})
+  @CsvSource({
+    Test_File1 + ", Positive, Positive",
+    Test_File2 + ", Negative, Positive",
+    Test_File3 + ", Positive, Negative",
+    Test_File4 + ", Positive, Negative",
+    Test_File5 + ", Positive, Positive",
+    Test_File6 + ", Positive, Positive",
+    Test_File7 + ", Positive, Positive",
+    Test_File8 + ", Positive, Positive"
+  })
   /**
    * @param fileName String file name for test file being passed to createModel
    * @param Bw4Result expected Bw4 result(Positive or Negative)
@@ -119,16 +189,18 @@ public class XMLScore6ParserTest {
 
   // create parameters to be used as a method source for checking the DRB345 parser
   private static Stream<Arguments> testGetDRB() {
-    return Stream.of(Arguments.of(Test_File1, null, null, new HLAType("DRB3", 2), null, null, null),
+    return Stream.of(
+        Arguments.of(Test_File1, null, null, new HLAType("DRB3", 2), null, null, null),
         Arguments.of(Test_File2, null, null, new HLAType("DRB3", 2), null, null, null),
         Arguments.of(Test_File3, null, null, null, null, null, null),
-        Arguments.of(Test_File4, null, null, null, null, new HLAType("DRB4", 1),
-            new HLAType("DRB4", 1)),
-        Arguments.of(Test_File5, null, null, new HLAType("DRB3", 2), new HLAType("DRB3", 2), null,
-            null),
+        Arguments.of(
+            Test_File4, null, null, null, null, new HLAType("DRB4", 1), new HLAType("DRB4", 1)),
+        Arguments.of(
+            Test_File5, null, null, new HLAType("DRB3", 2), new HLAType("DRB3", 2), null, null),
         Arguments.of(Test_File6, null, null, new HLAType("DRB3", 3), null, null, null),
-        Arguments.of(Test_File7, null, null, null, null, null, null), Arguments.of(Test_File8, null,
-            null, new HLAType("DRB3", 2), null, new HLAType("DRB4", 1), null));
+        Arguments.of(Test_File7, null, null, null, null, null, null),
+        Arguments.of(
+            Test_File8, null, null, new HLAType("DRB3", 2), null, new HLAType("DRB4", 1), null));
   }
 
   /**
@@ -143,8 +215,14 @@ public class XMLScore6ParserTest {
   @DisplayName("DRB345 parsing")
   @ParameterizedTest(name = "{0}")
   @MethodSource("testGetDRB")
-  public void XMLScore6ParserTest_getDRB(String fileName, HLAType DR51_1, HLAType DR51_2,
-      HLAType DR52_1, HLAType DR52_2, HLAType DR53_1, HLAType DR53_2) {
+  public void XMLScore6ParserTest_getDRB(
+      String fileName,
+      HLAType DR51_1,
+      HLAType DR51_2,
+      HLAType DR52_1,
+      HLAType DR52_2,
+      HLAType DR53_1,
+      HLAType DR53_2) {
     ValidationModel model = createModel(fileName);
     assertEquals(DR51_1, model.getDR51_1());
     assertEquals(DR51_2, model.getDR51_2());
@@ -157,35 +235,44 @@ public class XMLScore6ParserTest {
   // create the parameters to be used as a method source for the haplotype allele parser to run
   // through
   private static Stream<Arguments> testHaplotype() {
-    return Stream.of(Arguments.of(Test_File1,
-        "\n\tCAU\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\n\tAFA\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\n\tAPI\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\n\tHIS\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\n\tNAM\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tAFA\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tAPI\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tHIS\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tNAM\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]"),
-        Arguments.of(Test_File2,
+    return Stream.of(
+        Arguments.of(
+            Test_File1,
+            "\n\tCAU\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\n\tAFA\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\n\tAPI\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\n\tHIS\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\n\tNAM\n\tHaplotype [types=[B*07:02:01, C*07:02:01]]\n\tHaplotype [types=[B*49:01:01, C*07:01:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tAFA\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tAPI\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tHIS\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tNAM\n\tHaplotype [types=[DRB1*08:04:04, DRB3*00:00N, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:02:01, DRB3*02:02:01, DQB1*03:01:01]]"),
+        Arguments.of(
+            Test_File2,
             "\n\tCAU\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\n\tHaplotype [types=[B*40:02:01, C*02:02:02]]\n\tAFA\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\n\tHaplotype [types=[B*40:02:01, C*02:02:02]]\n\tAPI\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\n\tHaplotype [types=[B*40:02:01, C*02:02:02]]\n\tHIS\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\n\tHaplotype [types=[B*40:02:01, C*02:02:02]]\n\tNAM\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\n\tHaplotype [types=[B*40:02:01, C*02:02:02]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*01:01:02, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*11:01:02, DRB3*02:02:01, DQB1*03:01:01]]\n\tAFA\n\tHaplotype [types=[DRB1*01:01:02, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*11:01:02, DRB3*02:02:01, DQB1*03:01:01]]\n\tAPI\n\tHaplotype [types=[DRB1*01:01:02, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*11:01:02, DRB3*02:02:01, DQB1*03:01:01]]\n\tHIS\n\tHaplotype [types=[DRB1*01:01:02, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*11:01:02, DRB3*02:02:01, DQB1*03:01:01]]\n\tNAM\n\tHaplotype [types=[DRB1*01:01:02, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*11:01:02, DRB3*02:02:01, DQB1*03:01:01]]"),
-        Arguments.of(Test_File3,
+        Arguments.of(
+            Test_File3,
             "\n\tCAU\n\tHaplotype [types=[B*27:05:02, C*02:02:02]]\n\tHaplotype [types=[B*44:05, C*02:02:02]]\n\tAFA\n\tHaplotype [types=[B*27:05:02, C*02:02:02]]\n\tHaplotype [types=[B*44:05, C*02:02:02]]\n\tAPI\n\tHaplotype [types=[B*27:05:02, C*02:02:02]]\n\tHaplotype [types=[B*44:05, C*02:02:02]]\n\tHIS\n\tHaplotype [types=[B*27:05:02, C*02:02:02]]\n\tHaplotype [types=[B*44:05, C*02:02:02]]\n\tNAM\n\tHaplotype [types=[B*27:05:02, C*02:02:02]]\n\tHaplotype [types=[B*44:05, C*02:02:02]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*01:01:01, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*08:01:01, DRB3*00:00N, DQB1*04:02:01]]\n\tAFA\n\tHaplotype [types=[DRB1*01:01:01, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*08:01:01, DRB3*00:00N, DQB1*04:02:01]]\n\tAPI\n\tHaplotype [types=[DRB1*01:01:01, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*08:01:01, DRB3*00:00N, DQB1*04:02:01]]\n\tHIS\n\tHaplotype [types=[DRB1*01:01:01, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*08:01:01, DRB3*00:00N, DQB1*04:02:01]]\n\tNAM\n\tHaplotype [types=[DRB1*01:01:01, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*08:01:01, DRB3*00:00N, DQB1*04:02:01]]"),
-        Arguments.of(Test_File4,
+        Arguments.of(
+            Test_File4,
             "\n\tCAU\n\tHaplotype [types=[B*44:03:02, C*16:01:01]]\n\tHaplotype [types=[B*51:01:01, C*15:02:01]]\n\tAFA\n\tHaplotype [types=[B*44:03:02, C*16:01:01]]\n\tHaplotype [types=[B*51:01:01, C*15:02:01]]\n\tAPI\n\tHaplotype [types=[B*44:03:02, C*16:01:01]]\n\tHaplotype [types=[B*51:01:01, C*15:02:01]]\n\tHIS\n\tHaplotype [types=[B*44:03:02, C*16:01:01]]\n\tHaplotype [types=[B*51:01:01, C*15:02:01]]\n\tNAM\n\tHaplotype [types=[B*44:03:02, C*16:01:01]]\n\tHaplotype [types=[B*51:01:01, C*15:02:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*04:04:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]\n\tAFA\n\tHaplotype [types=[DRB1*04:04:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]\n\tAPI\n\tHaplotype [types=[DRB1*04:04:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]\n\tHIS\n\tHaplotype [types=[DRB1*04:04:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]\n\tNAM\n\tHaplotype [types=[DRB1*04:04:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]"),
-        Arguments.of(Test_File5,
+        Arguments.of(
+            Test_File5,
             "\n\tCAU\n\tHaplotype [types=[B*15:01:01, C*03:03:04]]\n\tHaplotype [types=[B*44:03:02, C*07:01:01]]\n\tAFA\n\tHaplotype [types=[B*15:01:01, C*03:03:04]]\n\tHaplotype [types=[B*44:03:02, C*07:01:01]]\n\tAPI\n\tHaplotype [types=[B*15:01:01, C*03:03:04]]\n\tHaplotype [types=[B*44:03:02, C*07:01:01]]\n\tHIS\n\tHaplotype [types=[B*15:01:01, C*03:03:04]]\n\tHaplotype [types=[B*44:03:02, C*07:01:01]]\n\tNAM\n\tHaplotype [types=[B*15:01:01, C*03:03:04]]\n\tHaplotype [types=[B*44:03:02, C*07:01:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*11:03:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:04:02, DRB3*02:02:01, DQB1*03:01:01]]\n\tAFA\n\tHaplotype [types=[DRB1*11:03:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:04:02, DRB3*02:02:01, DQB1*03:01:01]]\n\tAPI\n\tHaplotype [types=[DRB1*11:03:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:04:02, DRB3*02:02:01, DQB1*03:01:01]]\n\tHIS\n\tHaplotype [types=[DRB1*11:03:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:04:02, DRB3*02:02:01, DQB1*03:01:01]]\n\tNAM\n\tHaplotype [types=[DRB1*11:03:01, DRB3*02:02:01, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*11:04:02, DRB3*02:02:01, DQB1*03:01:01]]"),
-        Arguments.of(Test_File6,
+        Arguments.of(
+            Test_File6,
             "\n\tCAU\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tAFA\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tAPI\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tHIS\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tNAM\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:09:01]]\n\tAFA\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:09:01]]\n\tAPI\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:09:01]]\n\tHIS\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:09:01]]\n\tNAM\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:09:01]]"),
-        Arguments.of(Test_File7,
+        Arguments.of(
+            Test_File7,
             "\n\tCAU\n\tHaplotype [types=[B*35:01:01, C*03:03:04]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tAFA\n\tHaplotype [types=[B*35:01:01, C*03:03:04]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tAPI\n\tHaplotype [types=[B*35:01:01, C*03:03:04]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tHIS\n\tHaplotype [types=[B*35:01:01, C*03:03:04]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tNAM\n\tHaplotype [types=[B*35:01:01, C*03:03:04]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*08:01:01, DRB3*00:00N, DQB1*04:02:01]]\n\tAFA\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*08:01:01, DRB3*00:00N, DQB1*04:02:01]]\n\tAPI\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*08:01:01, DRB3*00:00N, DQB1*04:02:01]]\n\tHIS\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*08:01:01, DRB3*00:00N, DQB1*04:02:01]]\n\tNAM\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*08:01:01, DRB3*00:00N, DQB1*04:02:01]]"),
-        Arguments.of(Test_File8,
+        Arguments.of(
+            Test_File8,
             "\n\tCAU\n\tHaplotype [types=[B*15:01:01, C*03:03:04]]\n\tHaplotype [types=[B*44:02:01, C*05:01:01]]\n\tAFA\n\tHaplotype [types=[B*15:01:01, C*03:03:04]]\n\tHaplotype [types=[B*44:02:01, C*05:01:01]]\n\tAPI\n\tHaplotype [types=[B*15:01:01, C*03:03:04]]\n\tHaplotype [types=[B*44:02:01, C*05:01:01]]\n\tHIS\n\tHaplotype [types=[B*15:01:01, C*03:03:04]]\n\tHaplotype [types=[B*44:02:01, C*05:01:01]]\n\tNAM\n\tHaplotype [types=[B*15:01:01, C*03:03:04]]\n\tHaplotype [types=[B*44:02:01, C*05:01:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*04:01:01, DRB4*01:01:01, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*13:01:01, DRB3*02:02:01, DQB1*06:03:01]]\n\tAFA\n\tHaplotype [types=[DRB1*04:01:01, DRB4*01:01:01, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*13:01:01, DRB3*02:02:01, DQB1*06:03:01]]\n\tAPI\n\tHaplotype [types=[DRB1*04:01:01, DRB4*01:01:01, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*13:01:01, DRB3*02:02:01, DQB1*06:03:01]]\n\tHIS\n\tHaplotype [types=[DRB1*04:01:01, DRB4*01:01:01, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*13:01:01, DRB3*02:02:01, DQB1*06:03:01]]\n\tNAM\n\tHaplotype [types=[DRB1*04:01:01, DRB4*01:01:01, DQB1*03:01:01]]\n\tHaplotype [types=[DRB1*13:01:01, DRB3*02:02:01, DQB1*06:03:01]]"));
   }
 
   /**
    * @param fileName String file name for test file being passed to createModel
-   * @param expectedHaplotype string expected as the output of the string version of
-   *        {@link ValidationModel} when split to just be haplotype section
+   * @param expectedHaplotype string expected as the output of the string version of {@link
+   *     ValidationModel} when split to just be haplotype section
    */
   @DisplayName("Haplotype Alleles parsing")
   @ParameterizedTest(name = "{0}")
   @MethodSource("testHaplotype")
   public void XMLScore6ParserTest_haplotype(String fileName, String expectedHaplotype) {
     ValidationModel model = createModel(fileName);
-    if (HaplotypeFrequencies.successfullyInitialized()) {
+    if (HaplotypeFrequencies.successfullyInitialized().get()) {
       assertEquals(expectedHaplotype, model.toString().split("B-C Haplotype")[1]);
     } else {
       System.err.println("Error: Frequency files not loaded in");
@@ -196,23 +283,32 @@ public class XMLScore6ParserTest {
   // through
   // Expected results frequencies in CAU, AFA, API, HIS, NAM order
   private static Stream<Arguments> testBCHaplotypeFrequency() {
-    double[] freq1 =
-        {0.01611, 0.123, 0.02804, 0.05984, 0.00287, 0.02923, 0.02362, 0.05652, 0.01377, 0.09628};
-    double[] freq2 =
-        {0.01149, 0.05588, 0.00211, 0.05482, 0.00012, 0.03018, 0.00613, 0.06563, 0.00602, 0.08644};
-    double[] freq3 =
-        {0.00337, 0.02006, 0.00029, 0.00444, 0.00006, 0.00512, 0.00112, 0.01064, 0.00135, 0.03779};
-    double[] freq4 =
-        {0.02042, 0.02676, 0.00413, 0.00635, 0.00039, 0.00977, 0.03005, 0.03805, 0.02386, 0.03576};
-    double[] freq5 =
-        {0.00051, 0.03177, 0.00398, 0.00579, 0.01548, 0.03859, 0.00146, 0.01458, 0.00309, 0.02668};
-    double[] freq6 =
-        {0.02719, 0.03371, 0.00664, 0.02134, 0.00155, 0.03078, 0.01043, 0.04161, 0.0207, 0.02662};
-    double[] freq7 =
-        {0.00074, 0.03371, 0.00664, 0.00004, 0.01373, 0.03078, 0.01043, 0.00008, 0.0001, 0.02662};
-    double[] freq8 =
-        {0.03177, 0.07064, 0.0176, 0.00579, 0.00729, 0.01548, 0.01458, 0.0381, 0.02668, 0.06176};
-    return Stream.of(Arguments.of(Test_File1, HaplotypeTestingUtils.createTestMultimap(freq1)),
+    double[] freq1 = {
+      0.01611, 0.123, 0.02804, 0.05984, 0.00287, 0.02923, 0.02362, 0.05652, 0.01377, 0.09628
+    };
+    double[] freq2 = {
+      0.01149, 0.05588, 0.00211, 0.05482, 0.00012, 0.03018, 0.00613, 0.06563, 0.00602, 0.08644
+    };
+    double[] freq3 = {
+      0.00337, 0.02006, 0.00029, 0.00444, 0.00006, 0.00512, 0.00112, 0.01064, 0.00135, 0.03779
+    };
+    double[] freq4 = {
+      0.02042, 0.02676, 0.00413, 0.00635, 0.00039, 0.00977, 0.03005, 0.03805, 0.02386, 0.03576
+    };
+    double[] freq5 = {
+      0.00051, 0.03177, 0.00398, 0.00579, 0.01548, 0.03859, 0.00146, 0.01458, 0.00309, 0.02668
+    };
+    double[] freq6 = {
+      0.02719, 0.03371, 0.00664, 0.02134, 0.00155, 0.03078, 0.01043, 0.04161, 0.0207, 0.02662
+    };
+    double[] freq7 = {
+      0.00074, 0.03371, 0.00664, 0.00004, 0.01373, 0.03078, 0.01043, 0.00008, 0.0001, 0.02662
+    };
+    double[] freq8 = {
+      0.03177, 0.07064, 0.0176, 0.00579, 0.00729, 0.01548, 0.01458, 0.0381, 0.02668, 0.06176
+    };
+    return Stream.of(
+        Arguments.of(Test_File1, HaplotypeTestingUtils.createTestMultimap(freq1)),
         Arguments.of(Test_File2, HaplotypeTestingUtils.createTestMultimap(freq2)),
         Arguments.of(Test_File3, HaplotypeTestingUtils.createTestMultimap(freq3)),
         Arguments.of(Test_File4, HaplotypeTestingUtils.createTestMultimap(freq4)),
@@ -225,14 +321,14 @@ public class XMLScore6ParserTest {
   /**
    * @param fileName String file name for test file being passed to createModel
    * @param expectedBCMultimap a multimap of RaceGroup ethnicities with BigDecimal expected
-   *        frequencies
+   *     frequencies
    */
   @DisplayName("Haplotype BC Frequency parsing")
   @ParameterizedTest(name = "{0}")
   @MethodSource("testBCHaplotypeFrequency")
-  public void XMLScore6ParserTest_BCHaplotypeFrequency(String fileName,
-      SetMultimap<RaceGroup, BigDecimal> expectedBCMultimap) {
-    if (HaplotypeFrequencies.successfullyInitialized()) {
+  public void XMLScore6ParserTest_BCHaplotypeFrequency(
+      String fileName, SetMultimap<RaceGroup, BigDecimal> expectedBCMultimap) {
+    if (HaplotypeFrequencies.successfullyInitialized().get()) {
       ValidationModel model = createModel(fileName);
       assertEquals(
           "Difference between generated and expected: {}Difference between expected and generated: {}",
@@ -247,23 +343,32 @@ public class XMLScore6ParserTest {
   //
   // Expected results frequencies in CAU, AFA, API, HIS, NAM order
   private static Stream<Arguments> testDRDQHaplotypeFrequency() {
-    double[] freq1 =
-        {0.00078, 0.00282, 0.03548, 0.05223, 0.00012, 0.00016, 0.00497, 0.01253, 0.00372, 0.00474};
-    double[] freq2 =
-        {0.06304, 0.08444, 0.02587, 0.03555, 0.02642, 0.05341, 0.03747, 0.04482, 0.04266, 0.06747};
-    double[] freq3 =
-        {0.02349, 0.08444, 0.00362, 0.02587, 0.00169, 0.02642, 0.01091, 0.04482, 0.01519, 0.06747};
-    double[] freq4 =
-        {0.0327, 0.09595, 0.0081, 0.09746, 0.01148, 0.07397, 0.0464, 0.09536, 0.04735, 0.07928};
-    double[] freq5 =
-        {0.00686, 0.03528, 0.00069, 0.00395, 0.00024, 0.00962, 0.00376, 0.02922, 0.00322, 0.01672};
-    double[] freq6 =
-        {0.0087, 0.03364, 0.00295, 0.03757, 0.01746, 0.02507, 0.01004, 0.01206, 0.00998, 0.02339};
-    double[] freq7 =
-        {0.02349, 0.03364, 0.00295, 0.00362, 0.00169, 0.02507, 0.01091, 0.01206, 0.01519, 0.02339};
-    double[] freq8 =
-        {0.03479, 0.02591, 0.00672, 0.01002, 0.00345, 0.00968, 0.00897, 0.01737, 0.01885, 0.03675};
-    return Stream.of(Arguments.of(Test_File1, HaplotypeTestingUtils.createTestMultimap(freq1)),
+    double[] freq1 = {
+      0.00078, 0.00282, 0.03548, 0.05223, 0.00012, 0.00016, 0.00497, 0.01253, 0.00372, 0.00474
+    };
+    double[] freq2 = {
+      0.06304, 0.08444, 0.02587, 0.03555, 0.02642, 0.05341, 0.03747, 0.04482, 0.04266, 0.06747
+    };
+    double[] freq3 = {
+      0.02349, 0.08444, 0.00362, 0.02587, 0.00169, 0.02642, 0.01091, 0.04482, 0.01519, 0.06747
+    };
+    double[] freq4 = {
+      0.0327, 0.09595, 0.0081, 0.09746, 0.01148, 0.07397, 0.0464, 0.09536, 0.04735, 0.07928
+    };
+    double[] freq5 = {
+      0.00686, 0.03528, 0.00069, 0.00395, 0.00024, 0.00962, 0.00376, 0.02922, 0.00322, 0.01672
+    };
+    double[] freq6 = {
+      0.0087, 0.03364, 0.00295, 0.03757, 0.01746, 0.02507, 0.01004, 0.01206, 0.00998, 0.02339
+    };
+    double[] freq7 = {
+      0.02349, 0.03364, 0.00295, 0.00362, 0.00169, 0.02507, 0.01091, 0.01206, 0.01519, 0.02339
+    };
+    double[] freq8 = {
+      0.03479, 0.02591, 0.00672, 0.01002, 0.00345, 0.00968, 0.00897, 0.01737, 0.01885, 0.03675
+    };
+    return Stream.of(
+        Arguments.of(Test_File1, HaplotypeTestingUtils.createTestMultimap(freq1)),
         Arguments.of(Test_File2, HaplotypeTestingUtils.createTestMultimap(freq2)),
         Arguments.of(Test_File3, HaplotypeTestingUtils.createTestMultimap(freq3)),
         Arguments.of(Test_File4, HaplotypeTestingUtils.createTestMultimap(freq4)),
@@ -276,14 +381,14 @@ public class XMLScore6ParserTest {
   /**
    * @param fileName String file name for test file being passed to createModel
    * @param expectedDRDQMultimap a multimap of RaceGroup ethnicities with BigDecimal expected
-   *        frequencies
+   *     frequencies
    */
   @DisplayName("Haplotype DRDQ Frequency parsing")
   @ParameterizedTest(name = "{0}")
   @MethodSource("testDRDQHaplotypeFrequency")
-  public void XMLScore6ParserTest_DRDQHaplotypeFrequency(String fileName,
-      SetMultimap<RaceGroup, BigDecimal> expectedDRDQMultimap) {
-    if (HaplotypeFrequencies.successfullyInitialized()) {
+  public void XMLScore6ParserTest_DRDQHaplotypeFrequency(
+      String fileName, SetMultimap<RaceGroup, BigDecimal> expectedDRDQMultimap) {
+    if (HaplotypeFrequencies.successfullyInitialized().get()) {
       ValidationModel model = createModel(fileName);
       assertEquals(
           "Difference between generated and expected: {}Difference between expected and generated: {}",

--- a/src/test/java/org/pankratzlab/unet/integration/XMLSureTyperParserTest.java
+++ b/src/test/java/org/pankratzlab/unet/integration/XMLSureTyperParserTest.java
@@ -1,11 +1,13 @@
 package org.pankratzlab.unet.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.stream.Stream;
+
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.BeforeAll;
@@ -22,6 +24,7 @@ import org.pankratzlab.unet.hapstats.RaceGroup;
 import org.pankratzlab.unet.model.ValidationModel;
 import org.pankratzlab.unet.model.ValidationModelBuilder;
 import org.pankratzlab.unet.parser.util.XmlSureTyperParser;
+
 import com.google.common.collect.SetMultimap;
 
 public class XMLSureTyperParserTest {
@@ -41,8 +44,12 @@ public class XMLSureTyperParserTest {
   // create parameters to be used as CSV source for checking Donor ID parsing
   @DisplayName("Donor ID parsing")
   @ParameterizedTest(name = "{0}")
-  @CsvSource({Test_File1 + ", AFK3449", Test_File2 + ", AFLG241", Test_File3 + ", AFK3166",
-      Test_File4 + ", AFLG065"})
+  @CsvSource({
+    Test_File1 + ", AFK3449",
+    Test_File2 + ", AFLG241",
+    Test_File3 + ", AFK3166",
+    Test_File4 + ", AFLG065"
+  })
   /**
    * @param fileName String file name for test file being passed to createModel
    * @param donorId expected Donor ID for each respective donor file
@@ -54,14 +61,38 @@ public class XMLSureTyperParserTest {
   // create the parameters to be used as a method source for the allele parser to run through
   private static Stream<Arguments> testGetABC() {
     return Stream.of(
-        Arguments.of(Test_File1, new SeroType("A", 2), new SeroType("A", 3), new SeroType("B", 57),
-            new SeroType("B", 65), new SeroType("C", 06), new SeroType("C", 8)),
-        Arguments.of(Test_File2, new SeroType("A", 68), null, new SeroType("B", 48),
-            new SeroType("B", 58), new SeroType("C", 6), new SeroType("C", 8)),
-        Arguments.of(Test_File3, new SeroType("A", 3), new SeroType("A", 24), new SeroType("B", 27),
-            new SeroType("B", 35), new SeroType("C", 2), new SeroType("C", 4)),
-        Arguments.of(Test_File4, new SeroType("A", 68), null, new SeroType("B", 53),
-            new SeroType("B", 65), new SeroType("C", 4), new SeroType("C", 8)));
+        Arguments.of(
+            Test_File1,
+            new SeroType("A", 2),
+            new SeroType("A", 3),
+            new SeroType("B", 57),
+            new SeroType("B", 65),
+            new SeroType("C", 06),
+            new SeroType("C", 8)),
+        Arguments.of(
+            Test_File2,
+            new SeroType("A", 68),
+            null,
+            new SeroType("B", 48),
+            new SeroType("B", 58),
+            new SeroType("C", 6),
+            new SeroType("C", 8)),
+        Arguments.of(
+            Test_File3,
+            new SeroType("A", 3),
+            new SeroType("A", 24),
+            new SeroType("B", 27),
+            new SeroType("B", 35),
+            new SeroType("C", 2),
+            new SeroType("C", 4)),
+        Arguments.of(
+            Test_File4,
+            new SeroType("A", 68),
+            null,
+            new SeroType("B", 53),
+            new SeroType("B", 65),
+            new SeroType("C", 4),
+            new SeroType("C", 8)));
   }
 
   /**
@@ -76,8 +107,14 @@ public class XMLSureTyperParserTest {
   @DisplayName("Allele A, B and C parsing")
   @ParameterizedTest(name = "{0}")
   @MethodSource("testGetABC")
-  public void XMLSureTyperParserTest_getABC(String fileName, SeroType A1, SeroType A2, SeroType B1,
-      SeroType B2, SeroType C1, SeroType C2) {
+  public void XMLSureTyperParserTest_getABC(
+      String fileName,
+      SeroType A1,
+      SeroType A2,
+      SeroType B1,
+      SeroType B2,
+      SeroType C1,
+      SeroType C2) {
     ValidationModel model = createModel(fileName);
     assertEquals(A1, model.getA1());
     assertEquals(A2, model.getA2());
@@ -90,8 +127,12 @@ public class XMLSureTyperParserTest {
   // create parameters to be used as CSV source for checking Bw4 and Bw6 parsing
   @DisplayName("Bw4 and Bw6 parsing")
   @ParameterizedTest(name = "{0}")
-  @CsvSource({Test_File1 + ", Positive, Positive", Test_File2 + ", Positive, Positive",
-      Test_File3 + ", Negative, Positive", Test_File4 + ", Positive, Positive"})
+  @CsvSource({
+    Test_File1 + ", Positive, Positive",
+    Test_File2 + ", Positive, Positive",
+    Test_File3 + ", Negative, Positive",
+    Test_File4 + ", Positive, Positive"
+  })
   /**
    * @param fileName String file name for test file being passed to createModel
    * @param Bw4Result expected Bw4 result(Positive or Negative)
@@ -105,9 +146,10 @@ public class XMLSureTyperParserTest {
 
   // create parameters to be used as a method source for checking the DRB345 parser
   private static Stream<Arguments> testGetDRB() {
-    return Stream.of(Arguments.of(Test_File1, null, null, new HLAType("DRB3", 3), null, null, null),
-        Arguments.of(Test_File2, null, null, new HLAType("DRB3", 2), null, new HLAType("DRB4", 1),
-            null),
+    return Stream.of(
+        Arguments.of(Test_File1, null, null, new HLAType("DRB3", 3), null, null, null),
+        Arguments.of(
+            Test_File2, null, null, new HLAType("DRB3", 2), null, new HLAType("DRB4", 1), null),
         Arguments.of(Test_File3, null, null, null, null, new HLAType("DRB4", 1), null),
         Arguments.of(Test_File4, null, null, null, null, new HLAType("DRB4", 1), null));
   }
@@ -124,8 +166,14 @@ public class XMLSureTyperParserTest {
   @DisplayName("DRB345 parsing")
   @ParameterizedTest(name = "{0}")
   @MethodSource("testGetDRB")
-  public void XMLSureTyperParserTest_getDRB(String fileName, HLAType DR51_1, HLAType DR51_2,
-      HLAType DR52_1, HLAType DR52_2, HLAType DR53_1, HLAType DR53_2) {
+  public void XMLSureTyperParserTest_getDRB(
+      String fileName,
+      HLAType DR51_1,
+      HLAType DR51_2,
+      HLAType DR52_1,
+      HLAType DR52_2,
+      HLAType DR53_1,
+      HLAType DR53_2) {
     ValidationModel model = createModel(fileName);
     assertEquals(DR51_1, model.getDR51_1());
     assertEquals(DR51_2, model.getDR51_2());
@@ -138,27 +186,32 @@ public class XMLSureTyperParserTest {
   // create the parameters to be used as a method source for the haplotype allele parser to run
   // through
   private static Stream<Arguments> testHaplotype() {
-    return Stream.of(Arguments.of(Test_File1,
-        "\n\tCAU\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tAFA\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tAPI\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tHIS\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tNAM\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:04:01]]\n\tAFA\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:09:01]]\n\tAPI\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:04:01]]\n\tHIS\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:04:01]]\n\tNAM\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:04:01]]"),
-        Arguments.of(Test_File2,
+    return Stream.of(
+        Arguments.of(
+            Test_File1,
+            "\n\tCAU\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tAFA\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tAPI\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tHIS\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\n\tNAM\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*57:01:01, C*06:02:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:04:01]]\n\tAFA\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:09:01]]\n\tAPI\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:04:01]]\n\tHIS\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:04:01]]\n\tNAM\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*03:03:02]]\n\tHaplotype [types=[DRB1*13:02:01, DRB3*03:01:01, DQB1*06:04:01]]"),
+        Arguments.of(
+            Test_File2,
             "\n\tCAU\n\tHaplotype [types=[B*48:01:01, C*08:03:01]]\n\tHaplotype [types=[B*58:02:01, C*06:02:01]]\n\tAFA\n\tHaplotype [types=[B*48:01:01, C*08:01:01]]\n\tHaplotype [types=[B*58:02:01, C*06:02:01]]\n\tAPI\n\tHaplotype [types=[B*48:01:01, C*08:01:01]]\n\tHaplotype [types=[B*58:02:01, C*06:02:01]]\n\tHIS\n\tHaplotype [types=[B*48:01:01, C*08:01:01]]\n\tHaplotype [types=[B*58:02:01, C*06:02:01]]\n\tNAM\n\tHaplotype [types=[B*48:01:01, C*08:01:01]]\n\tHaplotype [types=[B*58:02:01, C*06:02:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*03:01:01, DRB3*02:02:01, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*04:01:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tAFA\n\tHaplotype [types=[DRB1*03:01:01, DRB3*02:02:01, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*04:05:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tAPI\n\tHaplotype [types=[DRB1*03:01:01, DRB3*02:02:01, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*04:03:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHIS\n\tHaplotype [types=[DRB1*03:01:01, DRB3*02:02:01, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*04:07:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tNAM\n\tHaplotype [types=[DRB1*03:01:01, DRB3*02:02:01, DQB1*02:01:01]]\n\tHaplotype [types=[DRB1*04:04:01, DRB4*01:01:01, DQB1*03:02:01]]"),
-        Arguments.of(Test_File3,
+        Arguments.of(
+            Test_File3,
             "\n\tCAU\n\tHaplotype [types=[B*27:08, C*02:10:01]]\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\n\tAFA\n\tHaplotype [types=[B*27:08, C*02:10:01]]\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\n\tAPI\n\tHaplotype [types=[B*27:08, C*02:10:01]]\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\n\tHIS\n\tHaplotype [types=[B*27:08, C*02:10:01]]\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\n\tNAM\n\tHaplotype [types=[B*27:08, C*02:10:01]]\n\tHaplotype [types=[B*35:01:01, C*04:01:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*04:01:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]\n\tAFA\n\tHaplotype [types=[DRB1*04:05:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]\n\tAPI\n\tHaplotype [types=[DRB1*04:03:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]\n\tHIS\n\tHaplotype [types=[DRB1*04:07:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]\n\tNAM\n\tHaplotype [types=[DRB1*04:04:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHaplotype [types=[DRB1*07:01:01, DRB4*01:01:01, DQB1*02:01:01]]"),
-        Arguments.of(Test_File4,
+        Arguments.of(
+            Test_File4,
             "\n\tCAU\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*53:01:01, C*04:01:01]]\n\tAFA\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*53:01:01, C*04:01:01]]\n\tAPI\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*53:01:01, C*04:01:01]]\n\tHIS\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*53:01:01, C*04:01:01]]\n\tNAM\n\tHaplotype [types=[B*14:02:01, C*08:02:01]]\n\tHaplotype [types=[B*53:01:01, C*04:01:01]]\nDR-DQ Haplotype\n\tCAU\n\tHaplotype [types=[DRB1*01:01:01, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*04:01:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tAFA\n\tHaplotype [types=[DRB1*01:02:01, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*04:05:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tAPI\n\tHaplotype [types=[DRB1*01:01:01, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*04:03:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tHIS\n\tHaplotype [types=[DRB1*01:01:01, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*04:07:01, DRB4*01:01:01, DQB1*03:02:01]]\n\tNAM\n\tHaplotype [types=[DRB1*01:01:01, DRB3*00:00N, DQB1*05:01:01]]\n\tHaplotype [types=[DRB1*04:04:01, DRB4*01:01:01, DQB1*03:02:01]]"));
   }
 
   /**
    * @param fileName String file name for test file being passed to createModel
-   * @param expectedHaplotype string expected as the output of the string version of
-   *        {@link ValidationModel} when split to just be haplotype section
+   * @param expectedHaplotype string expected as the output of the string version of {@link
+   *     ValidationModel} when split to just be haplotype section
    */
   @DisplayName("Haplotype Alleles parsing")
   @ParameterizedTest(name = "{0}")
   @MethodSource("testHaplotype")
   public void XMLSureTyperParserTest_haplotype(String fileName, String expectedHaplotype) {
     ValidationModel model = createModel(fileName);
-    if (HaplotypeFrequencies.successfullyInitialized()) {
+    if (HaplotypeFrequencies.successfullyInitialized().get()) {
       assertEquals(expectedHaplotype, model.toString().split("B-C Haplotype")[1]);
     } else {
       System.err.println("Error: Frequency files not loaded in");
@@ -169,14 +222,17 @@ public class XMLSureTyperParserTest {
   // through
   // Expected results frequencies in CAU, AFA, API, HIS, NAM order
   private static Stream<Arguments> testBCHaplotypeFrequency() {
-    double[] freq1 =
-        {.02719, .03371, .00664, 0.02134, 0.00155, 0.03078, .01043, 0.04161, 0.0207, 0.02662};
-    double[] freq2 =
-        {0.00013, .00042, 0.00034, 0.04008, 0.00007, 0.0123, 0.00365, 0.01583, 0.00217, 0.01307};
+    double[] freq1 = {
+      .02719, .03371, .00664, 0.02134, 0.00155, 0.03078, .01043, 0.04161, 0.0207, 0.02662
+    };
+    double[] freq2 = {
+      0.00013, .00042, 0.00034, 0.04008, 0.00007, 0.0123, 0.00365, 0.01583, 0.00217, 0.01307
+    };
     double[] freq3 = {0, .05588, 0, .05482, 0, .03018, 0, .06563, 0, .08644};
     double[] freq4 = {.00363, .02719, .02134, .1079, .00079, .00155, .0153, .04161, .00804, .0207};
 
-    return Stream.of(Arguments.of(Test_File1, HaplotypeTestingUtils.createTestMultimap(freq1)),
+    return Stream.of(
+        Arguments.of(Test_File1, HaplotypeTestingUtils.createTestMultimap(freq1)),
         Arguments.of(Test_File2, HaplotypeTestingUtils.createTestMultimap(freq2)),
         Arguments.of(Test_File3, HaplotypeTestingUtils.createTestMultimap(freq3)),
         Arguments.of(Test_File4, HaplotypeTestingUtils.createTestMultimap(freq4)));
@@ -185,14 +241,14 @@ public class XMLSureTyperParserTest {
   /**
    * @param fileName String file name for test file being passed to createModel
    * @param expectedBCMultimap a multimap of RaceGroup ethnicities with BigDecimal expected
-   *        frequencies
+   *     frequencies
    */
   @DisplayName("Haplotype BC Frequency parsing")
   @ParameterizedTest(name = "{0}")
   @MethodSource("testBCHaplotypeFrequency")
-  public void XMLScore6ParserTest_BCHaplotypeFrequency(String fileName,
-      SetMultimap<RaceGroup, BigDecimal> expectedBCMultimap) {
-    if (HaplotypeFrequencies.successfullyInitialized()) {
+  public void XMLScore6ParserTest_BCHaplotypeFrequency(
+      String fileName, SetMultimap<RaceGroup, BigDecimal> expectedBCMultimap) {
+    if (HaplotypeFrequencies.successfullyInitialized().get()) {
       ValidationModel model = createModel(fileName);
       assertEquals(
           "Difference between generated and expected: {}Difference between expected and generated: {}",
@@ -206,16 +262,21 @@ public class XMLSureTyperParserTest {
   // run through
   // Expected results frequencies in CAU, AFA, API, HIS, NAM order
   private static Stream<Arguments> testDRDQHaplotypeFrequency() {
-    double[] freq1 =
-        {0.03364, 0.03741, 0.00295, 0.03757, 0.01847, 0.02507, 0.01206, 0.02784, 0.02339, 0.02771};
-    double[] freq2 =
-        {0.01961, 0.04557, 0.01512, 0.05172, 0.03671, 0.05492, 0.03637, 0.06337, 0.01776, 0.04735};
-    double[] freq3 =
-        {0.04557, 0.09595, 0.01512, 0.09746, 0.03671, 0.07397, 0.06337, 0.09536, 0.04735, 0.07928};
-    double[] freq4 =
-        {0.04557, 0.08444, 0.01512, 0.04014, 0.02642, 0.03671, 0.04482, 0.06337, 0.04735, 0.06747};
+    double[] freq1 = {
+      0.03364, 0.03741, 0.00295, 0.03757, 0.01847, 0.02507, 0.01206, 0.02784, 0.02339, 0.02771
+    };
+    double[] freq2 = {
+      0.01961, 0.04557, 0.01512, 0.05172, 0.03671, 0.05492, 0.03637, 0.06337, 0.01776, 0.04735
+    };
+    double[] freq3 = {
+      0.04557, 0.09595, 0.01512, 0.09746, 0.03671, 0.07397, 0.06337, 0.09536, 0.04735, 0.07928
+    };
+    double[] freq4 = {
+      0.04557, 0.08444, 0.01512, 0.04014, 0.02642, 0.03671, 0.04482, 0.06337, 0.04735, 0.06747
+    };
 
-    return Stream.of(Arguments.of(Test_File1, HaplotypeTestingUtils.createTestMultimap(freq1)),
+    return Stream.of(
+        Arguments.of(Test_File1, HaplotypeTestingUtils.createTestMultimap(freq1)),
         Arguments.of(Test_File2, HaplotypeTestingUtils.createTestMultimap(freq2)),
         Arguments.of(Test_File3, HaplotypeTestingUtils.createTestMultimap(freq3)),
         Arguments.of(Test_File4, HaplotypeTestingUtils.createTestMultimap(freq4)));
@@ -224,14 +285,14 @@ public class XMLSureTyperParserTest {
   /**
    * @param fileName String file name for test file being passed to createModel
    * @param expectedDRDQMultimap a multimap of RaceGroup ethnicities with BigDecimal expected
-   *        frequencies
+   *     frequencies
    */
   @DisplayName("Haplotype DRDQ Frequency parsing")
   @ParameterizedTest(name = "{0}")
   @MethodSource("testDRDQHaplotypeFrequency")
-  public void XMLSureTyperParserTest_DRDQHaplotypeFrequency(String fileName,
-      SetMultimap<RaceGroup, BigDecimal> expectedDRDQMultimap) {
-    if (HaplotypeFrequencies.successfullyInitialized()) {
+  public void XMLSureTyperParserTest_DRDQHaplotypeFrequency(
+      String fileName, SetMultimap<RaceGroup, BigDecimal> expectedDRDQMultimap) {
+    if (HaplotypeFrequencies.successfullyInitialized().get()) {
       ValidationModel model = createModel(fileName);
       assertEquals(
           "Difference between generated and expected: {}Difference between expected and generated: {}",


### PR DESCRIPTION
#### SCORE 6:  
* Use assigned alleles, if present and valid in file. This functionality can be toggled on/off in the application properties.
* If HLA-B allele is assigned, use the Bw4/Bw6 status in the source file, even if allele values are invalid (e.g. allele groups).

#### SureTyper: 
* Allow non-standard DQA phenotype values (e.g. "DQA02" instead of "DQA1*02"). This functionality can be toggled on/off in the application properties.

#### General:
* Add application properties user interface (File > Properties).
* Allow users to specify a test name if a test with the same name already exists.
* Allow users to write test results to an Excel file.
* Bug fixes and UI tweaks. 